### PR TITLE
chore(devcontainer): install buildifier + buildozer via go feature

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-18T21:18:33Z -->
+<!-- updated: 2026-04-20T09:28:02Z -->
 # DevContainer Configuration
 
 ## Purpose

--- a/.devcontainer/features/CLAUDE.md
+++ b/.devcontainer/features/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-10T12:00:00Z -->
+<!-- updated: 2026-04-20T09:28:02Z -->
 # DevContainer Features
 
 ## Purpose

--- a/.devcontainer/features/languages/CLAUDE.md
+++ b/.devcontainer/features/languages/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-10T12:00:00Z -->
+<!-- updated: 2026-04-20T09:28:02Z -->
 # Language Features
 
 ## Purpose

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -232,11 +232,7 @@ install_go_tool "ktn-linter" \
     "" \
     "binary" &
 
-# ── Bazel tooling — formatter + scripted BUILD editor ────────────────
-# buildifier: gofmt for BUILD.bazel / WORKSPACE / *.bzl
-# buildozer : programmatic edits on BUILD targets
-# Both ship as prebuilt binaries from the same bazelbuild/buildtools
-# release so one version lookup feeds both.
+# Bazel tooling — same release ships both binaries.
 if [[ -n "$BUILDTOOLS_VERSION" ]]; then
     install_go_tool "buildifier" \
         "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildifier-linux-${GO_ARCH}" \
@@ -261,18 +257,26 @@ echo -e "${GREEN}✓ All Go tools installed${NC}"
 # Install Wails v2 + TinyGo in parallel
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Wails v2 (Desktop GUI Framework)
+# Wails v2 (Desktop GUI Framework) — binary from GitHub Releases, fallback go install
 (
     echo -e "${YELLOW}Installing Wails v2 (desktop GUI framework)...${NC}"
-    if go install github.com/wailsapp/wails/v2/cmd/wails@latest; then
-        if command -v wails &> /dev/null; then
-            WAILS_VERSION=$(wails version 2>/dev/null | head -n 1 || echo "installed")
-            echo -e "${GREEN}✓ Wails ${WAILS_VERSION}${NC}"
-        else
-            echo -e "${YELLOW}⚠ Wails installed but not in PATH yet${NC}"
+    WAILS_VERSION=$(get_github_latest_version_or_empty "wailsapp/wails")
+    WAILS_INSTALLED=false
+    if [[ -n "$WAILS_VERSION" ]]; then
+        WAILS_URL="https://github.com/wailsapp/wails/releases/download/v${WAILS_VERSION}/wails-linux-${GO_ARCH}"
+        if curl -fsSL --connect-timeout 10 --max-time 60 -o "$GOPATH/bin/wails" "$WAILS_URL" 2>/dev/null; then
+            chmod +x "$GOPATH/bin/wails"
+            echo -e "${GREEN}✓ Wails v${WAILS_VERSION} (binary)${NC}"
+            WAILS_INSTALLED=true
         fi
-    else
-        echo -e "${YELLOW}⚠ Wails installation failed${NC}"
+    fi
+    if [[ "$WAILS_INSTALLED" != "true" ]]; then
+        echo -e "${YELLOW}  Fallback to go install...${NC}"
+        if go install github.com/wailsapp/wails/v2/cmd/wails@latest; then
+            echo -e "${GREEN}✓ Wails installed (compiled)${NC}"
+        else
+            echo -e "${YELLOW}⚠ Wails installation failed${NC}"
+        fi
     fi
 ) &
 WAILS_PID=$!
@@ -338,6 +342,10 @@ echo "  - GOPATH: $GOPATH"
 echo "  - GOCACHE: $GOCACHE"
 echo "  - GOMODCACHE: $GOMODCACHE"
 echo ""
+
+# Write version marker for volume sync (Phase 2 acceleration)
+sudo mkdir -p /opt/devcontainer-versions
+go version 2>/dev/null | sudo tee /opt/devcontainer-versions/go >/dev/null
 
 # Install ktn-linter MCP fragment (feature-level, only when Go is enabled)
 # JSON is inlined because OCI feature artifacts don't include mcp.json files

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -166,6 +166,8 @@ GOLANGCI_VERSION=$(get_github_latest_version_or_empty "golangci/golangci-lint")
 GOSEC_VERSION=$(get_github_latest_version_or_empty "securego/gosec")
 GOFUMPT_VERSION=$(get_github_latest_version_or_empty "mvdan/gofumpt")
 GOTESTSUM_VERSION=$(get_github_latest_version_or_empty "gotestyourself/gotestsum")
