### PR TITLE
chore(ktn-linter): project-level config with scoped exceptions

### DIFF
--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -87,36 +87,17 @@ rules:
   # map storage) do not fire on concrete methods that simply delegate to
   # `encoding/json`, `encoding/xml`, etc.
   #
-  # We disable the rule ONLY inside codec trees. Every other Go package in
-  # the SDK must still avoid `any` except where the Codec contract requires it.
+  # Disable ONLY inside the codec tree. Every other Go package in the SDK
+  # must still avoid `any` except where the Codec contract requires it.
   KTN-INTERFACE-ANYUSE:
-    enabled: true
     exclude:
       - "**/internal/core/codec/**"
       - "**/internal/service/codec/**"
       - "**/pkg/v1/codec/**"
 
-  # KTN-FUNC-NOINIT (warning) — "init() is discouraged".
-  #
-  # Scoped exception: the codec registry uses the canonical Go pattern
-  # `import _ "…/service/codec/json"` which relies on the subpackage's
-  # init() calling codec.Register. There is no clean workaround without
-  # forcing every consumer to manually call a Register function.
-  #
-  # Same scope as above — the rule stays active everywhere else.
-  KTN-FUNC-NOINIT:
-    enabled: true
-    exclude:
-      - "**/internal/service/codec/**"
-      - "**/pkg/v1/codec/**"
-
-  # KTN-TEST-DECISION (info) — "exercise all decision outcomes".
-  #
-  # This rule's static analyser frequently fails to detect branch coverage
-  # when tests use a runCase helper or table-driven subtests. The rule is
-  # still useful as guidance; we just don't want it to block commits.
-  # Downgrade by leaving it enabled but allowing the hook (phase 8) to run
-  # it non-blocking via max_phase above — KTN-TEST-DECISION is in Phase 8,
-  # which we already cap out of blocking territory.
-  KTN-TEST-DECISION:
-    enabled: true
+  # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
+  # Go 1.26 convention is to avoid init() in favour of explicit constructors,
+  # sync.Once for lazy init, or package-level var initialisers. The codec
+  # registry will follow that: each codec subpackage registers itself via
+  # `var _ = codec.Register(New())` (var initialiser, not init()), or via
+  # an explicit constructor the facade invokes.

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -1,0 +1,122 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# KTN-Linter configuration — kitsunium/sdk
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# The defaults are strict (see `ktn-linter config --generate` for the full
+# reference). This file only overrides what conflicts with the SDK's design
+# choices; every other rule runs with its default behaviour.
+#
+# Every override below has a brief justification so future readers (and
+# code reviewers) can challenge the exception instead of rubber-stamping it.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+version: 1
+
+# ── Global options ────────────────────────────────────────────────────────────
+
+# Full strict mode stays off so test files / testdata keep their ergonomic
+# exemptions (mocks, table-driven assertions, etc.).
+strict_mode: false
+
+# Phase 8 is cosmetic / opt-in; we never block on it.
+max_phase: 7
+
+# Respect `// Code generated …` markers so generated files are skipped.
+skip_generated: true
+
+# Tags recognised by KTN-STRUCT-JSONTAG. Extend as we ship more codecs so the
+# audit keeps recognising legitimate struct-tag annotations.
+serialization_tags:
+  - json
+  - xml
+  - yaml
+  - toml
+  - protobuf
+  - msgpack
+  - cbor
+  - bson
+
+# ── Global file exclusions ────────────────────────────────────────────────────
+# Skip any path that matches one of the glob patterns below, for every rule.
+# Use this list for third-party / generated / non-source trees only.
+exclude:
+  # Vendored third-party code — never our convention to enforce.
+  - "vendor/**"
+  # Go module cache occasionally shows up in IDE-driven scans.
+  - "**/.cache/**"
+  # Protocol Buffers and gRPC generated code.
+  - "**/*.pb.go"
+  - "**/*.pb.gw.go"
+  - "**/*_grpc.pb.go"
+  # FlatBuffers / Cap'n Proto generated code.
+  - "**/*.capnp.go"
+  - "**/*_generated.go"
+  # Generic `*.gen.go` / `*_gen.go` marker used by stringer, mockgen, etc.
+  - "**/*.gen.go"
+  - "**/*_gen.go"
+  # Mock files produced by mockgen / moq / counterfeiter.
+  - "**/mocks/**"
+  - "**/*_mock.go"
+  - "**/mock_*.go"
+  # Stringer output.
+  - "**/*_string.go"
+  # Jennifer / go-jet / go-swagger generated trees.
+  - "**/generated/**"
+  - "**/gen/**"
+  # WebAssembly / CGO stubs we don't audit.
+  - "**/*.wasm.go"
+  # Test coverage artifacts and profile output.
+  - "**/coverage.out"
+  - "**/*.test"
+  - "**/*.prof"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RULE OVERRIDES
+# ═══════════════════════════════════════════════════════════════════════════════
+# Keep this list small on purpose — every entry here is a design choice we
+# committed to, not "this warning is annoying".
+# ═══════════════════════════════════════════════════════════════════════════════
+
+rules:
+  # KTN-INTERFACE-ANYUSE (info) — "prefer specific interface".
+  #
+  # Scoped exception: the codec packages implement a universal Codec
+  # interface whose Marshal/Unmarshal signatures REQUIRE `any` (the whole
+  # point of a universal codec is that the user's struct type is not known
+  # to the codec). The auto-exemptions documented in the rule (type switch,
+  # map storage) do not fire on concrete methods that simply delegate to
+  # `encoding/json`, `encoding/xml`, etc.
+  #
+  # We disable the rule ONLY inside codec trees. Every other Go package in
+  # the SDK must still avoid `any` except where the Codec contract requires it.
+  KTN-INTERFACE-ANYUSE:
+    enabled: true
+    exclude:
+      - "**/internal/core/codec/**"
+      - "**/internal/service/codec/**"
+      - "**/pkg/v1/codec/**"
+
+  # KTN-FUNC-NOINIT (warning) — "init() is discouraged".
+  #
+  # Scoped exception: the codec registry uses the canonical Go pattern
+  # `import _ "…/service/codec/json"` which relies on the subpackage's
+  # init() calling codec.Register. There is no clean workaround without
+  # forcing every consumer to manually call a Register function.
+  #
+  # Same scope as above — the rule stays active everywhere else.
+  KTN-FUNC-NOINIT:
+    enabled: true
+    exclude:
+      - "**/internal/service/codec/**"
+      - "**/pkg/v1/codec/**"
+
+  # KTN-TEST-DECISION (info) — "exercise all decision outcomes".
+  #
+  # This rule's static analyser frequently fails to detect branch coverage
+  # when tests use a runCase helper or table-driven subtests. The rule is
+  # still useful as guidance; we just don't want it to block commits.
+  # Downgrade by leaving it enabled but allowing the hook (phase 8) to run
+  # it non-blocking via max_phase above — KTN-TEST-DECISION is in Phase 8,
+  # which we already cap out of blocking territory.
+  KTN-TEST-DECISION:
+    enabled: true


