### PR TITLE
fix(docs): base-path the portal for GitHub Pages + a11y/SEO

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -10,7 +10,8 @@ CI/CD automation. The SDK lanes are `bazel-ci.yml` (gate) and `sdk-release.yml` 
 | File | Trigger | Description |
 |---|---|---|
 | `bazel-ci.yml` | push to `main`, PRs | Primary SDK CI — drift check + build + test + coverage via Bazel 9 |
-| `sdk-release.yml` | `workflow_run` after `SDK CI (Bazel)` success on `main`, plus manual `workflow_dispatch` | Impact-driven patch tags `pkg/<major>/vX.Y.Z` (see ADR 0007). Reads majors from `scripts/release/compute-bumps.sh` and pushes via `scripts/release/cut-tags.sh`. |
+| `sdk-release.yml` | `workflow_run` after `SDK CI (Bazel)` success on `main`, plus manual `workflow_dispatch` | Impact-driven patch tags `pkg/<major>/vX.Y.Z` (see ADR 0007). Reads majors from `scripts/release/compute-bumps.sh` and pushes via `scripts/release/cut-tags.sh`. First release is held unless dispatched manually (`--allow-bootstrap`, ADR 0009). |
+| `docs-deploy.yml` | `workflow_run` after `SDK Release`, push to `main` on docs paths, manual `workflow_dispatch` | Build + deploy the versioned docs portal (`docs/site`) to GitHub Pages. Separate from release (deploy is a consequence, not a release step). |
 | `docker-images.yml` | weekly + push to `.devcontainer/images/**` | Template-inherited; two-tier base+main image build |
 | `publish-features.yml` | push to `.devcontainer/features/**` | Template-inherited; publishes OCI feature artifacts |
 | `release.yml` | push to main on `.devcontainer/**` | Template-inherited; path-gated to `.devcontainer/**` and SDK-unaware — DO NOT edit for SDK reasons |

--- a/docs/site/CLAUDE.md
+++ b/docs/site/CLAUDE.md
@@ -1,0 +1,62 @@
+# docs/site/
+
+## Purpose
+
+The kitsunium/sdk documentation portal — an Astro static site published to
+GitHub Pages. Content is **generated, not hand-authored**: the prebuild step
+materialises every page from the real source repo (package READMEs, ADRs,
+CLAUDE.md sections, the root README) and from `git log`, so the site can never
+drift from the code.
+
+## Build pipeline
+
+`npm run build` → `prebuild` (sync) then `astro build` + `pagefind`:
+
+| Step | Script | Emits |
+|---|---|---|
+| `prebuild` | `scripts/sync-versions.mjs` | `src/content/docs/<release>/<major>/**` (gitignored), `src/data/versions.json`, `src/data/build-info.json`, the `whats-new-*.json` banner |
+| | `scripts/gen-symbols.mjs` → `tools/genindex` | `public/_search/symbols-<major>.json` (⌘K search index) |
+| `build` | `astro build` + `pagefind` | `dist/` + `dist/_pagefind/` |
+| `test` | `node --test scripts/**/*.test.mjs` | versioning-logic unit tests |
+
+Run `make docs` / `make serve` from the repo root (they call the above).
+
+## Deployment + base path
+
+Deployed by `.github/workflows/docs-deploy.yml` to GitHub Pages. It is a
+**project page** served under `/<repo>/` (e.g. `/sdk/`), so:
+
+- `astro.config.mjs` sets `site` = the org origin and `base` = `/<repo>` (both
+  derived from `build-info.repoUrl`; override with `DOCS_SITE_URL` / `DOCS_BASE`
+  for a custom domain).
+- Astro auto-prefixes assets it controls, but **hand-written absolute URLs do
+  not get the base** — prefix them with the helper in `scripts/lib/base.mjs`
+  (`DEPLOY_BASE` / `withBase`). `Default.astro` strips the base from
+  `currentPath` so the `/<release>/<major>/` parsing in the nav components works
+  unchanged; canonical/OG URLs use the full (base-included) path.
+
+A clean way to catch a base regression: build, then crawl `dist/` resolving
+every link under `/<repo>/` — any link outside it is a missing-base bug.
+
+## Versioning (ADR 0007)
+
+The version dropdown is driven by `versions.json`, built from
+`git tag -l 'pkg/v*/v*'`. Each tagged release is snapshotted via
+`git worktree`. `scripts/lib/tag-format.mjs` is the JS mirror of
+`scripts/release/lib/tag-format.sh` (same TAG_REGEX — edit together, ADR 0007
+§1). Tag-format + version-defaulting logic is unit-tested (`npm test`).
+
+## Conventions
+
+- Never hand-edit `src/content/docs/**` — it is regenerated each build. Edit the
+  upstream source (package doc comments, ADRs, README) instead.
+- Hand-written absolute internal URLs go through `withBase()`.
+- Generated markdown uses relative links (`./codec/`) — base-agnostic, no help
+  needed.
+
+## Do NOT
+
+- Commit `dist/`, `src/content/docs/local/**`, `versions.json`, or
+  `build-info.json` expecting them to be authoritative — they are build outputs.
+- Add a hand-written `href="/x"` without `withBase("/x")` — it 404s under the
+  project-page base.

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -113,13 +113,30 @@ function deriveSiteUrl(repoUrl) {
   if (process.env.DOCS_SITE_URL) return process.env.DOCS_SITE_URL;
   if (!repoUrl) return "https://example.invalid";
   const gh = repoUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
-  if (gh) return `https://${gh[1]}.github.io/${gh[2]}`;
+  //: ORIGIN only — the repo path is carried by `base` (a GitHub project page
+  //: serves under /<repo>/). site + base then compose correctly for routes,
+  //: assets, canonical, and sitemap.
+  if (gh) return `https://${gh[1]}.github.io`;
   return repoUrl;
 }