+# buildifier + buildozer ship from the same bazelbuild/buildtools release.
+BUILDTOOLS_VERSION=$(get_github_latest_version_or_empty "bazelbuild/buildtools")
 
 # gofumpt uses 'v' prefix in URLs
 [[ -n "$GOFUMPT_VERSION" && "$GOFUMPT_VERSION" != v* ]] && GOFUMPT_VERSION="v${GOFUMPT_VERSION}"
@@ -229,6 +231,28 @@ install_go_tool "ktn-linter" \
     "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
     "" \
     "binary" &
+
+# ── Bazel tooling — formatter + scripted BUILD editor ────────────────
+# buildifier: gofmt for BUILD.bazel / WORKSPACE / *.bzl
+# buildozer : programmatic edits on BUILD targets
+# Both ship as prebuilt binaries from the same bazelbuild/buildtools
+# release so one version lookup feeds both.
+if [[ -n "$BUILDTOOLS_VERSION" ]]; then
+    install_go_tool "buildifier" \
+        "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildifier-linux-${GO_ARCH}" \
+        "github.com/bazelbuild/buildtools/buildifier" \
+        "binary" &
+    install_go_tool "buildozer" \
+        "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildozer-linux-${GO_ARCH}" \
+        "github.com/bazelbuild/buildtools/buildozer" \
+        "binary" &
+else
+    (echo -e "${YELLOW}buildifier/buildozer: version unavailable, building from source...${NC}" && \
+     go install github.com/bazelbuild/buildtools/buildifier@latest && \
+     go install github.com/bazelbuild/buildtools/buildozer@latest && \
+     echo -e "${GREEN}✓ buildifier + buildozer installed (from source)${NC}" || \
+     echo -e "${YELLOW}⚠ buildifier/buildozer: source build failed, skipping${NC}") &
+fi
 
 wait
 echo -e "${GREEN}✓ All Go tools installed${NC}"
@@ -297,7 +321,7 @@ echo "  - ${GO_INSTALLED}"
 echo "  - Go Modules (package manager)"
 echo ""
 echo "Development tools:"
-for _tool in golangci-lint gosec gofumpt goimports gotestsum ktn-linter; do
+for _tool in golangci-lint gosec gofumpt goimports gotestsum ktn-linter buildifier buildozer; do
     if command -v "$_tool" &>/dev/null; then
         echo "  - $_tool (installed)"
     else

