### PR TITLE
fix(docs): make npm test glob node-version-agnostic

### DIFF
--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -9,7 +9,7 @@
     "prebuild": "node scripts/sync-versions.mjs && node scripts/gen-symbols.mjs",
     "build": "astro build && pagefind --site dist --output-subdir _pagefind",
     "preview": "astro preview",
-    "test": "node --test \"scripts/**/*.test.mjs\""
+    "test": "node --test scripts/lib/*.test.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,9 +1,18 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-25T09:43:11.364Z",
+  "generatedAt": "2026-05-25T09:57:29.782Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
+    {
+      "type": "fix",
+      "scope": "docs",
+      "breaking": false,
+      "summary": "base-path the portal for GitHub Pages project deploys + a11y/SEO (#30)",
+      "sha": "5bff559252443700989d2507c57039696da9ded2",
+      "short": "5bff559",
+      "date": "2026-05-25T09:45:30Z"
+    },
     {
       "type": "feat",
       "scope": "release+docs",


### PR DESCRIPTION
## Summary

- The docs-deploy lane pins node 20, but `node --test "scripts/**/*.test.mjs"` needs node 21+ to expand the glob; on node 20 it failed ("Could not find …") and broke the Docs Deploy build.
- Switch to `node --test scripts/lib/*.test.mjs` so the shell expands the glob on any node version.

## Test plan

- [ ] `npm test` 6/6 (verified locally)
- [ ] Docs Deploy build passes the test step → site publishes