+//: Base path. A GitHub project page serves at https://<org>.github.io/<repo>/,
+//: so every absolute asset/link must be prefixed with /<repo> or it 404s
+//: (ADR 0009 §accessible). A custom domain (DOCS_SITE_URL) or non-GitHub
+//: remote serves at root. Override with DOCS_BASE if needed.
+function deriveBase(repoUrl) {
+  if (process.env.DOCS_BASE) return process.env.DOCS_BASE;
+  if (process.env.DOCS_SITE_URL) return "/";
+  const gh = (repoUrl || "").match(
+    /github\.com\/[^/]+\/([^/]+?)(?:\.git)?\/?$/,
+  );
+  return gh ? `/${gh[1]}` : "/";
+}
 const site = deriveSiteUrl(buildInfo.repoUrl);
+const base = deriveBase(buildInfo.repoUrl);
 
 export default defineConfig({
   site,
+  base,
   output: "static",
   build: {
     //: directory format so the catch-all generates real index.html files

--- a/docs/site/public/robots.txt
+++ b/docs/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kitsunium.github.io/sdk/sitemap-index.xml

--- a/docs/site/scripts/lib/base.mjs
+++ b/docs/site/scripts/lib/base.mjs
@@ -1,0 +1,23 @@
+// Deployment base path for hand-written absolute URLs.
+//
+// Astro auto-prefixes paths it controls (imported assets, bundled scripts)
+// with the configured `base`, but NOT hand-written href/src strings. On a
+// GitHub project page the site serves under /<repo>/ (e.g. /sdk/), so every
+// hand-written absolute internal URL must be prefixed or it 404s (ADR 0009
+// §accessible). At a custom-domain root the base is "" and these are no-ops.
+//
+// Only imported by .astro components (Vite injects import.meta.env.BASE_URL at
+// build time); never run under plain node.
+
+// DEPLOY_BASE is the base with any trailing slash stripped: "/sdk" or "".
+export const DEPLOY_BASE = (import.meta.env.BASE_URL || "/").replace(
+  /\/+$/,
+  "",
+);
+
+// withBase prefixes an absolute site path with the deployment base.
+// withBase("/rss.xml") → "/sdk/rss.xml" (or "/rss.xml" at root).
+export function withBase(path) {
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${DEPLOY_BASE}${p}`;
+}

--- a/docs/site/src/components/ApiDropdown.astro
+++ b/docs/site/src/components/ApiDropdown.astro
@@ -6,6 +6,8 @@
 //
 // Hides itself when only one major exists — switching makes no
 // sense with a single entry.
+import { withBase } from "../../scripts/lib/base.mjs";
+
 interface Release {
   version: string;
   default: boolean;
@@ -53,7 +55,7 @@ const activeLabel = active ? active.major + (active.eol ? " (EOL)" : "") : "v?";
           aria-selected={v.major === currentMajor}
           class:list={[v.major === currentMajor && "active"]}
         >
-          <a href={`/${defaultReleaseOf(v)}/${v.major}/`}>
+          <a href={withBase(`/${defaultReleaseOf(v)}/${v.major}/`)}>
             <span class="opt-version">{v.major}</span>
             {v.eol && <span class="opt-eol">(EOL)</span>}
           </a>

--- a/docs/site/src/components/Brand.astro
+++ b/docs/site/src/components/Brand.astro
@@ -2,6 +2,8 @@
 // Brand block — logo + literal "SDK". The API dropdown used to live
 // here but moved to the Header bar (left side, next to the build
 // date / branch) so all version controls share one location.
+import { withBase } from "../../scripts/lib/base.mjs";
+
 interface Props {
   currentPath: string;
 }
@@ -17,13 +19,15 @@ try {
 const def = versions.find(v => v?.default) ?? versions[0];
 const defRelease = def?.releases?.find(r => r.default) ?? def?.releases?.[0];
 //: URL layout is /<release>/<major>/... — release first.
-const homeHref = def && defRelease ? `/${defRelease.version}/${def.major}/` : "/";
+const homeHref = withBase(
+  def && defRelease ? `/${defRelease.version}/${def.major}/` : "/",
+);
 ---
 
 <div class="brand-block">
   <a href={homeHref} class="brand" aria-label="kitsunium SDK — home">
     <img
-      src="/brand/kitsunium.jpg"
+      src={withBase("/brand/kitsunium.jpg")}
       alt="Kitsunium"
       width="28"
       height="28"

--- a/docs/site/src/components/Breadcrumbs.astro
+++ b/docs/site/src/components/Breadcrumbs.astro
@@ -13,6 +13,7 @@
 // shows; falls back to the raw slug segment when no catalog entry
 // applies (deep-nested pages).
 import { RESERVED } from "../../scripts/lib/page-catalog.mjs";
+import { DEPLOY_BASE } from "../../scripts/lib/base.mjs";
 
 interface Props {
   currentPath: string;
@@ -25,7 +26,10 @@ const segments = currentPath
   .filter(Boolean);
 //: segments[0] = release, segments[1] = major, segments[2..] = in-doc.
 const inDoc = segments.slice(2);
-const base = segments.length >= 2 ? `/${segments[0]}/${segments[1]}` : "";
+const base =
+  segments.length >= 2
+    ? `${DEPLOY_BASE}/${segments[0]}/${segments[1]}`
+    : DEPLOY_BASE || "";
 const homeLabel = RESERVED.index.label ?? "Home";
 
 const crumbs: Array<{ href: string; label: string }> = [];

--- a/docs/site/src/components/PrevNext.astro
+++ b/docs/site/src/components/PrevNext.astro
@@ -6,6 +6,7 @@
 import { getCollection } from "astro:content";
 import { findDefaults } from "../../scripts/lib/tag-format.mjs";
 import { buildCatalog, flattenCatalog } from "../../scripts/lib/page-catalog.mjs";
+import { DEPLOY_BASE } from "../../scripts/lib/base.mjs";
 
 interface Props {
   currentPath: string;
@@ -27,7 +28,7 @@ const m = currentPath.match(/^\/([^/]+)\/(v\d+)(?:\/|$)/);
 const fallback = findDefaults(versions);
 const currentRelease = m?.[1] ?? fallback.release;
 const currentMajor = m?.[2] ?? fallback.major;
-const base = `/${currentRelease}/${currentMajor}`;
+const base = `${DEPLOY_BASE}/${currentRelease}/${currentMajor}`;
 const root = `${currentRelease}/${currentMajor}`;
 
 let entries: Awaited<ReturnType<typeof getCollection>> = [];

--- a/docs/site/src/components/ReleaseDropdown.astro
+++ b/docs/site/src/components/ReleaseDropdown.astro
@@ -7,6 +7,8 @@
 // Accessibility: roles + aria-expanded + aria-activedescendant follow
 // the WAI-ARIA combobox / listbox pattern. Keyboard: Up / Down move
 // focus, Enter activates, Escape closes.
+import { withBase } from "../../scripts/lib/base.mjs";
+
 interface Release {
   version: string;
   label: string;
@@ -62,7 +64,7 @@ const activeLabel =
           aria-selected={r.version === currentRelease}
           class:list={[r.version === currentRelease && "active"]}
         >
-          <a href={`/${r.version}/${currentMajor}/`}>
+          <a href={withBase(`/${r.version}/${currentMajor}/`)}>
             {shaText && (
               <>
                 <span class="opt-sha">{shaText}</span>

--- a/docs/site/src/components/Search.astro
+++ b/docs/site/src/components/Search.astro
@@ -19,6 +19,7 @@
 import { getCollection } from "astro:content";
 import { findDefaults } from "../../scripts/lib/tag-format.mjs";
 import { buildCatalog } from "../../scripts/lib/page-catalog.mjs";
+import { DEPLOY_BASE } from "../../scripts/lib/base.mjs";
 
 interface VersionEntry {
   major: string;
@@ -34,7 +35,7 @@ try {
 //: URL layout is /<release>/<major>/<page> — see Sidebar.astro for
 //: the rationale (release is time-axis, major is API surface).
 const { major, release } = findDefaults(versions);
-const base = `/${release}/${major}`;
+const base = `${DEPLOY_BASE}/${release}/${major}`;
 const root = `${release}/${major}`;
 
 let entries: Awaited<ReturnType<typeof getCollection>> = [];

--- a/docs/site/src/components/Sidebar.astro
+++ b/docs/site/src/components/Sidebar.astro
@@ -10,6 +10,7 @@ import Search from "./Search.astro";
 import ThemeToggle from "./ThemeToggle.astro";
 import { findDefaults } from "../../scripts/lib/tag-format.mjs";
 import { buildCatalog } from "../../scripts/lib/page-catalog.mjs";
+import { DEPLOY_BASE, withBase } from "../../scripts/lib/base.mjs";
 
 interface Release {
   version: string;
@@ -42,7 +43,7 @@ const fallback = findDefaults(versions);
 const currentRelease = m?.[1] ?? fallback.release;
 const currentMajor = m?.[2] ?? fallback.major;
 
-const base = `/${currentRelease}/${currentMajor}`;
+const base = `${DEPLOY_BASE}/${currentRelease}/${currentMajor}`;
 const root = `${currentRelease}/${currentMajor}`;
 
 let entries: Awaited<ReturnType<typeof getCollection>> = [];
@@ -125,7 +126,7 @@ function isActive(href: string): boolean {
           pkg.go.dev ↗
         </a>
       )}
-      <a href="/rss.xml" rel="alternate">
+      <a href={withBase("/rss.xml")} rel="alternate">
         RSS feed ↗
       </a>
     </div>

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,26 +1,35 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-24T23:49:32.273Z",
+  "generatedAt": "2026-05-25T09:43:11.364Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
     {
-      "type": "fix",
-      "scope": "review",
+      "type": "feat",
+      "scope": "release+docs",
       "breaking": false,
-      "summary": "address legitimate CodeRabbit + Qodo findings (PR #29)",
-      "sha": "5e861e3edf2854d50a8867ddc9379465e90c46a2",
-      "short": "5e861e3",
-      "date": "2026-05-25T01:26:36+02:00"
+      "summary": "impact-driven patch tags + versioned docs (ADR 0007) (#29)",
+      "sha": "f8a3aed28e648a7df889b8895ba46c21bec66075",
+      "short": "f8a3aed",
+      "date": "2026-05-25T11:01:40+02:00"
     },
     {
-      "type": "fix",
-      "scope": "docs",
+      "type": "feat",
+      "scope": "codec",
+      "breaking": true,
+      "summary": "add TLV + FlatBuffers codecs + migrate baseenc to Codec family (#27)",
+      "sha": "45ab9fb51b8bf4b30f4c970a3f64b8a2dc295398",
+      "short": "45ab9fb",
+      "date": "2026-05-20T13:31:25+02:00"
+    },
+    {
+      "type": "feat",
+      "scope": "logger",
       "breaking": false,
-      "summary": "resolve all broken docs-portal links + add MIT LICENSE",
-      "sha": "a077134fcfb6250a1f5973109e34dbbdc1d9e956",
-      "short": "a077134",
-      "date": "2026-05-24T23:29:07+02:00"
+      "summary": "v2 zero-alloc multi-sink architecture (#12)",
+      "sha": "7fd4c5c4f6d2dafeb70fdd4f75dac0328bc57437",
+      "short": "7fd4c5c",
+      "date": "2026-04-23T15:13:58+02:00"
     }
   ]
 }

--- a/docs/site/src/layouts/Default.astro
+++ b/docs/site/src/layouts/Default.astro
@@ -34,7 +34,15 @@ const {
   hideChrome = false,
 } = Astro.props;
 const url = new URL(Astro.request.url);
-const currentPath = url.pathname;
+//: fullPath keeps the deploy base (/sdk) for canonical/OG URLs; currentPath
+//: strips it so the /<release>/<major>/ parsing in Sidebar/Breadcrumbs/etc.
+//: works unchanged. Hrefs built in those components re-add the base.
+const fullPath = url.pathname;
+const deployBase = (import.meta.env.BASE_URL || "/").replace(/\/+$/, "");
+const currentPath =
+  (deployBase && fullPath.startsWith(deployBase)
+    ? fullPath.slice(deployBase.length)
+    : fullPath) || "/";
 
 interface BuildInfo {
   repoUrl?: string | null;
@@ -57,21 +65,26 @@ function projectName(repoUrl: string | null | undefined): string {
 const project = projectName(build.repoUrl);
 const pageTitle = title === project ? `${project} — documentation` : `${title} — ${project}`;
 const descFallback = `Documentation portal for ${project}.`;
-const canonicalUrl = new URL(currentPath, Astro.site ?? url.origin).toString();
-const ogImage = new URL("/brand/kitsunium.jpg", Astro.site ?? url.origin).toString();
+const canonicalUrl = new URL(fullPath, Astro.site ?? url.origin).toString();
+const ogImage = new URL(
+  `${deployBase}/brand/kitsunium.jpg`,
+  Astro.site ?? url.origin,
+).toString();
 ---
 
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <title>{pageTitle}</title>
     <meta name="description" content={description ?? descFallback} />
     <meta name="generator" content={Astro.generator} />
     <link rel="canonical" href={canonicalUrl} />
-    <link rel="icon" type="image/jpeg" href="/brand/kitsunium.jpg" />
-    <link rel="apple-touch-icon" href="/brand/kitsunium.jpg" />
-    <link rel="alternate" type="application/rss+xml" title={`${project} — documentation feed`} href="/rss.xml" />
+    <link rel="icon" type="image/jpeg" href={`${deployBase}/brand/kitsunium.jpg`} />
+    <link rel="apple-touch-icon" href={`${deployBase}/brand/kitsunium.jpg`} />
+    <link rel="alternate" type="application/rss+xml" title={`${project} — documentation feed`} href={`${deployBase}/rss.xml`} />
     {/* OpenGraph + Twitter cards — link previews on Slack / X / Discord / etc. */}
     <meta property="og:type" content="article" />
     <meta property="og:title" content={pageTitle} />

--- a/docs/site/src/pages/404.astro
+++ b/docs/site/src/pages/404.astro
@@ -11,6 +11,7 @@ import {
   flattenCatalog,
 } from "../../scripts/lib/page-catalog.mjs";
 import { findDefaults } from "../../scripts/lib/tag-format.mjs";
+import { DEPLOY_BASE } from "../../scripts/lib/base.mjs";
 
 interface VersionEntry {
   major: string;
@@ -27,7 +28,7 @@ try {
 //: + its default release. Same fallback Sidebar/Search use.
 //: URL layout: /<release>/<major>/... — release first, then major.
 const { major, release } = findDefaults(versions);
-const base = `/${release}/${major}`;
+const base = `${DEPLOY_BASE}/${release}/${major}`;
 const root = `${release}/${major}`;
 
 let entries: Awaited<ReturnType<typeof getCollection>> = [];
@@ -70,7 +71,7 @@ const suggestions = flattenCatalog(buildCatalog(entries as any, root, base)).sli
 
     <h2>Go home</h2>
     <p>
-      <a href={`${base}/`}>Return to {root}</a> · <a href="/">Site root</a>
+      <a href={`${base}/`}>Return to {root}</a>
     </p>
   </article>
 </Default>

--- a/docs/site/src/pages/[release]/[major]/[...slug].astro
+++ b/docs/site/src/pages/[release]/[major]/[...slug].astro
@@ -8,6 +8,7 @@
 import { getCollection, render } from "astro:content";
 import Default from "../../../layouts/Default.astro";
 import WhatsNew from "../../../components/WhatsNew.astro";
+import { withBase } from "../../../../scripts/lib/base.mjs";
 
 export async function getStaticPaths() {
   const all = await getCollection("docs");
@@ -61,7 +62,7 @@ const segments = entry.id.split("/");
 const isHome = segments.length === 2;
 const release = segments[0];
 const major = segments[1];
-const changelogHref = `/${release}/${major}/changelog/`;
+const changelogHref = withBase(`/${release}/${major}/changelog/`);
 ---
 
 <Default title={title} description={description} headings={tocHeadings} source={source}>

--- a/docs/site/src/pages/[release]/index.astro
+++ b/docs/site/src/pages/[release]/index.astro
@@ -3,6 +3,8 @@
 // Implemented as a real Astro page (not via the astro.config redirects
 // map) so the emitted file has a proper <html lang="en"> wrapper for
 // Pagefind. data-pagefind-ignore on <body> excludes it from the index.
+import { withBase } from "../../../scripts/lib/base.mjs";
+
 interface VersionEntry {
   major: string;
   default: boolean;
@@ -31,7 +33,7 @@ export async function getStaticPaths() {
   }
   return [...seen.entries()].map(([release, major]) => ({
     params: { release },
-    props: { target: `/${release}/${major}/` },
+    props: { target: withBase(`/${release}/${major}/`) },
   }));
 }
 

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -6,6 +6,8 @@
 // That keeps Pagefind from warning about pages without a lang attr
 // on every build; data-pagefind-ignore on <body> stops the page
 // being indexed in the first place.
+import { withBase } from "../../scripts/lib/base.mjs";
+
 interface VersionEntry {
   major: string;
   default: boolean;
@@ -27,7 +29,7 @@ const defaultRelease =
 //: URL layout is /<release>/<major>/<page> — release is the time axis,
 //: major the API surface. The root redirect lands the visitor at the
 //: newest non-EOL major's default release.
-const target = `/${defaultRelease}/${defaultMajor}/`;
+const target = withBase(`/${defaultRelease}/${defaultMajor}/`);
 ---
 <!doctype html>
 <html lang="en">

--- a/docs/site/src/styles/global.css
+++ b/docs/site/src/styles/global.css
@@ -521,7 +521,9 @@ footer p {
   --color-border: #d0d7de;
   --color-border-bright: #afb8c1;
   --color-text: #1f2328;
-  --color-muted: #57606a;
+  /* Darkened from #57606a so muted text clears WCAG AA (4.5:1) on white even
+     through the 0.7-opacity usages (build-coord, hints). */
+  --color-muted: #4a535d;
   --color-accent: #0969da;
   --color-accent-2: #8250df;
   --color-code-bg: #f1f4f8;


### PR DESCRIPTION
## Summary

- Base-path the docs portal for GitHub Pages **project** deploys (`/sdk/`): `site`=origin, `base`=/<repo>, plus a `withBase()` helper applied to every hand-written absolute URL (nav, dropdowns, redirects, canonical, OG, favicon, RSS).
- `Default.astro` strips the base for `/<release>/<major>/` parsing; canonical/OG use the full path.
- a11y/SEO: theme-color meta, WCAG-AA light-theme muted colour, robots.txt + sitemap pointer.
- Docs: new `docs/site/CLAUDE.md` + `docs-deploy.yml` row in the workflow inventory.

Addresses the docs-portal audit punch-list (the CRITICAL base-path item + a11y/SEO/docs).

## Test plan

- [ ] `npm test` 6/6
- [ ] full build green; base-aware `dist/` crawl reports 0 broken links under `/sdk`
- [ ] bazel CI green (docs-only, no Go changes)
- [ ] after Settings → Pages → GitHub Actions, Docs Deploy publishes a working site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Documentation portal now deploys correctly to custom GitHub Pages paths with working navigation links.
  * Added SEO support via robots.txt file.
  * Enhanced theme with separate dark and light color scheme preferences.

* **Bug Fixes**
  * Improved light mode text contrast for better readability.

* **Documentation**
  * Added detailed guides on documentation building, versioning, and deployment processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->