### PR TITLE
docs: add per-directory CLAUDE.md hierarchy for SDK layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,210 +1,75 @@
-<!-- updated: 2026-04-18T21:18:33Z -->
-# devcontainer-template
+<!-- updated: 2026-04-19T10:18:42Z -->
+# kitsunium/sdk
 
 ## Purpose
 
-Universal DevContainer shell providing cutting-edge AI agents, skills, and workflows to bootstrap any project. Reliability first: agents reason deeply, cross-reference sources, and self-correct until the output meets quality standards.
+Go SDK providing a normed, performant toolbox for downstream applications. The first tool shipped is a structured logger; more domains land in the same 4-layer shape.
 
-## Project Structure
+**Repository**: `github.com/kitsunium/sdk` · **Module name**: same · **Go**: 1.26
 
-```
-/workspace
-├── .devcontainer/   # Container config, features, hooks, images
-├── .github/         # GitHub Actions workflows
-├── .githooks/       # Git hooks (pre-commit: regenerate assets)
-├── .claude/         # Workspace Claude overrides (settings.local.json, features.json)
-├── .grepai/         # GrepAI project config (exclusions)
-├── docs/            # Documentation (MkDocs: vision, architecture, guides)
-├── src/             # All source code (created per project via /init)
-├── tests/           # Unit tests (created per project via /init)
-├── AGENTS.md        # Specialist agents specification (81 agents)
-└── CLAUDE.md        # This file
-```
-
-## Tech Stack
-
-- **Languages**: Python, C, C++, Java, C#, JavaScript/Node.js, Visual Basic, R, Pascal, Perl, Fortran, PHP, Rust, Go, Ada, MATLAB, Assembly, Kotlin, Swift, COBOL, Ruby, Dart, Lua, Scala, Elixir, SQL
-- **Cloud CLIs**: AWS v2, GCP SDK, Azure CLI
-- **IaC**: Terraform, Vault, Consul, Nomad, Packer, Ansible
-- **Containers**: Docker, kubectl, Helm
-- **AI**: Claude Code, RTK (token savings), MCP servers (GitHub, GitLab, grepai, context7 + feature-based: Playwright, ktn-linter)
-
-## How to Work
-
-1. **New project**: `/init` → conversational discovery → doc generation
-2. **New feature**: `/plan "description"` → planning mode → `/do` → `/git --commit`
-3. **Bug fix**: `/plan "description"` → planning mode → `/do` → `/git --commit`
-4. **Code review**: `/review` → 3-tier review (agents + Qodo + CodeRabbit)
-
-Branch conventions: `feat/<desc>` or `fix/<desc>`, commit prefix matches.
-
-## Key Principles
-
-**Reliability first**: Verify before generating. Agents consult context7 and official docs before producing non-trivial code.
-
-**MCP-first**: Use MCP tools (`mcp__github__*`, `mcp__gitlab__*`) before CLI fallbacks. Auth is pre-configured.
-
-**Self-correction**: When linting or tests fail, agents fix and retry automatically.
-
-**Semantic search**: Use `grepai_search` for meaning-based queries. Fall back to Grep for exact strings.
-
-**Specialist agents**: Language conventions enforced by agents that know current stable versions.
-
-**Deep reasoning**: For complex tasks — Peek, Decompose, Parallelize, Synthesize.
-
-**Bot reviews are signal, not orders**: CodeRabbit, Qodo, Codacy and similar AI review bots produce useful hints but their findings are **non-binding**. Triage with judgment — never blindly iterate on every comment. Reject (with a short rationale) any finding that is:
-- A style nitpick, not a real bug
-- Defensive hardening against a threat model that does not apply (e.g., `mktemp` in a root-only devcontainer build)
-- A false positive (run the actual linter / test before accepting the bot's claim)
-- An out-of-scope rewrite that would expand the PR beyond its original intent
-- The third+ new demand on the same PR — after two rounds of fixes, stop, respond with rationale, and merge
-
-If the CI bot says "no" and you have verified the code is correct, the CI is wrong. Post the rationale, move on, merge.
-
-**Intended working directories are writeable without prompting**: `.claude/contexts/` (search outputs), `.claude/plans/` (planning mode), and other agent-managed working directories are configured as writeable in `~/.claude/settings.json`. Never treat them as "sensitive" — they are the agent's scratchpad. If a permission prompt fires for these paths, fix the settings, do not ask the user.
-
-## Safeguards
-
-Ask before:
-- Deleting files in `.claude/` or `.devcontainer/`
-- Removing features from `.claude/commands/*.md`
-- Removing hooks from `.devcontainer/hooks/`
-- Dropping database state, force-push, dependency downgrades
-
-Investigate before deleting unfamiliar state (branches, lock files, unknown files) — it may be user work-in-progress.
-
-Never ask for:
-- Writing new files under `.claude/contexts/` or `.claude/plans/` (configured as free-write in `~/.claude/settings.json`)
-
-When refactoring: move content to separate files, preserve logic.
-
-## Pre-commit
-
-Auto-detected by language marker (`go.mod`, `Cargo.toml`, `package.json`, etc.). Priority: Makefile targets, then language-specific commands.
-
-## Hooks (17 event types)
-
-| Hook | Purpose |
-|------|---------|
-| SessionStart | Cache project metadata + compact recovery |
-| SessionEnd | Session cleanup |
-| UserPromptSubmit | Prompt tracking |
-| PreToolUse | Commit validate, security scan, RTK rewrite, logging |
-| PostToolUse | Format + lint, security, test, feature update, logging |
-| PostToolUseFailure | Failure diagnostics |
-| PermissionRequest | Permission logging |
-| SubagentStart/Stop | Agent lifecycle tracking |
-| Stop | Session summary + terminal bell + quality gate (lint/typecheck/test) |
-| TeammateIdle | Multi-agent coordination + pending-task enforcement |
-| TaskCreated | Task payload contract validation + file conflict advisory |
-| TaskCompleted | Async task completion + registry lifecycle transition |
-| ConfigChange | Configuration change tracking |
-| WorktreeCreate/Remove | Git worktree lifecycle |
-| PreCompact | Context preservation before compaction |
-| Notification | External monitoring notifications |
-
-## Agent Teams (experimental)
-
-Parallel multi-agent execution for 7 high-value skills (`/review`, `/plan`, `/docs`, `/do`, `/infra`, `/test`, `/improve`). Each skill detects its runtime mode at invocation and branches:
-
-| Capability (persisted) | Runtime mode | Where |
-|---|---|---|
-| TMUX | TEAMS_TMUX | Split-pane teammates in tmux |
-| IN_PROCESS | TEAMS_INPROCESS | Shift+Down to cycle teammates |
-| NONE | SUBAGENTS | Legacy Task-tool dispatch |
-
-**Single source of truth:** `.devcontainer/images/.claude/commands/shared/team-mode.md`
-**Primitives:** `~/.claude/scripts/team-mode-primitives.sh` (`detect_runtime_mode`, `extract_task_contract`, `classify_terminal`, …)
-**Capability file:** `~/.claude/.team-capability` (hint only — live probe is source of truth)
-**Install:** automatic via `install.sh`; opt-out with `install.sh --no-teams`
-**Runtime opt-out:** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=0 /<skill>`
-**Debug:** `TEAM_MODE_DEBUG=1` → stderr decision logs
-**Kill switch:** `echo NONE > ~/.claude/.team-capability`
-
-Every team task embeds a `<!-- task-contract v1 ... -->` JSON block (contract_version, access_mode, owned_paths, acceptance_criteria, …). Parsed and validated by `task-created.sh` in advisory mode — strict only on explicit contract violations.
-
-## /secret - Secure Secret Management (1Password)
+## Architecture at a glance
 
 ```
-/secret --push DB_PASSWORD=mypass     # Store secret
-/secret --get DB_PASSWORD             # Retrieve secret
-/secret --list                        # List project secrets
-/secret --push KEY=val --path org/other  # Cross-project
+internal/
+├── kernel/        stdlib-only AND generic primitives  (errs, clock, buffer)
+├── core/          domain interfaces + domain values   (logger, logger/level)
+└── service/       concrete implementations            (logger/text handler)
+pkg/
+└── v1/            stable public API (type aliases + ergonomic helpers)
+    ├── logger/
+    └── errs/
 ```
 
-**Path convention:** `<org>/<repo>/<key>` (auto-resolved from git remote)
-**Backend:** 1Password CLI (`op`) with `OP_SERVICE_ACCOUNT_TOKEN`
-**Integration:** `/init` (check), `/git` (scan), `/do` (discover), `/infra` (TF_VAR_*)
+- Every directory is an independent Go module (see `go.work`); each is individually buildable with `GOWORK=off`.
+- Dependency direction is strictly top-down: kernel → core → service → pkg/v1. Enforced by `depguard` in `.golangci.yml`.
+- Consumers import only `pkg/v1/*`; `internal/*` is blocked by Go's `internal/` firewall.
 
-## Documentation Hierarchy
+## How to work
+
+| Goal | Flow |
+|---|---|
+| New feature or bug fix | `/plan "description"` → `/do` → `/git --commit` → `/git --merge` |
+| Code review | `/review` |
+| Linting | `make sdk-lint` (ktn-linter) |
+| Local test suite | `make sdk-all` (sync → tidy → lint → errs-audit → test) |
+
+Branch naming matches the conventional commit prefix: `feat/*`, `fix/*`, `refactor/*`, `chore/*`, `docs/*`.
+
+## SDK-wide rules (non-negotiable)
+
+1. **Kernel gate.** A kernel package MUST be stdlib-only AND generic (no domain vocabulary). `level` was moved OUT of kernel because it fails the second half — see ADR 0002 / the layer-placement audit in `.claude/contexts/sdk-layer-placement-audit.md`.
+2. **Typed errors only.** Every error returned from SDK code goes through `errs.Define` or `errs.Wrap` (`internal/kernel/errs`). `fmt.Errorf` / `errors.New` are banned in production code. The AST audit (`make sdk-errs-audit`) fails the build on violations.
+3. **Public/Private split.** Every SDK error carries a wire-safe `Public` (string literal ≤120 runes) and a log-only `Private`. `err.Error()` returns `"[<code> <REASON>] <public>"` — never Private, never Fields.
+4. **No empty stub files / dirs.** If a file or directory only carries a placeholder, inline its content into an existing file or delete it. Enforced by convention and by the "feedback_no_empty_stub_files" rule in the agent's memory.
+5. **Origin wins on wrap.** When `errs.Wrap` receives an `*errs.Error` cause, it inherits the cause's Code/Reason/Public/Private. Wrappers can only add `Fields`. To relabel, define a fresh sentinel.
+6. **`Version` via ldflags.** `pkg/v1/logger.Version` is injected at build time via `-ldflags "-X github.com/kitsunium/sdk/pkg/v1/logger.Version=…"`; every emitted record carries `framework_version` automatically.
+
+## Layout
 
 ```
-CLAUDE.md                    # This overview
-├── AGENTS.md                # Specialist agents (79 agents)
-├── docs/vision.md           # Objectives, success criteria
-├── docs/architecture.md     # System design, components
-├── docs/workflows.md        # Detailed workflows
-├── docs/ktn-linter-integration.md  # ktn-linter hook contract
-├── .github/CLAUDE.md        # GitHub Actions, dependabot
-├── .devcontainer/CLAUDE.md  # Container config details
-│   ├── features/CLAUDE.md   # Language & tool features
-│   ├── hooks/CLAUDE.md      # Host-side hooks (initialize.sh only)
-│   └── images/CLAUDE.md     # Two-tier images (base + dynamic)
-└── .claude/commands/        # Slash commands (20 skills)
+/workspace/
+├── internal/              see internal/CLAUDE.md
+├── pkg/v1/                see pkg/CLAUDE.md + pkg/v1/CLAUDE.md
+├── docs/                  ADRs — see docs/CLAUDE.md
+├── .devcontainer/         devcontainer infrastructure (template-seeded; leave alone)
+├── .github/               CI workflows — sdk-ci.yml is the one SDK-relevant job
+├── go.work, go.mod        workspace + umbrella module
+├── Makefile               SDK targets: sdk-sync / sdk-tidy / sdk-lint / sdk-errs-audit / sdk-test / sdk-all
+├── .golangci.yml          depguard layer firewall
+├── AGENTS.md, agent.toml  devcontainer agent specs (not SDK)
+└── README.md              SDK quickstart + public API entry point
 ```
-
-Principle: More detail deeper in tree. Target < 200 lines each.
-
-## Commands
-
-| Command | Purpose |
-|---------|---------|
-| `/init` | Conversational project discovery + doc generation |
-| `/plan` | Analyze codebase and design implementation approach |
-| `/do` | Execute approved plans iteratively |
-| `/review` | Code review (3-tier: agents + Qodo + CodeRabbit) |
-| `/git` | Conventional commits, branch management |
-| `/search` | Documentation research with official sources |
-| `/docs` | Deep project documentation generation |
-| `/test` | E2E testing with Playwright MCP |
-| `/lint` | Multi-language intelligent linting |
-| `/infra` | Infrastructure automation (Terraform/Terragrunt) |
-| `/secret` | Secure secret management (1Password) |
-| `/vpn` | Multi-protocol VPN management |
-| `/warmup` | Context pre-loading and CLAUDE.md update |
-| `/update` | DevContainer update from template |
-| `/improve` | Documentation QA for design patterns |
-| `/learn` | Extract reusable patterns from the current session into `~/.claude/docs/learned/` |
-| `/feature` | Feature tracking RTM (CRUD, audit, auto-learn) |
-| `/prompt` | Generate ideal prompt structure for /plan requests |
-
-## Collaboration Rules
-
-**Response style**
-- Terse. No trailing summary ("I did X, Y, Z"). The diff and output are enough.
-- Lead with action or decision, not with preamble.
-- French or English to match the user's language.
-
-**Tool discipline**
-- Dedicated tools over Bash equivalents: Read (not cat), Edit (not sed), Glob (not find), Grep (not grep).
-- Read the full file before modifying it. No guessing.
-- Parallelize independent tool calls in a single message when possible.
-
-**Git discipline**
-- Branch prefix matches commit prefix: `feat/*` → `feat:`, `fix/*` → `fix:`.
-- Never `--no-verify`, never `git push --force` without explicit user approval.
-- Always create NEW commits after hook failure, never `--amend`.
-
-**Memory discipline**
-- Propose feedback/user/project memories when the user corrects you, confirms an unusual choice, or shares a deadline/constraint.
-- At session end with significant corrections, suggest running `/learn`.
-
-**Destructive actions** — see the canonical [Safeguards](#safeguards) section above.
 
 ## Verification
 
-Changes are complete when:
-- Tests pass (`make test` or language equivalent)
-- Linting passes (auto-run by hooks)
-- No secrets in commits (checked by security hook)
-- Commit follows conventional format
+| Command | Expected |
+|---|---|
+| `ktn-linter lint ./...` | No issues found |
+| `make sdk-all` | all modules green, coverage ≥ 90% on emitter packages |
+| `make sdk-errs-audit` | AST audit passes (literal Public, Reason = var name, code uniqueness) |
+
+## Reference
+
+- ADR 0001 — multi-module layout — `docs/adr/0001-sdk-go-multimodule-layout.md`
+- ADR 0002 — layered `errs` package — `docs/adr/0002-sdk-errors-package.md`
+- Layer placement audit — `.claude/contexts/sdk-layer-placement-audit.md`

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,35 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# docs/
+
+## Purpose
+
+Long-form SDK documentation. Everything in here is authoritative — READMEs at the package level are the short-form mirror; ADRs here are the source of truth for cross-cutting decisions.
+
+## Contents
+
+| File | Topic | State |
+|---|---|---|
+| `adr/0001-sdk-go-multimodule-layout.md` | Multi-module layout (kernel/core/service/pkg-v1) | Accepted |
+| `adr/0002-sdk-errors-package.md` | Layered `errs` package, registry, breaking changes | Accepted |
+
+## ADR conventions
+
+- Sequential numbering (`0001`, `0002`, …). Never reuse a number.
+- Filename slug = short kebab-case summary of the decision.
+- Header fields: `Status`, `Date`, `Deciders`, optional `Supersedes`, optional `Related`.
+- Standard sections: Context, Decision, Consequences / Semantics, Breaking changes, Why not …, Deferred, References.
+- Immutable after merge. Supersede via a new ADR that references the old one.
+
+## ADR 0002 registry coupling
+
+The code-allocation table in `docs/adr/0002-sdk-errors-package.md` is the **documentary source of truth**; the AST audit test in `internal/kernel/errs/registry_external_test.go` embeds the same table as the **executable source of truth**. Keep the two in sync manually on every change — a future cross-reference test will catch drift.
+
+## Do NOT
+
+- Put feature documentation here. Packages document themselves via `README.md`.
+- Delete an accepted ADR. Mark it superseded by adding a new ADR and updating the `Status`.
+- Re-number existing ADRs.
+
+## Subtree
+
+- `adr/` — Architecture Decision Records (see files above)

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -1,0 +1,75 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# internal/
+
+## Purpose
+
+The SDK's private layer. Everything here is blocked from external import by Go's `internal/` rule. Three sublayers model the SDK's dependency discipline:
+
+```
+kernel/    stdlib-only, generic primitives (no domain vocabulary)
+core/      domain interfaces and domain values
+service/   concrete implementations of core contracts
+```
+
+## Dependency direction
+
+Strictly top-down:
+
+```
+kernel ──┐
+core  ──┼──▶ service ──▶ (pkg/v1 re-exports / consumes)
+         │
+         └── pkg/v1 (direct for value types like Attr / Level)
+```
+
+`.golangci.yml` encodes this via `depguard`:
+
+| Files match | Allow-list |
+|---|---|
+| `**/internal/kernel/**/*.go` | stdlib only |
+| `**/internal/core/**/*.go`  | stdlib + `…/internal/kernel` |
+| `**/internal/service/**/*.go` | stdlib + kernel + core |
+| `**/pkg/**/*.go` | stdlib + kernel + core + service |
+
+Any import going "upward" fails the lint.
+
+## Modules
+
+Each layer directory is its own Go module (for release independence):
+
+| Module path | Build with |
+|---|---|
+| `github.com/kitsunium/sdk/internal/kernel` | `cd internal/kernel && GOWORK=off go build ./...` |
+| `github.com/kitsunium/sdk/internal/core` | `cd internal/core && GOWORK=off go build ./...` |
+| `github.com/kitsunium/sdk/internal/service` | `cd internal/service && GOWORK=off go build ./...` |
+
+`replace` directives in each `go.mod` resolve intra-repo dependencies without published pseudo-versions. `go.work` at the repo root lets `go build ./...` from the SDK root work without `replace`.
+
+## Conventions
+
+- **Role-suffix types.** Exported structs take a role suffix (`AttrValue`, `RecordEvent`, `WrapParams`) per ktn-linter `KTN-STRUCT-ROLE`. Short, clean names are re-exported at `pkg/v1/*` via type aliases (`Attr = AttrValue`).
+- **One exported struct per file** (`KTN-STRUCT-ONEFILE`). Exceptions: DTOs with serialization tags.
+- **Every function needs a docstring** with `Params:` + `Returns:` sections; every control block takes a `//:` intent comment; every case label has its own intent comment. See existing files for the concrete shape.
+- **Tests.** `*_internal_test.go` for white-box, `*_external_test.go` for black-box; table-driven with a `runCase` helper so the linter's static analyser sees direct calls.
+- **Code ranges.** Each emitter package owns a 100-slot block of error codes (ADR 0002 registry). The AST audit (`make sdk-errs-audit`) enforces uniqueness and `reason = screamingSnake(varName)`.
+
+## Subtree
+
+- `kernel/` — see `internal/kernel/CLAUDE.md`
+- `core/` — see `internal/core/CLAUDE.md`
+- `service/` — see `internal/service/CLAUDE.md`
+
+## Do NOT
+
+- Move a logger-specific concept into `kernel/`. The kernel rule is both "stdlib-only" AND "generic". `level` was moved OUT for that reason.
+- Call `fmt.Errorf` / `errors.New` in production. All errors go through `errs.Define` / `errs.Wrap`.
+- Reference `service/*` from `core/*` or `kernel/*`; the direction is top-down.
+
+## Verification
+
+```
+GOWORK=off
+for m in internal/kernel internal/core internal/service; do
+  (cd $m && go test -race -cover ./...)
+done
+```

--- a/internal/core/CLAUDE.md
+++ b/internal/core/CLAUDE.md
@@ -1,0 +1,58 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# internal/core/
+
+## Purpose
+
+Domain **interfaces** and domain **value types**. No concrete behaviour lives here — implementations go in `internal/service/*`, the public facade lives in `pkg/v1/*`. Core's job is to describe "what the SDK's domains are" without prescribing how they are realised.
+
+## Contents
+
+| Package | Purpose | Code range |
+|---|---|---|
+| `logger/` | `Handler` + `Logger` interfaces, `RecordEvent`, `AttrValue` | 2100-2199 (reserved) |
+| `logger/level/` | Severity levels (`Debug` / `Info` / `Warn` / `Error`) | 1100-1199 (reserved) |
+
+## Module
+
+Single module `github.com/kitsunium/sdk/internal/core` — one `go.mod`, one `go.sum`.
+
+## Conventions
+
+- **Interface-first.** Core packages expose interfaces + immutable value types. Methods with bodies belong in `internal/service/*`.
+- **Role-suffix on exported structs.** `AttrValue` / `RecordEvent` — the ktn-linter `KTN-STRUCT-ROLE` rule requires it. Short names reappear as type aliases at `pkg/v1/logger` (`Attr = AttrValue`).
+- **Imports allowed**: stdlib + `internal/kernel/*`. Never `internal/service/*` or `pkg/*`.
+
+## Design notes (logger)
+
+The `core/logger` package is deliberately tiny:
+
+- `Handler` — 3 methods (`Enabled` / `Handle` / `WithAttrs`), not single-method, to avoid the ktn-linter `-er` naming rule AND because `WithAttrs` is a genuine part of the contract.
+- `Logger` — 3 methods (`Log` / `With` / `Enabled`), mirror the structure.
+- `RecordEvent` carries a `time.Time` that MAY be the zero value; `service/logger.TextHandler` supplies the fallback via `kernel/clock`.
+- Levels live in the `level/` subpackage (not inlined) so they keep their short import alias `level.Debug` and stay isolated from the interface surface.
+
+## Why `level/` is a subpackage here
+
+See `.claude/contexts/sdk-layer-placement-audit.md`. Summary:
+- `level` is logger-domain vocabulary; it cannot live in `internal/kernel/`.
+- Inlining Level into `internal/core/logger` would clutter the interface package and force a namespace collision (`logger.Level` next to `logger.Logger`).
+- Subpackage keeps the `level.Debug` call-site short AND tests isolated.
+
+## Do NOT
+
+- Add concrete types with runtime behaviour here. Any struct whose methods DO anything belongs in `internal/service/*`.
+- Import `context` outside of interface signatures.
+- Grow a third "level-like" subpackage. If a second domain needs severity, declare its own type in that domain; don't reuse `logger/level`.
+
+## Subtree
+
+- `logger/` — see `internal/core/logger/README.md` (no CLAUDE.md needed: one package, README.md covers the hierarchy)
+- `logger/level/` — see `internal/core/logger/level/README.md`
+
+## Verification
+
+```
+cd internal/core
+GOWORK=off go test -race -cover ./...
+# expected: logger has no tests (interfaces only), logger/level 100%
+```

--- a/internal/kernel/CLAUDE.md
+++ b/internal/kernel/CLAUDE.md
@@ -1,0 +1,54 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# internal/kernel/
+
+## Purpose
+
+The SDK's lowest layer: **stdlib-only AND generic** primitives. A package qualifies for `kernel/` only if both halves are true — it imports nothing outside the Go standard library AND its vocabulary is domain-neutral enough that any future domain could plausibly import it.
+
+## Contents
+
+| Package | Purpose | Code range |
+|---|---|---|
+| `errs/` | SDK-wide typed error + registry audit | 1000-1099 (meta-codes, documentary only) |
+| `buffer/` | `sync.Pool` of `[]byte` for zero-alloc formatting | 1200-1299 (reserved) |
+| `clock/` | Time abstraction (`Now` + `Since`) for testability | 1300-1399 (reserved) |
+
+The README of each package documents its surface, contract, and the explicit "Do NOT" list.
+
+## Module
+
+Single module `github.com/kitsunium/sdk/internal/kernel` — one `go.mod`, one `go.sum`, shared test harness. Each subdirectory is a Go package (not a sub-module).
+
+## Why NO `level/` here?
+
+`level` used to live at `internal/kernel/level/` but was moved to `internal/core/logger/level/` on 2026-04-19. Rationale: `Debug / Info / Warn / Error` is logger-domain vocabulary. No non-logger domain will ever import it, so it fails the "generic" half of the kernel rule even though it's stdlib-only. The audit that led to the move is documented in `.claude/contexts/sdk-layer-placement-audit.md`.
+
+Lesson: stdlib-only is necessary but NOT sufficient for kernel placement. When considering a new kernel package, ask "would a future HTTP middleware, metrics writer, or cache reach for this?". If no, it belongs in `core/<domain>/`.
+
+## Audit: who stays, who would leave
+
+As of 2026-04-19 audit (context doc above):
+
+- `errs` stays — every layer of the SDK uses typed errors, including kernel itself. Meta-infrastructure.
+- `clock` stays — textbook generic time abstraction.
+- `buffer` stays — byte-pool scratchpad is generic even though only `service/logger` uses it today (HTTP body encoder, JSON serialiser, metrics line-protocol would all reach for it).
+
+## Conventions unique to kernel
+
+1. **Import-only-stdlib.** No package outside of `kernel/errs` may use `fmt.Errorf`; kernel packages themselves may use `fmt` for formatting since they define the error type.
+2. **`errs` is the only kernel package that may use `errs` itself** (circularly, for its meta-codes 1001-1003 — those codes are documentary, never instantiated as `*Error`).
+3. **No domain vocabulary in public APIs.** No `User`, `Request`, `Log`, `Entity` in type names.
+
+## Do NOT
+
+- Add a package here whose only consumer is a specific domain (logger, HTTP, DB). Put it under `internal/core/<domain>/` as a subpackage.
+- Import anything from `internal/core/*` or `internal/service/*`; kernel sits at the bottom.
+- Rely on `kernel/` package imports for cross-package coupling — keep each package self-contained.
+
+## Verification
+
+```
+cd internal/kernel
+GOWORK=off go test -race -cover ./...
+# expected: buffer 90%, clock 100%, errs 97.3%
+```

--- a/internal/service/CLAUDE.md
+++ b/internal/service/CLAUDE.md
@@ -1,0 +1,52 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# internal/service/
+
+## Purpose
+
+Concrete implementations of the contracts declared in `internal/core/*`. This is where actual I/O, formatting, locking, and error wrapping happen. The `pkg/v1/*` facade wraps service constructors and hides the wiring from consumers.
+
+## Contents
+
+| Package | Purpose | Code range |
+|---|---|---|
+| `logger/` | `TextHandler` + `loggerImpl` realising `core/logger.Handler` + `Logger` | 3100-3199 (emitter) |
+
+## Module
+
+Single module `github.com/kitsunium/sdk/internal/service` — one `go.mod`. `replace` directives resolve `../kernel` and `../core` locally so `GOWORK=off go build ./...` works per-module in CI.
+
+## Emitted errors (service/logger)
+
+| Code | Var | Trigger |
+|---|---|---|
+| 3101 | `WriterNil` | `NewTextHandler(nil, …)` |
+| 3102 | `HandlerNil` | `New(nil)` |
+| 3110 | `CtxCancelled` | `Handle(ctx, r)` with a cancelled context — wraps `context.Canceled` |
+| 3120 | `WriteFailed` | Underlying `io.Writer.Write` returned an error — wraps the cause, ExitCode override 74 (EX_IOERR) |
+
+All four are declared in `logger/codes.go` + `logger/errors.go`. The AST audit (`make sdk-errs-audit`) enforces the convention `Go var name == Reason`.
+
+## Conventions
+
+- **Imports allowed**: stdlib + `internal/kernel/*` + `internal/core/*`. Never `pkg/*`.
+- **Concurrent safety**: every public type exposes the "safe for concurrent use" contract from core, and implements it (typically via `sync.Mutex` for stateful handlers).
+- **Error wrapping**: `errs.Wrap(cause, WrapParams{…})` when the cause is a stdlib error; the `errs.WrapParams` fields are SILENTLY IGNORED when the cause is already an `*errs.Error` (origin wins). See `internal/kernel/errs/README.md`.
+- **Function length**: `KTN-FUNC-MAXLOC` caps at 50 lines. `TextHandler.Handle` was split into `renderLine` + `writeLine` helpers for that reason.
+
+## Do NOT
+
+- Re-export a service type as the public-facing API. The public facade is `pkg/v1/*` — consumers should never see a `svclogger.TextHandler` type.
+- Reach into `core/logger` structs to mutate them. `AttrValue` and `RecordEvent` are immutable after construction.
+- Swallow writer errors silently in a handler. Wrap them via `errs.Wrap` so `errors.Is(err, originalCause)` keeps working.
+
+## Subtree
+
+- `logger/` — see `internal/service/logger/README.md` (full contract, error catalogue, output format)
+
+## Verification
+
+```
+cd internal/service
+GOWORK=off go test -race -cover ./...
+# expected: logger 100%
+```

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -1,0 +1,35 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# pkg/
+
+## Purpose
+
+The SDK's stable public API surface. Each subdirectory is a major version (`v1`, `v2`, …). Consumers import `pkg/<major>/*`; `internal/*` is blocked by Go's internal-import rule.
+
+## Contents
+
+| Major | Purpose | State |
+|---|---|---|
+| `v1/` | Stable public API for logging + error introspection | Shipping |
+
+## Versioning policy
+
+- `pkg/v1` signatures are **frozen post-v1.0.0**. Any breaking change goes into a new `pkg/v2` (coexists with v1 until deprecation).
+- Security fixes in `internal/*` propagate via minor bumps on the module concerned — no `pkg/v1` changes required because it only re-exports.
+- Adding a new `pkg/vN` is a dedicated ADR.
+
+## Conventions
+
+- Public types are **type aliases** onto `internal/core/*` / `internal/kernel/*` (clean short names, zero runtime cost).
+- Public functions are thin wrappers: validation + delegation. No business logic in this layer.
+- **No constructors for internal types**. Consumers can introspect SDK errors via `pkg/v1/errs.*Of(err)` accessors but cannot forge `*errs.Error` values.
+- **ldflags injection**: `pkg/v1/logger.Version` is the single injection point; all other packages read via `logger.FrameworkVersion()`.
+
+## Subtree
+
+- `v1/` — see `pkg/v1/CLAUDE.md`
+
+## Do NOT
+
+- Export the concrete `*errs.Error` type here; consumers should see `error` only.
+- Import from `pkg/v1` into `internal/*`. The public facade sits at the top of the dependency graph.
+- Rename or remove an exported identifier in `pkg/v1/*` without cutting `pkg/v2`.

--- a/pkg/v1/CLAUDE.md
+++ b/pkg/v1/CLAUDE.md
@@ -1,0 +1,49 @@
+<!-- updated: 2026-04-19T10:18:42Z -->
+# pkg/v1/
+
+## Purpose
+
+The first (and today only) major version of the SDK's public API. Type signatures exposed here are frozen post-v1.0.0 — breaking changes land in `pkg/v2`.
+
+## Packages
+
+| Package | Role | README |
+|---|---|---|
+| `logger/` | Logging facade: `Config`, `NewText`, `Default`, `Info/Warn/Error/Debug`, `String/Int` | `pkg/v1/logger/README.md` |
+| `errs/` | Read-only error introspection: `CodeOf`, `ReasonOf`, `PublicOf`, `PrivateOf`, `LayerOf`, `HTTPStatusOf`, `ExitCodeOf`, `HasCode`, `HasReason` | `pkg/v1/errs/README.md` |
+
+## Module
+
+Single module `github.com/kitsunium/sdk/pkg/v1` — one `go.mod`, one `go.sum`.
+
+## Public surface contract
+
+- **Stable identifiers**: every exported name / type / const listed in the package READMEs is frozen until `pkg/v2`.
+- **No constructors for internal types**: `pkg/v1/errs` exposes `Of`-accessors, never the concrete `*errs.Error`.
+- **No pass-through of `FieldValue`** at v1: if consumer demand appears, we add `FieldsOfAsMap(err) map[string]string` in a minor bump.
+- **Breaking change policy**: 4 breaking signature changes + 1 behaviour change already landed with the errors MR (see ADR 0002 "Breaking changes"). The next set — if any — goes to `pkg/v2`.
+
+## Conventions
+
+- Import aliases at call sites: always `logger "github.com/kitsunium/sdk/pkg/v1/logger"` + `errs "github.com/kitsunium/sdk/pkg/v1/errs"` for clarity.
+- Every emitted record carries `framework_version` via the ldflags-injected `logger.Version`. Injection recipe is in `pkg/v1/logger/README.md`.
+- `logger.NewText(Config{})` refuses a nil Writer and returns `(nil, WriterRequired)`. Use `logger.Default()` for the stderr convenience.
+
+## Do NOT
+
+- Expose `PrivateOf(err)` output in HTTP/gRPC responses, error pages, or any user-facing surface. It is diagnostic-only — documented in the package godoc and the README.
+- Try to construct a `*errs.Error` from consumer code. Go's `internal/` rule blocks it and the design is deliberate.
+- Set `Version` at runtime from application code; use the ldflags recipe so every binary commits its version at link time.
+
+## Verification
+
+```
+cd pkg/v1
+GOWORK=off go test -race -cover ./...
+# expected: logger 84.2%, errs [no statements] (accessors are re-exports)
+```
+
+## Subtree
+
+- `logger/` — `pkg/v1/logger/README.md`
+- `errs/` — `pkg/v1/errs/README.md`


### PR DESCRIPTION
## Summary

Funnel documentation for the SDK: every SDK-relevant directory now owns a concise CLAUDE.md describing its purpose, conventions, and do-not rules. Leaf packages keep their README.md as the human/consumer surface; CLAUDE.md is the AI-facing hierarchy context.

- **Rewrites** `/workspace/CLAUDE.md` — the root was still describing the devcontainer-template; it now documents the SDK (`github.com/kitsunium/sdk`).
- **Adds** 7 directory-level CLAUDE.md files:
  - `internal/CLAUDE.md` — 4-layer overview + dependency direction + depguard policy
  - `internal/kernel/CLAUDE.md` — kernel gate rules, why `level` was moved out
  - `internal/core/CLAUDE.md` — domain interfaces, rationale for the `level/` subpackage
  - `internal/service/CLAUDE.md` — concrete impls, full error catalogue (3101/3102/3110/3120)
  - `pkg/CLAUDE.md` — public API versioning policy
  - `pkg/v1/CLAUDE.md` — stable surface contract + verification commands
  - `docs/CLAUDE.md` — ADR conventions, registry table ↔ AST-audit coupling
- **Leaves untouched**: `.devcontainer/*`, `.github/*`, image-embedded `.claude/*` CLAUDE.md files — those describe devcontainer infrastructure, not SDK architecture.

Each file is well under the 200-line ceiling (35-75 lines). Every level defers package-level detail to the existing per-package README.md files added in PR #2.

## Test plan

- [ ] `ktn-linter lint ./...` still reports zero issues
- [ ] `find . -name CLAUDE.md -not -path '*/.git/*' | wc -l` returns the expected count (17 = 8 SDK + 9 devcontainer)
- [ ] Spot-check a few leaf READMEs / CLAUDE.md pairs — verify they point at each other without duplication
