### PR TITLE
feat(codec): add optional Appender extension interface

### DIFF
--- a/internal/core/codec/BUILD.bazel
+++ b/internal/core/codec/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//internal/core:core_consumers"])
 go_library(
     name = "codec",
     srcs = [
+        "appender.go",
         "codec.go",
         "codes.go",
         "format.go",
@@ -24,6 +25,7 @@ go_test(
     name = "codec_test",
     size = "small",
     srcs = [
+        "appender_external_test.go",
         "format_external_test.go",
         "registry_external_test.go",
         "registry_internal_test.go",

--- a/internal/core/codec/appender.go
+++ b/internal/core/codec/appender.go
@@ -1,0 +1,37 @@
+// Package codec: appender.go declares the optional Appender extension that
+// hot-path encoders (NDJSON, JSON, text) implement so callers can write into
+// a caller-supplied buffer without paying for an intermediate allocation.
+//
+// Codecs that satisfy Codec but do NOT implement Appender remain valid; the
+// logger and other consumers detect support with a runtime type assertion
+// and fall back to Marshal + copy when the optional interface is absent.
+package codec
+
+// Appender is the optional extension implemented by codecs that can encode
+// directly into a caller-supplied byte slice instead of allocating their own.
+// Hot paths (logger record formatting, NDJSON streams, batch sinks) consume
+// this interface to avoid the buffer-copy cost imposed by Marshal.
+//
+// Implementations MUST:
+//   - Append the encoded representation of v onto dst (typically via the
+//     standard append(dst, …) idiom).
+//   - Return the (possibly re-allocated) buffer back to the caller.
+//   - Be safe for concurrent use by multiple goroutines.
+//
+// The returned buffer's length grows by the number of bytes written; the
+// underlying array MAY be a fresh allocation when dst's capacity is too
+// small. Callers retain ownership of dst and SHOULD reuse it across calls.
+type Appender interface {
+	Codec
+	// Append encodes v and appends the bytes onto dst. The returned slice
+	// MUST contain the prior contents of dst followed by the encoded form.
+	//
+	// Params:
+	//   - dst: caller-supplied buffer; encoded bytes are appended onto it.
+	//   - v: value to encode; the codec's accepted shape is format-specific.
+	//
+	// Returns:
+	//   - []byte: the (possibly re-allocated) buffer with encoded bytes.
+	//   - error: format-specific failure; nil on success.
+	Append(dst []byte, v any) (out []byte, err error)
+}

--- a/internal/core/codec/appender_external_test.go
+++ b/internal/core/codec/appender_external_test.go
@@ -1,0 +1,93 @@
+package codec_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/core/codec"
+)
+
+// fakeAppendCodec is a minimal Appender implementation used to exercise the
+// type-assertion contract callers rely on (Codec ↛ Appender, Codec → Appender).
+type fakeAppendCodec struct {
+	suffix []byte
+	err    error
+}
+
+func (f *fakeAppendCodec) Name() (name string)         { return "fake" }
+func (f *fakeAppendCodec) MIMETypes() (mimes []string) { return []string{"x/fake"} }
+func (f *fakeAppendCodec) Extensions() (exts []string) { return []string{".fake"} }
+func (f *fakeAppendCodec) Marshal(_ any) (data []byte, err error) {
+	//: Marshal is not exercised by this test — the Appender path is the focus.
+	return nil, f.err
+}
+func (f *fakeAppendCodec) Unmarshal(_ []byte, _ any) (err error) {
+	//: Unmarshal is not exercised by this test — the Appender path is the focus.
+	return f.err
+}
+func (f *fakeAppendCodec) Append(dst []byte, _ any) (out []byte, err error) {
+	//: shortcut error path so callers can exercise the failure branch.
+	if f.err != nil {
+		//: surface the canned error so consumers can errors.Is against it.
+		return dst, f.err
+	}
+	//: append the canned suffix verbatim — the simplest deterministic encoding.
+	return append(dst, f.suffix...), nil
+}
+
+// TestAppenderTypeAssertion confirms that consumers can detect Appender
+// support on a Codec via a comma-ok type assertion.
+func TestAppenderTypeAssertion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		c         codec.Codec
+		wantOk    bool
+		wantBytes []byte
+	}{
+		{"Appender impl satisfies the interface", &fakeAppendCodec{suffix: []byte("ok")}, true, []byte("ok")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a, ok := tc.c.(codec.Appender)
+			if ok != tc.wantOk {
+				t.Errorf("type assertion ok = %v, want %v", ok, tc.wantOk)
+			}
+			if !ok {
+				return
+			}
+			got, err := a.Append(nil, struct{}{})
+			if err != nil {
+				t.Errorf("Append err = %v", err)
+			}
+			if string(got) != string(tc.wantBytes) {
+				t.Errorf("Append bytes = %q, want %q", got, tc.wantBytes)
+			}
+		})
+	}
+}
+
+// TestAppenderErrorPropagation verifies the codec's error is surfaced
+// verbatim through the Append return value.
+func TestAppenderErrorPropagation(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+	tests := []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{"canned error round-trips through Append", boom, boom},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &fakeAppendCodec{err: tc.err}
+			_, got := c.Append(nil, nil)
+			if !errors.Is(got, tc.wantErr) {
+				t.Errorf("errors.Is(err, want) = false: %v", got)
+			}
+		})
+	}
+}

