### PR TITLE
fix(ci): sanitize coverage artifact names + bump golangci-lint to v2

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -59,9 +59,14 @@ jobs:
           go test -race -cover -coverprofile=coverage.out
           -ldflags "-X github.com/kitsunium/sdk/pkg/v1/logger.Version=ci-${{ github.sha }}"
           ./...
+      - name: sanitize module name for artifact
+        id: artifact-name
+        run: echo "slug=coverage-${MOD//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          MOD: ${{ matrix.module }}
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.module }}
+          name: ${{ steps.artifact-name.outputs.slug }}
           path: ${{ matrix.module }}/coverage.out
 
   lint:
@@ -71,9 +76,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.62
+          version: v2.11
           args: --timeout=5m
 
   vulncheck:


### PR DESCRIPTION
## Summary

Post-merge CI on main failed: [run 24639552407](https://github.com/kitsunium/sdk/actions/runs/24639552407). Two latent issues the pre-merge run hadn't surfaced (sdk-ci triggers are path-filtered, and the matrix had not been exercised against the new modules).

- **upload-artifact**: `coverage-${{ matrix.module }}` resolves to `coverage-pkg/v1`, `coverage-internal/service`, etc. GitHub Actions forbids `/` in artifact names. Fix: sanitise the slug in a pre-step (`${MOD//\//-}`) and reference it.
- **lint**: `golangci-lint v1.62.2` is built with Go 1.23; the `.golangci.yml` `go: "1.26"` setting is higher than the lint binary's toolchain, so the action aborts. Fix: bump `golangci/golangci-lint-action@v6` → `@v9` and the lint version `v1.62` → `v2.11` (built against Go 1.24+, supports Go 1.26 toolchain). The project's `.golangci.yml` already uses the v2 schema; no config migration needed.

## Test plan

- [ ] CI on this PR: `test (internal/kernel|internal/core|internal/service|pkg/v1)` jobs all succeed including the upload-artifact step.
- [ ] `lint` job succeeds with golangci-lint v2.11.
- [ ] `vulncheck (*)` jobs remain green.

## Notes

- The sanitised artifact names become `coverage-internal-kernel`, `coverage-internal-core`, `coverage-internal-service`, `coverage-pkg-v1`.
- No source code change — this is a workflow-only fix.