### PR DESCRIPTION
## Summary

Adds `.ktn-linter.yaml` at the repo root so we can ship the universal codec package (approved plan `sdk-universal-codec`) without wrestling with a rule whose auto-exemption patterns do not fire on delegating concrete methods.

**Global excludes** (apply to every rule):
- `vendor/**`, `**/.cache/**`
- Generated code: `*.pb.go`, `*.pb.gw.go`, `*_grpc.pb.go`, `*.capnp.go`, `*_generated.go`, `*.gen.go`, `*_gen.go`, `*_string.go`, `*.wasm.go`
- Mocks: `**/mocks/**`, `*_mock.go`, `mock_*.go`
- Test artefacts: `coverage.out`, `*.test`, `*.prof`

**`serialization_tags`** extended with `msgpack`, `cbor`, `bson` so the AST audit keeps recognising legitimate struct tags when the corresponding codecs land.

**Two scoped exceptions** (every other rule stays at default strictness):

| Rule | Scope of exception | Why |
|---|---|---|
| `KTN-INTERFACE-ANYUSE` | `internal/core/codec/**`, `internal/service/codec/**`, `pkg/v1/codec/**` | Universal Codec interface requires `Marshal(v any) / Unmarshal(v any)` by design; auto-exemptions documented by the rule (type switch, map storage) do not fire on concrete delegating methods. |
| `KTN-FUNC-NOINIT` | `internal/service/codec/**`, `pkg/v1/codec/**` | Blank-import registration pattern (`import _ "…/codec/json"`) relies on `init()` calling `codec.Register`; no cleaner alternative without forcing manual registration. |

Every other Go package in the SDK still runs under the full rule set, including `any` discipline and no-init policy. The exceptions are explicitly scoped to the codec tree and documented inline in the config so future reviewers can challenge them instead of rubber-stamping.

## Test plan

- [ ] `ktn-linter lint ./...` from repo root reports no issues
- [ ] Lint a future codec file in `internal/service/codec/json/` with a concrete `Marshal(v any)` method — no longer blocks
- [ ] Any new non-codec file with `Marshal(v any)` continues to be flagged by `KTN-INTERFACE-ANYUSE`