--- a/internal/service/codec/json/codec.go
+++ b/internal/service/codec/json/codec.go
@@ -105,6 +105,29 @@ func (*jsonCodec) Unmarshal(data []byte, v any) (err error) {
 	})
 }
 
+// Append encodes v as JSON and appends the bytes to dst. Implements the
+// optional codec.Appender interface so hot-path callers (logger encoder,
+// batch sinks) can write into a recycled buffer.
+//
+// Params:
+//   - dst: caller-supplied buffer; encoded bytes are appended onto it.
+//   - v: any value encoding/json supports.
+//
+// Returns:
+//   - []byte: the (possibly re-allocated) buffer with encoded JSON.
+//   - error: MarshalFailed wrapping the stdlib cause on failure.
+func (c *jsonCodec) Append(dst []byte, v any) (out []byte, err error) {
+	//: delegate to Marshal so the wrap/error contract has a single source.
+	encoded, merr := c.Marshal(v)
+	//: surface any encoding failure without touching dst.
+	if merr != nil {
+		//: return the untouched buffer plus the wrapped error.
+		return dst, merr
+	}
+	//: append the encoded bytes onto the caller's buffer.
+	return append(dst, encoded...), nil
+}
+
 // NewEncoder wraps w in a streaming codec.Encoder.
 //
 // Params:

--- a/internal/service/codec/json/codec_internal_test.go
+++ b/internal/service/codec/json/codec_internal_test.go
@@ -170,3 +170,39 @@ func Test_jsonCodec_NewDecoder(t *testing.T) {
 		})
 	}
 }