--- a/.devcontainer/features/languages/python/install.sh
+++ b/.devcontainer/features/languages/python/install.sh
@@ -154,10 +154,6 @@ pip_install() {
 # Quality, linting, type checking, security, testing — single batch
 pip_install ruff pylint mypy bandit pytest pytest-cov
 
-# Documentation Tools (MkDocs Material) — single batch
-echo -e "${YELLOW}Installing documentation tools...${NC}"
-pip_install mkdocs mkdocs-material mkdocs-minify-plugin mkdocs-awesome-pages-plugin
-
 echo -e "${GREEN}✓ Python development tools installed${NC}"
 
 # Setup shell integration for pyenv (if installed)
@@ -194,10 +190,6 @@ echo "  - pylint (linter)"
 echo "  - mypy (type checker)"
 echo "  - bandit (security scanner)"
 echo "  - pytest + pytest-cov (testing)"
-echo ""
-echo "Documentation tools:"
-echo "  - mkdocs + mkdocs-material (static site generator)"
-echo "  - mkdocs-material includes native Mermaid support"
 echo ""
 echo "Cache directory:"
 echo "  - pip: $PIP_CACHE_DIR"

--- a/.devcontainer/features/languages/rust/install.sh
+++ b/.devcontainer/features/languages/rust/install.sh
@@ -118,9 +118,12 @@ CORE_TOOLS=(
     cargo-watch       # Auto-rebuild on file changes
     cargo-nextest     # Fast test runner
     cargo-deny        # Dependency security + license checker
-    cargo-outdated    # Dependency update checker
-    cargo-tarpaulin   # Code coverage tool
-    wasm-bindgen-cli  # JS bindings generator for WASM
+)
+
+BINSTALL_ONLY_TOOLS=(
+    cargo-outdated    # Dependency update checker (skip if no binary — 3min compile)
+    cargo-tarpaulin   # Code coverage tool (skip if no binary — 5min compile)
+    wasm-bindgen-cli  # JS bindings generator (skip if no binary — 3min compile)
 )
 
 # Phase 1: Parallel binstall (fast binary downloads)
@@ -148,7 +151,7 @@ for i in "${!BINSTALL_PIDS[@]}"; do
     fi
 done
 
-# Phase 2: Sequential fallback for failures (cargo install)
+# Phase 2: Sequential fallback for CORE tools only (cargo install)
 for tool in "${TOOLS_TO_RETRY[@]}"; do
     echo -e "${YELLOW}Compiling ${tool} (no binary available)...${NC}"
     if cargo install --locked "$tool" 2>/dev/null; then
@@ -156,6 +159,19 @@ for tool in "${TOOLS_TO_RETRY[@]}"; do
     else
         warn "${tool} failed"
         FAILED_TOOLS+=("$tool")
+    fi
+done
+
+# Phase 3: Binary-only tools (skip compilation — too slow for devcontainer builds)
+for tool in "${BINSTALL_ONLY_TOOLS[@]}"; do
+    if command -v "${tool}" &>/dev/null 2>&1; then
+        ok "${tool} (cached)"
+        continue
+    fi
+    if cargo binstall --no-confirm --disable-strategies compile "$tool" 2>/dev/null; then
+        ok "${tool} (binary)"
+    else
+        warn "${tool}: no pre-built binary, install with: cargo install ${tool}"
     fi
 done
 
@@ -267,6 +283,10 @@ echo "  - RUSTUP_HOME: $RUSTUP_HOME"
 echo ""
 echo "Note: WebKitGTK/Tauri libs are pre-installed in base image"
 echo ""
+
+# Write version marker for volume sync (Phase 2 acceleration)
+sudo mkdir -p /opt/devcontainer-versions
+{ rustc --version 2>/dev/null; cargo --version 2>/dev/null; } | sudo tee /opt/devcontainer-versions/rust >/dev/null
 
 # Install MCP fragment (rust-analyzer MCP server)
 # JSON is inlined because OCI feature artifacts don't include mcp.json files

--- a/.devcontainer/images/.claude/CLAUDE.md
+++ b/.devcontainer/images/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-18T21:18:33Z -->
+<!-- updated: 2026-04-20T09:28:02Z -->
 # Claude Code Core Rules
 
 ## 1.0 MCP-FIRST (MANDATORY)

--- a/.devcontainer/images/.claude/commands/update/apply.md
+++ b/.devcontainer/images/.claude/commands/update/apply.md
@@ -144,6 +144,23 @@ apply_devcontainer_tarball() {
         echo "  ✓ mcp-fragments"
     fi
 
+    # DevContainer features (container only) — mirror from tarball.
+    # postStart also force-syncs from the image's embedded copy; /update brings
+    # them current immediately without waiting for the next image rebuild.
+    # The updated .template-version written in §5.7 tells postStart to yield
+    # when the repo is ahead of the image.
+    if [ "$CONTEXT" = "container" ] && [ -d "$src/.devcontainer/features" ]; then
+        mkdir -p ".devcontainer/features"
+        if command -v rsync &>/dev/null; then
+            rsync -a --delete "$src/.devcontainer/features/" ".devcontainer/features/"
+        else
+            rm -rf ".devcontainer/features"
+            mkdir -p ".devcontainer/features"
+            cp -rf "$src/.devcontainer/features/." ".devcontainer/features/"
+        fi
+        echo "  ✓ features"
+    fi
+
     # Design patterns docs
     if [ -d "$src/.devcontainer/images/.claude/docs" ]; then
         mkdir -p "$UPDATE_TARGET/docs"
@@ -158,10 +175,9 @@ apply_devcontainer_tarball() {
         echo "  ✓ templates"
     fi
 
-    # devcontainer.json (container only - update feature refs)
+    # devcontainer.json (container only - merge template + local override)
     if [ "$CONTEXT" = "container" ] && [ -f "$src/.devcontainer/devcontainer.json" ]; then
-        cp -f "$src/.devcontainer/devcontainer.json" ".devcontainer/devcontainer.json"
-        echo "  ✓ devcontainer.json"
+        update_devcontainer_json_from_tarball "$src"
     fi
 
     # Dockerfile (container only - update FROM reference)
@@ -333,6 +349,55 @@ update_compose_from_tarball() {
 }
 ```
 
+### 5.3.1: devcontainer.json merge (from tarball)
+
+```bash
+# Merge template devcontainer.json with local override
+# - Template: structure, feature refs (GHCR URLs), lifecycle commands → always updated
+# - devcontainer.local.json (optional, project-managed): enabled features with options,
+#   custom extensions, env vars, mounts → always preserved across /update runs
+#
+# No override file → template copied as-is (preserves JSONC comments for discovery)
+# Override file exists → deep merge written as strict JSON (comments stripped)
+update_devcontainer_json_from_tarball() {
+    local src="$1"
+    local template_file="$src/.devcontainer/devcontainer.json"
+    local target_file=".devcontainer/devcontainer.json"
+    local override_file=".devcontainer/devcontainer.local.json"
+    local merge_script="$src/.devcontainer/images/scripts/merge-devcontainer-json.mjs"
+
+    if [ ! -f "$override_file" ]; then
+        # Advisory: warn if local diverges from template — user likely needs a local override
+        if [ -f "$target_file" ] && ! cmp -s "$target_file" "$template_file"; then
+            echo "  ⚠ devcontainer.json differs from template and no devcontainer.local.json found"
+            echo "    Local customizations will be overwritten. To preserve them, create"
+            echo "    .devcontainer/devcontainer.local.json with your overrides (see .devcontainer/CLAUDE.md)."
+        fi
+        cp -f "$template_file" "$target_file"
+        echo "  ✓ devcontainer.json (template, no override)"
+        return 0
+    fi
+
+    if ! command -v node >/dev/null 2>&1 || [ ! -f "$merge_script" ]; then
+        echo "  ⚠ devcontainer.json merge skipped (node or merge script missing); copying template"
+        cp -f "$template_file" "$target_file"
+        return 0
+    fi
+
+    local backup_file="${target_file}.backup"
+    [ -f "$target_file" ] && cp "$target_file" "$backup_file"
+
+    if node "$merge_script" "$template_file" "$override_file" "$target_file" 2>/dev/null; then
+        rm -f "$backup_file"
+        echo "  ✓ devcontainer.json (template + devcontainer.local.json merged)"
+    else
+        [ -f "$backup_file" ] && mv "$backup_file" "$target_file"
+        echo "  ✗ devcontainer.json merge failed, restored backup"
+        return 1
+    fi
+}
+```
+
 ### 5.4: Apply infrastructure components
 
 ```bash
@@ -436,6 +501,7 @@ echo "  ✓ .template-version updated ($DC_COMMIT)"
     ✓ grepai         (bge-m3 config)
     ✓ mcp-template   (mcp.json.tpl)
     ✓ mcp-fragments  (context7, ktn-linter)
+    ✓ features       (devcontainer features, 25 languages)
     ✓ docs           (design patterns KB)
     ✓ templates      (project/docs templates)
     ✓ devcontainer   (feature refs)

--- a/.devcontainer/images/CLAUDE.md
+++ b/.devcontainer/images/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-18T21:18:33Z -->
+<!-- updated: 2026-04-20T09:28:02Z -->
 # DevContainer Images
 
 ## Purpose

--- a/.devcontainer/images/hooks/lifecycle/postStart.sh
+++ b/.devcontainer/images/hooks/lifecycle/postStart.sh
@@ -1642,6 +1642,72 @@ init_vpn() {
     return 0
 }
 
+# Force-sync .devcontainer/features/ from image-embedded copy (always overwrites).
+# Consumer projects get upstream template features at every container start.
+# Auto-skips when running inside the template repo itself (detected via
+# .devcontainer/.template-version matching git HEAD).
+step_sync_features() {
+    local src="/etc/devcontainer-template/features"
+    local dst="${WORKSPACE_FOLDER:-/workspace}/.devcontainer/features"
+    local marker="${WORKSPACE_FOLDER:-/workspace}/.devcontainer/.template-version"
+
+    if [ ! -d "$src" ]; then
+        log_info "No embedded features dir in image, skipping sync"
+        return 0
+    fi
+
+    if [ ! -d "${WORKSPACE_FOLDER:-/workspace}/.devcontainer" ]; then
+        log_warn "No .devcontainer/ in workspace, skipping features sync"
+        return 0
+    fi
+
+    # Self-exclusion: skip if we ARE the template repo (git HEAD matches marker commit).
+    if [ -f "$marker" ] && command -v jq &>/dev/null; then
+        local marker_commit current_commit
+        marker_commit=$(jq -r '.commit // empty' "$marker" 2>/dev/null || true)
+        current_commit=$(git -C "${WORKSPACE_FOLDER:-/workspace}" rev-parse --short HEAD 2>/dev/null || true)
+        if [ -n "$marker_commit" ] && [ -n "$current_commit" ] && \
+           { [[ "$current_commit" == "$marker_commit"* ]] || [[ "$marker_commit" == "$current_commit"* ]]; }; then
+            log_info "Template repo detected (template-version matches HEAD), skipping features sync"
+            return 0
+        fi
+    fi
+
+    # /update harmony: skip sync when consumer's .template-version is newer than
+    # the image's embedded version (consumer ran /update on a fresher template).
+    # Syncing would silently regress /update's work.
+    local image_version="/etc/devcontainer-template/.template-version"
+    if [ -f "$marker" ] && [ -f "$image_version" ] && command -v jq &>/dev/null; then
+        local repo_updated image_updated
+        repo_updated=$(jq -r '.updated // empty' "$marker" 2>/dev/null || true)
+        image_updated=$(jq -r '.updated // empty' "$image_version" 2>/dev/null || true)
+        if [ -n "$repo_updated" ] && [ -n "$image_updated" ] && \
+           [[ "$repo_updated" > "$image_updated" ]]; then
+            log_info "Repo template-version ($repo_updated) newer than image ($image_updated), skipping features sync"
+            return 0
+        fi
+    fi
+
+    log_info "Force-syncing .devcontainer/features/ from template image..."
+    if command -v rsync &>/dev/null; then
+        if rsync -a --delete --checksum "$src/" "$dst/"; then
+            log_success ".devcontainer/features/ synced ($(find "$dst" -type f 2>/dev/null | wc -l) files)"
+        else
+            log_error "rsync failed; features dir may be in inconsistent state"
+            return 1
+        fi
+    else
+        rm -rf "$dst"
+        mkdir -p "$dst"
+        if cp -a "$src/." "$dst/"; then
+            log_success ".devcontainer/features/ synced via cp ($(find "$dst" -type f 2>/dev/null | wc -l) files)"
+        else
+            log_error "cp fallback failed"
+            return 1
+        fi
+    fi
+}
+
 # Clean up legacy workspace hook stubs (replaced by direct /etc/devcontainer-hooks/ calls)
 step_cleanup_legacy_stubs() {
     local dc_dir="${WORKSPACE_FOLDER:-/workspace}/.devcontainer"
@@ -1663,6 +1729,7 @@ step_cleanup_legacy_stubs() {
 # Execution
 # ============================================================================
 
+run_step "Sync features dir"        step_sync_features
 run_step "Cleanup legacy stubs"     step_cleanup_legacy_stubs
 run_step "Restore Claude config"    step_restore_claude_config
 run_step "Init Claude dirs"         step_init_claude_dirs


### PR DESCRIPTION
## Summary

PR #7 migrated the SDK to Bazel 9. Contributors now need two companion tools that the Go feature doesn't install yet:

- **buildifier** — gofmt for `BUILD.bazel` / `WORKSPACE` / `*.bzl` files.
- **buildozer** — programmatic edits on BUILD targets (add attr, rename rule, …).

Both ship as prebuilt linux/{amd64,arm64} binaries from the same `bazelbuild/buildtools` release (v8.5.1 as of 2026-04), so one `get_github_latest_version_or_empty` call feeds both installs. Follows the existing `install_go_tool` pattern with a go-install source fallback when the GitHub API rate-limits the version lookup.

## Test plan

- [x] `curl .../buildifier-linux-arm64 && chmod +x && buildifier --help` → banner printed
- [x] `curl .../buildozer-linux-arm64 && chmod +x && buildozer --help` → banner printed
- [ ] After devcontainer rebuild, `buildifier --version` and `buildozer --version` both succeed
- [ ] Final inventory line in install.sh lists both new tools

## Notes

- This is the SDK-local mirror. An upstream issue will propose the same change in [kodflow/devcontainer-template](https://github.com/kodflow/devcontainer-template) so other consumers benefit without forking.
- No new feature flag — the tools install unconditionally whenever the Go feature is enabled. Buildozer/buildifier are lightweight (<10 MiB each) so opt-out isn't worth the complexity.
