### PR TITLE
refactor: drive ktn-linter phases 1-8 to zero issues (post-codec)

### DIFF
--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-05-12T09:29:19Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # DevContainer Configuration
 
 ## Purpose

--- a/.devcontainer/features/CLAUDE.md
+++ b/.devcontainer/features/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-21T15:27:23Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # DevContainer Features
 
 ## Purpose

--- a/.devcontainer/features/languages/CLAUDE.md
+++ b/.devcontainer/features/languages/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-04-10T12:00:00Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # Language Features
 
 ## Purpose

--- a/.devcontainer/features/languages/go/install.sh
+++ b/.devcontainer/features/languages/go/install.sh
@@ -19,6 +19,7 @@ trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
 FEATURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../shared/feature-utils.sh
+# shellcheck disable=SC1091  # Sourced at runtime; static path varies by install layout.
 source "${FEATURE_DIR}/feature-utils.sh" 2>/dev/null || \
 source "${FEATURE_DIR}/../shared/feature-utils.sh" 2>/dev/null || {
     RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
@@ -225,11 +226,52 @@ spawn_tool() {
 }
 
 # Fetch latest versions (non-fatal: empty string on rate-limit/timeout, retries 3x)
+# Resolve the most recent release tag whose assets contain a name matching
+# `pattern`. `releases/latest` returns the latest tag regardless of whether
+# its assets shipped — a broken upstream release pipeline can stamp a tag
+# with zero binary assets (kodflow/ktn-linter v1.32+) and make every
+# `releases/latest/download/...` URL 404 forever. Walking `releases?per_page=20`
+# newest-first and skipping empty-asset releases makes the install path
+# self-healing against that class of upstream regression.
+get_github_latest_release_with_asset() {
+    local repo="$1" pattern="$2" auth_args=()
+    [[ -n "${GITHUB_TOKEN:-}" ]] && auth_args=(-H "Authorization: token ${GITHUB_TOKEN}")
+    local attempt payload tag
+    for attempt in 1 2 3; do
+        payload=$(curl -fsS --connect-timeout 5 --max-time 10 \
+            "${auth_args[@]}" \
+            "https://api.github.com/repos/${repo}/releases?per_page=20" 2>/dev/null || true)
+        if [[ -n "$payload" ]]; then
+            tag=$(printf '%s' "$payload" | awk -v pat="$pattern" '
+                /"tag_name":/ {
+                    if (match($0, /"tag_name": *"v?[^"]+"/)) {
+                        t = substr($0, RSTART, RLENGTH)
+                        sub(/"tag_name": *"v?/, "", t); sub(/".*/, "", t)
+                        cur = t; have_asset = 0
+                    }
+                }
+                /"name":/ && index($0, pat) > 0 && cur != "" && !have_asset {
+                    have_asset = 1
+                    print cur
+                    exit
+                }
+            ' 2>/dev/null || true)
+            [[ -n "$tag" ]] && { echo "$tag"; return 0; }
+        fi
+        sleep $((attempt * 2))
+    done
+    return 1
+}
+
 step fetch-tool-versions begin
 GOLANGCI_VERSION=$(get_github_latest_version_or_empty "golangci/golangci-lint")
 GOSEC_VERSION=$(get_github_latest_version_or_empty "securego/gosec")
 GOFUMPT_VERSION=$(get_github_latest_version_or_empty "mvdan/gofumpt")
 GOTESTSUM_VERSION=$(get_github_latest_version_or_empty "gotestyourself/gotestsum")
+# ktn-linter publishes asset name `ktn-linter_linux_<arch>.tar.gz`; pinned to
+# the most recent release that actually ships that asset (skips broken tags).
+KTN_LINTER_VERSION=$(get_github_latest_release_with_asset \
+    "kodflow/ktn-linter" "ktn-linter_linux_${GO_ARCH}.tar.gz" 2>/dev/null || echo "")
 # buildifier + buildozer ship from the same bazelbuild/buildtools release.
 BUILDTOOLS_VERSION=$(get_github_latest_version_or_empty "bazelbuild/buildtools")
 
@@ -312,10 +354,27 @@ set +e
 TOOL_PIDS[goimports]=$!
 set -e
 
-spawn_tool "ktn-linter" \
-    "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
-    "" \
-    "binary"
+# ktn-linter ships its binary as `ktn-linter_linux_<arch>.tar.gz`, not as a bare
+# binary. The previous URL (`releases/latest/download/ktn-linter-linux-<arch>`)
+# 404'd against every release because the asset name uses underscores + tarball
+# packaging, AND `releases/latest` currently resolves to v1.33.0 / v1.32.x —
+# upstream tags shipped with zero assets. KTN_LINTER_VERSION is resolved against
+# `releases?per_page=20` to find the most recent tag that actually ships the
+# asset, so this self-heals once upstream republishes.
+if [[ -n "$KTN_LINTER_VERSION" ]]; then
+    spawn_tool "ktn-linter" \
+        "https://github.com/kodflow/ktn-linter/releases/download/v${KTN_LINTER_VERSION}/ktn-linter_linux_${GO_ARCH}.tar.gz" \
+        "" \
+        "tar.gz"
+else
+    set +e
+    ( trap - ERR; \
+      echo -e "${RED}ktn-linter: no recent release ships ktn-linter_linux_${GO_ARCH}.tar.gz${NC}" >&2; \
+      echo -e "${RED}  → upstream pipeline likely broken (kodflow/ktn-linter). Skipping.${NC}" >&2; \
+      exit 1 ) &
+    TOOL_PIDS[ktn-linter]=$!
+    set -e
+fi
 
 # Bazel tooling — same release ships both binaries.
 if [[ -n "$BUILDTOOLS_VERSION" ]]; then

--- a/.devcontainer/images/CLAUDE.md
+++ b/.devcontainer/images/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-05-12T09:29:19Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # DevContainer Images
 
 ## Purpose

--- a/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
+++ b/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
@@ -72,6 +72,7 @@ sync_rust() {
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path 2>/dev/null
     fi
 
+    # shellcheck disable=SC1091  # cargo env is created at runtime by rustup; existence guarded above.
     [ -f "${CARGO_HOME}/env" ] && source "${CARGO_HOME}/env"
     rustup toolchain install stable --profile minimal 2>/dev/null
     rustup default stable 2>/dev/null
@@ -201,51 +202,90 @@ sync_go() {
     # short-circuit and skip Go sync entirely.
     local failed=0
     local tool installed upstream major_pin
-    # Atomic binary install for ktn-linter (release asset, not a Go module).
-    # Writes to a sibling .download path then renames — protects against a
-    # half-fetched binary if curl is interrupted mid-stream. Returns non-zero
-    # on any failure so the caller can flag the sync as incomplete.
+
+    # Resolve the most recent release tag whose assets contain a name matching
+    # `pattern`. `releases/latest` returns the latest tag regardless of whether
+    # any binary asset shipped — upstream pipelines can stamp a tag with zero
+    # assets (kodflow/ktn-linter v1.32+) and make `releases/latest/download/...`
+    # 404 forever. Walking `releases?per_page=20` newest-first and skipping
+    # empty-asset releases makes this path self-healing without manual pinning.
+    latest_release_with_asset() {
+        local repo="$1" pattern="$2" auth=()
+        [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: token ${GITHUB_TOKEN}")
+        local payload tag
+        payload=$(curl -fsS --connect-timeout 3 --max-time 8 \
+                       "${auth[@]}" \
+                       "https://api.github.com/repos/${repo}/releases?per_page=20" 2>/dev/null || true)
+        [ -z "$payload" ] && return 1
+        tag=$(printf '%s' "$payload" | awk -v pat="$pattern" '
+            /"tag_name":/ {
+                if (match($0, /"tag_name": *"v?[^"]+"/)) {
+                    t = substr($0, RSTART, RLENGTH)
+                    sub(/"tag_name": *"v?/, "", t); sub(/".*/, "", t)
+                    cur = t; have_asset = 0
+                }
+            }
+            /"name":/ && index($0, pat) > 0 && cur != "" && !have_asset {
+                have_asset = 1
+                print cur
+                exit
+            }
+        ' 2>/dev/null || true)
+        [ -n "$tag" ] && { echo "$tag"; return 0; }
+        return 1
+    }
+
+    # Atomic install for ktn-linter (tar.gz release asset).
+    # Writes to a sibling .download path then atomically renames the extracted
+    # binary — protects against a half-fetched archive if curl is interrupted
+    # mid-stream. Returns non-zero on any failure so the caller can flag the
+    # sync as incomplete and let onCreate retry next start.
     install_ktn_linter() {
+        local version="$1"
         local target="${GOPATH}/bin/ktn-linter"
-        local tmp="${target}.download"
-        if curl -fsSL --connect-timeout 10 --max-time 60 \
-                "https://github.com/kodflow/ktn-linter/releases/latest/download/ktn-linter-linux-${GO_ARCH}" \
-                -o "$tmp" 2>/dev/null \
-            && chmod +x "$tmp" \
-            && mv -f "$tmp" "$target"; then
+        local tmp_tar="${target}.download.tar.gz"
+        local tmp_bin="${target}.download"
+        local url="https://github.com/kodflow/ktn-linter/releases/download/v${version}/ktn-linter_linux_${GO_ARCH}.tar.gz"
+
+        if curl -fsSL --connect-timeout 10 --max-time 60 "$url" -o "$tmp_tar" 2>/dev/null \
+            && tar -xzf "$tmp_tar" -C "$(dirname "$tmp_bin")" ktn-linter 2>/dev/null \
+            && mv -f "$(dirname "$tmp_bin")/ktn-linter" "$tmp_bin" 2>/dev/null \
+            && chmod +x "$tmp_bin" \
+            && mv -f "$tmp_bin" "$target"; then
+            rm -f "$tmp_tar"
             return 0
         fi
-        rm -f "$tmp"
+        rm -f "$tmp_tar" "$tmp_bin"
         return 1
     }
 
     for tool in golangci-lint gosec gofumpt gotestsum goimports ktn-linter; do
         case "$tool" in
             ktn-linter)
-                # ktn-linter is published as a release binary on GitHub, NOT as a Go
+                # ktn-linter is published as a release tarball on GitHub, NOT as a Go
                 # module — `go install ktn-linter@latest` silently fails (not a valid
                 # module path). Must download the release asset directly, and do it
                 # HERE at runtime so the write lands in the already-mounted
                 # package-cache volume (build-time writes under $GOPATH/bin are
                 # masked by the volume at container start).
                 #
-                # Auto-refresh: probe upstream tag, reinstall on drift. Without
-                # this guard, an old ktn-linter cached in the volume survived
-                # every container rebuild — `command -v` short-circuited the
-                # install path even when a newer release was available. Mirrors
-                # the GO_TOOL_REPOS pattern (#330) but with direct asset download.
+                # Asset resolution: latest_release_with_asset() walks recent
+                # releases instead of trusting `releases/latest`, because the
+                # latest tag can ship with zero binary assets when upstream CI
+                # breaks (v1.32+ on kodflow/ktn-linter, May 2026). Without this
+                # `install_ktn_linter` would 404 forever and leave the stale
+                # volume-cached binary in place every rebuild.
                 installed=$(installed_tool_version ktn-linter)
-                upstream=$(upstream_latest_version "kodflow/ktn-linter")
+                upstream=$(latest_release_with_asset \
+                    "kodflow/ktn-linter" "ktn-linter_linux_${GO_ARCH}.tar.gz")
                 if [ -z "$upstream" ]; then
-                    # Network/rate-limit failure: keep an existing binary, only
-                    # install when truly missing (best-effort cold-start path).
                     if [ -z "$installed" ]; then
-                        echo "    ktn-linter: upstream probe failed and tool missing — installing latest (best-effort)..."
-                        install_ktn_linter || failed=1
+                        echo "    ktn-linter: no recent release ships ktn-linter_linux_${GO_ARCH}.tar.gz and tool missing — upstream pipeline likely broken"
+                        failed=1
                     fi
                 elif [ "$installed" != "$upstream" ]; then
                     echo "    ktn-linter: ${installed:-none} → ${upstream}"
-                    install_ktn_linter || failed=1
+                    install_ktn_linter "$upstream" || failed=1
                 fi
                 ;;
             *)

--- a/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
+++ b/.devcontainer/images/hooks/lifecycle/sync-toolchains.sh
@@ -236,26 +236,38 @@ sync_go() {
     }
 
     # Atomic install for ktn-linter (tar.gz release asset).
-    # Writes to a sibling .download path then atomically renames the extracted
-    # binary — protects against a half-fetched archive if curl is interrupted
-    # mid-stream. Returns non-zero on any failure so the caller can flag the
+    # Extracts into a unique temp directory so the existing working binary at
+    # $target is NEVER touched until the final rename — a mid-stream tar
+    # failure can no longer overwrite or remove the previous good binary.
+    # Supports both root-level and nested tar layouts (mirrors the build-time
+    # spawn_tool path in install.sh) so runtime and build-time behaviour stay
+    # consistent. Returns non-zero on any failure so the caller can flag the
     # sync as incomplete and let onCreate retry next start.
     install_ktn_linter() {
         local version="$1"
         local target="${GOPATH}/bin/ktn-linter"
         local tmp_tar="${target}.download.tar.gz"
         local tmp_bin="${target}.download"
+        local tmp_dir
+        tmp_dir=$(mktemp -d 2>/dev/null) || return 1
         local url="https://github.com/kodflow/ktn-linter/releases/download/v${version}/ktn-linter_linux_${GO_ARCH}.tar.gz"
 
+        # ktn-linter ships its archive with the binary at root in current
+        # releases, but older releases used nested layouts. Try the root layout
+        # first (cheap), fall back to the wildcard strip used by install.sh.
         if curl -fsSL --connect-timeout 10 --max-time 60 "$url" -o "$tmp_tar" 2>/dev/null \
-            && tar -xzf "$tmp_tar" -C "$(dirname "$tmp_bin")" ktn-linter 2>/dev/null \
-            && mv -f "$(dirname "$tmp_bin")/ktn-linter" "$tmp_bin" 2>/dev/null \
+            && { tar -xzf "$tmp_tar" -C "$tmp_dir" ktn-linter 2>/dev/null \
+                 || tar -xzf "$tmp_tar" --wildcards --strip-components=1 -C "$tmp_dir" '*/ktn-linter' 2>/dev/null; } \
+            && [ -f "$tmp_dir/ktn-linter" ] && [ ! -L "$tmp_dir/ktn-linter" ] \
+            && mv -f "$tmp_dir/ktn-linter" "$tmp_bin" 2>/dev/null \
             && chmod +x "$tmp_bin" \
             && mv -f "$tmp_bin" "$target"; then
             rm -f "$tmp_tar"
+            rm -rf "$tmp_dir"
             return 0
         fi
         rm -f "$tmp_tar" "$tmp_bin"
+        rm -rf "$tmp_dir"
         return 1
     }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-05-18T14:30:00Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # kitsunium/sdk
 
 ## Purpose

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-05-18T14:30:00Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # internal/
 
 ## Purpose

--- a/internal/service/CLAUDE.md
+++ b/internal/service/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-05-18T14:30:00Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # internal/service/
 
 ## Purpose

--- a/internal/service/codec/CLAUDE.md
+++ b/internal/service/codec/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-05-18T14:30:00Z -->
+<!-- updated: 2026-05-21T21:27:56Z -->
 # internal/service/codec/
 
 ## Purpose

--- a/internal/service/codec/flatbuffers/CLAUDE.md
+++ b/internal/service/codec/flatbuffers/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- updated: 2026-05-21T21:27:56Z -->
 # internal/service/codec/flatbuffers/
 
 ## Purpose
@@ -27,6 +28,11 @@ No third-party dependency — pure stdlib.
 |---|---|---|
 | `BytesProvider` (`Bytes() []byte`)     | Marshal / Append | lets generated FlatBuffer types expose their underlying buffer without exporting it as `[]byte` |
 | `BytesAcceptor` (`SetBytes([]byte)`)   | Unmarshal        | lets generated FlatBuffer types accept the buffer with their own ownership semantics |
+
+The `Provider` / `Acceptor` suffixes are registered as legitimate
+adapter-role vocabulary in `/workspace/.ktn-linter.yaml`
+(per kodflow/ktn-linter#337), so `KTN-INTERFACE-ERNAME` does not fire
+on these names.
 
 `Marshal` accepts `[]byte` directly OR any `BytesProvider`. `Unmarshal`
 accepts `*[]byte` directly (zero-copy reference; caller takes shared

--- a/internal/service/codec/flatbuffers/codec.go
+++ b/internal/service/codec/flatbuffers/codec.go
@@ -150,9 +150,9 @@ func resolveSourceBytes(v any) (src []byte, err error) {
 		return b, nil
 	}
 	//: structured-source path: caller implements BytesProvider.
-	if p, ok := v.(BytesProvider); ok {
+	if prov, ok := v.(BytesProvider); ok {
 		//: extract the payload; the implementation owns lifetime semantics.
-		return p.Bytes(), nil
+		return prov.Bytes(), nil
 	}
 	//: anything else is a programming error for this codec.
 	return nil, errs.Wrap(nil, errs.WrapParams{

--- a/internal/service/codec/flatbuffers/codec_internal_test.go
+++ b/internal/service/codec/flatbuffers/codec_internal_test.go
@@ -1,6 +1,7 @@
 package flatbuffers
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/kitsunium/sdk/internal/kernel/errs"
@@ -216,11 +217,19 @@ func Test_flatbuffersCodec_Unmarshal(t *testing.T) {
 		//: happy path — verify the target actually received the buffer.
 		switch dst := target.(type) {
 		case *[]byte:
-			if string(*dst) != string(tc.data) {
+			//: full byte equality, not just length.
+			if !bytes.Equal(*dst, tc.data) {
 				t.Errorf("%s: *[]byte target got %v want %v", tc.name, *dst, tc.data)
 			}
+			//: zero-copy contract: the published slice MUST alias tc.data's
+			//: backing array (Unmarshal documents zero-copy reference for
+			//: *[]byte targets). Compare the addresses of the first element.
+			if len(tc.data) > 0 && len(*dst) > 0 && &(*dst)[0] != &tc.data[0] {
+				t.Errorf("%s: *[]byte fast-path is not zero-copy (got new backing array)", tc.name)
+			}
 		case *fakeAcceptor:
-			if string(dst.got) != string(tc.data) {
+			//: full byte equality of the slice handed to the Acceptor.
+			if !bytes.Equal(dst.got, tc.data) {
 				t.Errorf("%s: fakeAcceptor.got=%v want %v", tc.name, dst.got, tc.data)
 			}
 		default:
@@ -265,6 +274,17 @@ func Test_flatbuffersCodec_Append(t *testing.T) {
 			if len(got) != tc.wantLen {
 				t.Errorf("%s: len(out)=%d want %d", tc.name, len(got), tc.wantLen)
 			}
+			//: happy path — verify the appended suffix matches the resolved
+			//: source bytes, not just total length (catches byte-corruption
+			//: regressions with unchanged length).
+			src, srcErr := resolveSourceBytes(tc.in)
+			if srcErr != nil {
+				t.Errorf("%s: resolveSourceBytes unexpectedly failed: %v", tc.name, srcErr)
+				return
+			}
+			if !bytes.Equal(got[len(tc.dst):], src) {
+				t.Errorf("%s: appended payload mismatch: got=%v want=%v", tc.name, got[len(tc.dst):], src)
+			}
 			return
 		}
 		if !errs.HasReason(err, tc.wantErr) {
@@ -273,6 +293,11 @@ func Test_flatbuffersCodec_Append(t *testing.T) {
 		//: error-path rollback: dst length must equal the input dst length.
 		if len(got) != tc.wantLen {
 			t.Errorf("%s: error-path len(out)=%d want %d", tc.name, len(got), tc.wantLen)
+		}
+		//: error-path content rollback: dst MUST be byte-identical to the
+		//: input dst (catches in-place mutations that preserve length).
+		if !bytes.Equal(got, tc.dst) {
+			t.Errorf("%s: error-path mutated dst: got=%v want=%v", tc.name, got, tc.dst)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/flatbuffers/codec_internal_test.go
+++ b/internal/service/codec/flatbuffers/codec_internal_test.go
@@ -21,6 +21,21 @@ func (f *fakeProvider) Bytes() []byte {
 	return f.payload
 }
 
+// fakeAcceptor is the minimal BytesAcceptor used to exercise the
+// structured-target branch of Unmarshal.
+type fakeAcceptor struct {
+	got []byte
+}
+
+// compile-time check that fakeAcceptor satisfies BytesAcceptor.
+var _ BytesAcceptor = (*fakeAcceptor)(nil)
+
+// SetBytes captures the buffer handed in by the codec.
+func (f *fakeAcceptor) SetBytes(data []byte) {
+	//: store the slice verbatim; the test inspects this field afterwards.
+	f.got = data
+}
+
 // Test_flatbuffersCodec_Name covers the canonical identifier returned by the codec.
 func Test_flatbuffersCodec_Name(t *testing.T) {
 	t.Parallel()
@@ -155,6 +170,109 @@ func Test_resolveSourceBytes(t *testing.T) {
 		}
 		if tc.wantErr == "" && string(got) != string(tc.want) {
 			t.Errorf("%s: bytes=%v want %v", tc.name, got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// Test_flatbuffersCodec_Unmarshal exercises every branch of the internal
+// Unmarshal method: truncated buffer, *[]byte fast-path, SetBytesser sink,
+// and unsupported target rejection.
+func Test_flatbuffersCodec_Unmarshal(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		data    []byte
+		target  func() any
+		wantErr string
+	}
+	canned := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00}
+	tests := []tc{
+		{"truncated buffer surfaces FLATBUFFERS_TRUNCATED", []byte{1, 2}, func() any { var b []byte; return &b }, "FLATBUFFERS_TRUNCATED"},
+		{"*[]byte fast-path zero-copy", canned, func() any { var b []byte; return &b }, ""},
+		{"BytesAcceptor sink receives payload", canned, func() any { return &fakeAcceptor{} }, ""},
+		{"unsupported target surfaces FLATBUFFERS_BAD_TARGET", canned, func() any { var s string; return &s }, "FLATBUFFERS_BAD_TARGET"},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &flatbuffersCodec{}
+		target := tc.target()
+		err := c.Unmarshal(tc.data, target)
+		if tc.wantErr == "" && err != nil {
+			t.Errorf("%s: Unmarshal err=%v", tc.name, err)
+			return
+		}
+		if tc.wantErr != "" {
+			if !errs.HasReason(err, tc.wantErr) {
+				t.Errorf("%s: expected %s, got %v", tc.name, tc.wantErr, err)
+			}
+			return
+		}
+		//: happy path — verify the target actually received the buffer.
+		switch dst := target.(type) {
+		case *[]byte:
+			if string(*dst) != string(tc.data) {
+				t.Errorf("%s: *[]byte target got %v want %v", tc.name, *dst, tc.data)
+			}
+		case *fakeAcceptor:
+			if string(dst.got) != string(tc.data) {
+				t.Errorf("%s: fakeAcceptor.got=%v want %v", tc.name, dst.got, tc.data)
+			}
+		default:
+			t.Errorf("%s: unexpected target shape %T", tc.name, target)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// Test_flatbuffersCodec_Append exercises every branch of the internal
+// Append method: Marshal-failure rollback (dst untouched), []byte happy
+// path, and Bytesser happy path.
+func Test_flatbuffersCodec_Append(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		dst     []byte
+		in      any
+		wantLen int
+		wantErr string
+	}
+	canned := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	tests := []tc{
+		{"appends []byte onto empty dst", nil, canned, len(canned), ""},
+		{"appends BytesProvider onto prefilled dst", []byte{0xAA}, &fakeProvider{payload: canned}, 1 + len(canned), ""},
+		{"truncated source surfaces FLATBUFFERS_TRUNCATED and keeps dst", []byte{0xAA}, []byte{1, 2}, 1, "FLATBUFFERS_TRUNCATED"},
+		{"unsupported type surfaces FLATBUFFERS_BAD_TYPE and keeps dst", []byte{0xAA, 0xBB}, "nope", 2, "FLATBUFFERS_BAD_TYPE"},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &flatbuffersCodec{}
+		got, err := c.Append(tc.dst, tc.in)
+		if tc.wantErr == "" {
+			if err != nil {
+				t.Errorf("%s: Append err=%v", tc.name, err)
+			}
+			if len(got) != tc.wantLen {
+				t.Errorf("%s: len(out)=%d want %d", tc.name, len(got), tc.wantLen)
+			}
+			return
+		}
+		if !errs.HasReason(err, tc.wantErr) {
+			t.Errorf("%s: expected %s, got %v", tc.name, tc.wantErr, err)
+		}
+		//: error-path rollback: dst length must equal the input dst length.
+		if len(got) != tc.wantLen {
+			t.Errorf("%s: error-path len(out)=%d want %d", tc.name, len(got), tc.wantLen)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/flatbuffers/types.go
+++ b/internal/service/codec/flatbuffers/types.go
@@ -7,6 +7,10 @@ package flatbuffers
 // satisfy to hand the codec its already-encoded FlatBuffer payload. The
 // returned slice MUST remain valid for the lifetime of the codec call;
 // the codec performs no copy and treats the buffer as read-only.
+//
+// `Provider`/`Acceptor` suffixes are registered as legitimate adapter-role
+// vocabulary in `/workspace/.ktn-linter.yaml` (per kodflow/ktn-linter#337),
+// so `KTN-INTERFACE-ERNAME` does not fire here.
 type BytesProvider interface {
 	Bytes() []byte
 }


### PR DESCRIPTION
## Summary

- Resolve the 61 ktn-linter issues re-introduced by the codec migration (#27): 56× phase-3 ANYUSE, 3× phase-6, 2× phase-8.
- **Zero changes to the codec public API** — ADR 0003 (universal `Marshal/Unmarshal(v any)`) is preserved. P3 ANYUSE handled by the YAML-level `rules.exclude` + `vocabulary.adapter_role_suffixes` block already shipped in `.ktn-linter.yaml`; the daemon (v1.31.0) pre-dated the schema and wasn't honoring them. Upgrade to v1.33.0 makes them effective.
- P6: `BytesProvider`/`BytesAcceptor` preserved (vocab exempts `Provider`/`Acceptor` per kodflow/ktn-linter#337); `p` → `prov` for MINLEN.
- P8: add `Test_flatbuffersCodec_Unmarshal` + `_Append` (table-driven; covers truncated, type-mismatch, `*[]byte` fast-path, BytesAcceptor sink, Appender rollback) — genuine test gap from #27.
- Devcontainer install scripts self-heal against upstream ktn-linter release tags shipping with zero binary assets (walk `releases?per_page=20` newest-first instead of trusting `releases/latest`).
- `mcp.json` daemon args `["serve","--phases=all"]` so phase 8 is in the active set (default is 1-7).

## Test plan

- [ ] `ktn-linter lint --phases=all ./...` reports `No issues found! Code is compliant.` under v1.33.0
- [ ] `bazel build //...` green
- [ ] `bazel test --config=race //...` green (34/34 including the new `Test_flatbuffersCodec_Unmarshal` / `_Append`)
- [ ] `bazel run //:gazelle` is a no-op
- [ ] `make sdk-errs-audit` green
- [ ] After session restart (or `ktn-linter mcp serve` respawn), `mcp__ktn-linter__status` reports `total_issues == 0` and `active_phases ⊇ {1..8}`
- [ ] Fresh devcontainer builds successfully install ktn-linter via the asset-walking path (skips releases with empty assets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development container configurations with improved tool installation and syncing reliability.

* **Tests**
  * Added comprehensive unit tests for codec serialization operations to enhance code coverage.

* **Documentation**
  * Clarified adapter interface documentation and naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->