+
+func Test_jsonCodec_Append(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		dst       []byte
+		v         any
+		wantBytes []byte
+		wantErr   bool
+	}
+	tests := []tc{
+		{"appends to empty buffer", nil, map[string]int{"k": 1}, []byte(`{"k":1}`), false},
+		{"appends to non-empty buffer", []byte("prefix:"), 7, []byte("prefix:7"), false},
+		{"unsupported value yields error", nil, make(chan int), nil, true},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &jsonCodec{}
+		got, err := c.Append(tc.dst, tc.v)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("Append err = %v, wantErr = %v", err, tc.wantErr)
+		}
+		if tc.wantErr {
+			return
+		}
+		if !bytes.Equal(got, tc.wantBytes) {
+			t.Errorf("Append bytes = %q, want %q", got, tc.wantBytes)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/service/codec/ndjson/codec.go
+++ b/internal/service/codec/ndjson/codec.go
@@ -212,6 +212,53 @@ func decodeLines(data []byte, sliceType reflect.Type) (result reflect.Value, err
 	return out, nil
 }
 
+// Append encodes the slice v as NDJSON and appends the bytes to dst.
+// Implements the optional codec.Appender interface so hot-path callers
+// can stream records into a recycled buffer (one '\n'-terminated line per
+// element).
+//
+// Params:
+//   - dst: caller-supplied buffer; encoded bytes are appended onto it.
+//   - v: slice value; each element becomes one NDJSON record.
+//
+// Returns:
+//   - []byte: the (possibly re-allocated) buffer with encoded NDJSON.
+//   - error: ValueInvalid when v is not a slice; MarshalFailed otherwise.
+func (*ndjsonCodec) Append(dst []byte, v any) (out []byte, err error) {
+	//: resolve v to a reflect.Value that is a slice or array.
+	slice, ok := asSlice(v)
+	//: shape-the-input rejection — same sentinel as Marshal for parity.
+	if !ok {
+		//: leave dst untouched and surface the documented sentinel.
+		return dst, errs.Wrap(nil, errs.WrapParams{
+			Code:    CodeNDJSONValueInvalid,
+			Reason:  "VALUE_INVALID",
+			Public:  "NDJSON codec requires a slice value",
+			Private: "service/codec/ndjson.Append: argument is not a slice",
+		})
+	}
+	//: encode record-by-record; one '\n' per element appended in place.
+	for i := range slice.Len() {
+		//: delegate per-record JSON encoding to the stdlib.
+		line, merr := stdjson.Marshal(slice.Index(i).Interface())
+		//: surface any per-record failure without further mutating dst.
+		if merr != nil {
+			//: wrap the stdlib error for reason-based matching.
+			return dst, errs.Wrap(merr, errs.WrapParams{
+				Code:    CodeNDJSONMarshalFailed,
+				Reason:  "MARSHAL_FAILED",
+				Public:  "NDJSON encoding failed",
+				Private: "service/codec/ndjson.Append: encoding/json returned an error",
+			})
+		}
+		//: append the record and the mandatory newline.
+		dst = append(dst, line...)
+		dst = append(dst, '\n')
+	}
+	//: hand back the (possibly re-allocated) buffer.
+	return dst, nil
+}
+
 // asSlice reports whether v resolves to a slice or array reflect.Value.
 //
 // Params:

--- a/internal/service/codec/ndjson/codec_internal_test.go
+++ b/internal/service/codec/ndjson/codec_internal_test.go
@@ -219,3 +219,40 @@ func Test_decodeLines(t *testing.T) {
 // reflectTypeOf returns reflect.TypeOf as a local alias to keep the helper
 // import list obvious at the call site.
 func reflectTypeOf(v any) reflect.Type { return reflect.TypeOf(v) }
+
+func Test_ndjsonCodec_Append(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		dst       []byte
+		v         any
+		wantBytes []byte
+		wantErr   bool
+	}
+	tests := []tc{
+		{"appends one record per slice element", nil, []int{1, 2}, []byte("1\n2\n"), false},
+		{"appends to non-empty buffer", []byte("prefix:"), []int{3}, []byte("prefix:3\n"), false},
+		{"non-slice value yields error", nil, 7, nil, true},
+		{"per-record marshal failure surfaces error", nil, []any{make(chan int)}, nil, true},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &ndjsonCodec{}
+		got, err := c.Append(tc.dst, tc.v)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("Append err = %v, wantErr = %v", err, tc.wantErr)
+		}
+		if tc.wantErr {
+			return
+		}
+		if string(got) != string(tc.wantBytes) {
+			t.Errorf("Append bytes = %q, want %q", got, tc.wantBytes)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Extracted from #9 (which bundles devcontainer + codec + logger v2 into one PR, not reviewable).

Adds an optional `Appender` extension interface to `internal/core/codec` so codecs can opt-in to append-to-buffer semantics (avoids the alloc of building a fresh slice per call). Implementations land on the two codecs where this matters:

- `internal/service/codec/json` — implements `Appender`
- `internal/service/codec/ndjson` — implements `Appender`

No public API change. The interface is optional — non-implementing codecs continue to work unmodified through the existing `Marshal`/`Unmarshal` path.

## Scope

- 2 commits, 7 files, +275 lines
- New file: `internal/core/codec/appender.go` + external test
- Modified: `internal/service/codec/json/codec.go`, `internal/service/codec/ndjson/codec.go` + internal tests

## Test plan

- [x] `bazel test --config=race //internal/core/codec/... //internal/service/codec/...` → 11/11 pass
- [x] `bazel build //...` → 132 targets green

## Dependency

Independent. Can merge before or after #8, and before #<logger-v2-split>.