### PR TITLE
refactor(kernel): extract object-recycling into recycler.Pool[T] + CappedPool[T] (ADR 0010)

### DIFF
--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -127,20 +127,11 @@ rules:
       - "**/internal/service/logger/**"
       - "**/pkg/v1/logger/**"
 
-  # KTN-VAR-MAKEAPPEND + KTN-VAR-SLICECAP false-positive on generic
-  # fixed-length storage. The ring buffer (and other future generic
-  # primitives) allocate their slot array via `make([]T, n)` and only
-  # use indexed access (no append ever runs against the slice). The
-  # linter heuristic cannot prove the absence of append for a generic
-  # type parameter and conservatively flags every such call. We scope
-  # the exclusion to the kernel/ring tree so the rule still catches
-  # genuine append-as-storage misuse everywhere else.
-  KTN-VAR-MAKEAPPEND:
-    exclude:
-      - "**/internal/kernel/ring/**"
-  KTN-VAR-SLICECAP:
-    exclude:
-      - "**/internal/kernel/ring/**"
+  # (Removed) KTN-VAR-MAKEAPPEND + KTN-VAR-SLICECAP ring exclusion: the
+  # generic fixed-length-storage false positive it covered was fixed upstream
+  # in ktn-linter (append-reachability gating, kodflow/ktn-linter#183) and is
+  # no longer reproducible on v1.34.0 — verified by lint-with-exclusion-removed.
+  # Re-add a scoped exclusion only if a future binary regresses the heuristic.
 
   # KTN-TEST-SUFFIX + KTN-TEST-TABLE — scoped exception for the codec
   # benchmark file. Normally Test* functions must live in

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -159,6 +159,23 @@ rules:
     exclude:
       - "**/pkg/v1/codec/codec_bench_test.go"
 
+  # KTN-STRUCT-ROLE + KTN-STRUCT-ROLE-STUTTER — scoped exception for the
+  # generic recycler primitives. Recycler[T] and CappedRecycler[T] ARE the
+  # package's whole public surface: their names are the API, exactly like the
+  # stdlib's ring.Ring / list.List single-concept primitives. A role suffix
+  # would be redundant noise (there is no second "kind" of recycler to
+  # disambiguate from) and the package/type repetition is the idiomatic shape
+  # for a single-concept primitive package. The role-suffix heuristic reports
+  # "no strong inference available" for a pure generic pool — the same class of
+  # generic-type-parameter false positive already scoped out for kernel/ring
+  # above. Concrete structs (not interfaces) are deliberate per ADR 0010.
+  KTN-STRUCT-ROLE:
+    exclude:
+      - "**/internal/kernel/recycler/**"
+  KTN-STRUCT-ROLE-STUTTER:
+    exclude:
+      - "**/internal/kernel/recycler/**"
+
   # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
   # Go 1.26 convention is to avoid init() in favour of explicit constructors,
   # sync.Once for lazy init, or package-level var initialisers. The codec

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -150,38 +150,34 @@ rules:
     exclude:
       - "**/pkg/v1/codec/codec_bench_test.go"
 
-  # KTN-STRUCT-ROLE + KTN-STRUCT-ROLE-STUTTER — TEMPORARY scoped exception for
-  # the generic recycler primitives. Recycler[T] and CappedRecycler[T] ARE the
-  # package's whole public surface: their names are the API, exactly like the
-  # stdlib's ring.Ring / list.List single-concept primitives. A role suffix
-  # would be redundant noise (no second "kind" of recycler to disambiguate);
-  # the package/type repetition is idiomatic for a single-concept primitive
-  # package; and recycler is internal/kernel plumbing (never re-exported in
-  # pkg/v1), so the "interface-for-consumers" convention does not apply — a
-  # concrete struct is deliberate per ADR 0010 and avoids an interface dispatch
-  # on the Get/Put hot path.
+  # KTN-STRUCT-ROLE + KTN-STRUCT-ROLE-STUTTER — narrow exclude for CappedRecycler
+  # ONLY (one file). recycler is internal/kernel plumbing, never re-exported in
+  # pkg/v1, so the interface-for-consumers convention does not apply; the
+  # primitives are concrete structs per ADR 0010 (avoids an interface dispatch
+  # on the Get/Put hot path).
   #
-  # WHY AN EXCLUDE AND NOT CONFIG (today): the underlying trigger is an upstream
-  # heuristic gap — KTN-STRUCT-ROLE's PNPT exemption (kodflow/ktn-linter#263) is
-  # silently suppressed when a non-package-matching sibling (CappedRecycler) is
-  # added. Filed as kodflow/ktn-linter#356.
+  # Recycler[T] needs NO exclude: the PNPT per-declaration fix
+  # (kodflow/ktn-linter#356, PR #357) makes a package-named primitive exempt
+  # regardless of siblings. CappedRecycler[T] is a cap-bounded variant of the
+  # same primitive, but its name is not an exact PNPT match (recycler !=
+  # cappedrecycler), so STRUCT-ROLE + the info-level STUTTER still flag it.
+  # That compound-variant case is filed as kodflow/ktn-linter#359 (proposal:
+  # extend PNPT to a trailing-component match, or adopt #285 additional_suffixes).
   #
-  # TODO(remove once a ktn-linter release > v1.34.0 ships the config knobs that
-  # are already merged on the linter's main branch):
-  #   - replace this exclude with `KTN-STRUCT-ROLE.additional_suffixes: [Recycler]`
-  #     (kodflow/ktn-linter#285 — both Recycler and CappedRecycler end in
-  #     "Recycler", so the suffix rule then passes natively, no path-suppress);
-  #   - drop the STUTTER line via a `KTN-STRUCT-ROLE-STUTTER.severity` override
-  #     (kodflow/ktn-linter#332) instead of fully excluding it.
-  # Neither knob exists in the v1.34.0 binary the devcontainer ships (verified
-  # via `ktn-linter config --generate`), so the path-exclude is the only
-  # mechanism for now.
+  # REQUIRES a ktn-linter build that includes #356 (on the linter's main branch
+  # today; cut a release > v1.34.0, or pin the devcontainer to it). Under the
+  # plain v1.34.0 release Recycler ALSO flags and this one-file exclude is
+  # insufficient — widen back to "**/internal/kernel/recycler/**" in that case.
+  #
+  # TODO(remove entirely once #359 lands OR #285 additional_suffixes ships in a
+  # release: then add `KTN-STRUCT-ROLE.additional_suffixes: [Recycler]` and drop
+  # this block).
   KTN-STRUCT-ROLE:
     exclude:
-      - "**/internal/kernel/recycler/**"
+      - "**/internal/kernel/recycler/capped.go"
   KTN-STRUCT-ROLE-STUTTER:
     exclude:
-      - "**/internal/kernel/recycler/**"
+      - "**/internal/kernel/recycler/capped.go"
 
   # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
   # Go 1.26 convention is to avoid init() in favour of explicit constructors,

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -150,34 +150,12 @@ rules:
     exclude:
       - "**/pkg/v1/codec/codec_bench_test.go"
 
-  # KTN-STRUCT-ROLE + KTN-STRUCT-ROLE-STUTTER — narrow exclude for CappedRecycler
-  # ONLY (one file). recycler is internal/kernel plumbing, never re-exported in
-  # pkg/v1, so the interface-for-consumers convention does not apply; the
-  # primitives are concrete structs per ADR 0010 (avoids an interface dispatch
-  # on the Get/Put hot path).
-  #
-  # Recycler[T] needs NO exclude: the PNPT per-declaration fix
-  # (kodflow/ktn-linter#356, PR #357) makes a package-named primitive exempt
-  # regardless of siblings. CappedRecycler[T] is a cap-bounded variant of the
-  # same primitive, but its name is not an exact PNPT match (recycler !=
-  # cappedrecycler), so STRUCT-ROLE + the info-level STUTTER still flag it.
-  # That compound-variant case is filed as kodflow/ktn-linter#359 (proposal:
-  # extend PNPT to a trailing-component match, or adopt #285 additional_suffixes).
-  #
-  # REQUIRES a ktn-linter build that includes #356 (on the linter's main branch
-  # today; cut a release > v1.34.0, or pin the devcontainer to it). Under the
-  # plain v1.34.0 release Recycler ALSO flags and this one-file exclude is
-  # insufficient — widen back to "**/internal/kernel/recycler/**" in that case.
-  #
-  # TODO(remove entirely once #359 lands OR #285 additional_suffixes ships in a
-  # release: then add `KTN-STRUCT-ROLE.additional_suffixes: [Recycler]` and drop
-  # this block).
-  KTN-STRUCT-ROLE:
-    exclude:
-      - "**/internal/kernel/recycler/capped.go"
-  KTN-STRUCT-ROLE-STUTTER:
-    exclude:
-      - "**/internal/kernel/recycler/capped.go"
+  # (No recycler exclusion.) internal/kernel/recycler ships Pool[T] +
+  # CappedPool[T]: "Pool" is a recognized role suffix, so both pass
+  # KTN-STRUCT-ROLE and KTN-STRUCT-ROLE-STUTTER natively — no path-suppress and
+  # no dependency on the PNPT fix (#356). The earlier Recycler/CappedRecycler
+  # naming stuttered (kodflow/ktn-linter#359, by-design) and was renamed to the
+  # idiomatic sync.Pool-style form instead of carrying an exclusion (ADR 0010).
 
   # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
   # Go 1.26 convention is to avoid init() in favour of explicit constructors,

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -150,16 +150,32 @@ rules:
     exclude:
       - "**/pkg/v1/codec/codec_bench_test.go"
 
-  # KTN-STRUCT-ROLE + KTN-STRUCT-ROLE-STUTTER — scoped exception for the
-  # generic recycler primitives. Recycler[T] and CappedRecycler[T] ARE the
+  # KTN-STRUCT-ROLE + KTN-STRUCT-ROLE-STUTTER — TEMPORARY scoped exception for
+  # the generic recycler primitives. Recycler[T] and CappedRecycler[T] ARE the
   # package's whole public surface: their names are the API, exactly like the
   # stdlib's ring.Ring / list.List single-concept primitives. A role suffix
-  # would be redundant noise (there is no second "kind" of recycler to
-  # disambiguate from) and the package/type repetition is the idiomatic shape
-  # for a single-concept primitive package. The role-suffix heuristic reports
-  # "no strong inference available" for a pure generic pool — the same class of
-  # generic-type-parameter false positive already scoped out for kernel/ring
-  # above. Concrete structs (not interfaces) are deliberate per ADR 0010.
+  # would be redundant noise (no second "kind" of recycler to disambiguate);
+  # the package/type repetition is idiomatic for a single-concept primitive
+  # package; and recycler is internal/kernel plumbing (never re-exported in
+  # pkg/v1), so the "interface-for-consumers" convention does not apply — a
+  # concrete struct is deliberate per ADR 0010 and avoids an interface dispatch
+  # on the Get/Put hot path.
+  #
+  # WHY AN EXCLUDE AND NOT CONFIG (today): the underlying trigger is an upstream
+  # heuristic gap — KTN-STRUCT-ROLE's PNPT exemption (kodflow/ktn-linter#263) is
+  # silently suppressed when a non-package-matching sibling (CappedRecycler) is
+  # added. Filed as kodflow/ktn-linter#356.
+  #
+  # TODO(remove once a ktn-linter release > v1.34.0 ships the config knobs that
+  # are already merged on the linter's main branch):
+  #   - replace this exclude with `KTN-STRUCT-ROLE.additional_suffixes: [Recycler]`
+  #     (kodflow/ktn-linter#285 — both Recycler and CappedRecycler end in
+  #     "Recycler", so the suffix rule then passes natively, no path-suppress);
+  #   - drop the STUTTER line via a `KTN-STRUCT-ROLE-STUTTER.severity` override
+  #     (kodflow/ktn-linter#332) instead of fully excluding it.
+  # Neither knob exists in the v1.34.0 binary the devcontainer ships (verified
+  # via `ktn-linter config --generate`), so the path-exclude is the only
+  # mechanism for now.
   KTN-STRUCT-ROLE:
     exclude:
       - "**/internal/kernel/recycler/**"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ filegroup(
         "//internal/kernel/buffer:audit_srcs",
         "//internal/kernel/clock:audit_srcs",
         "//internal/kernel/errs:audit_srcs",
+        "//internal/kernel/recycler:audit_srcs",
         "//internal/service/codec/asn1:audit_srcs",
         "//internal/service/codec/baseenc:audit_srcs",
         "//internal/service/codec/cbor:audit_srcs",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Go SDK providing a normed, performant toolbox for downstream applications. Two d
 ```
 internal/
 ├── kernel/        stdlib-only AND generic primitives
-│                  errs, buffer, clock, ring
+│                  errs, recycler, buffer, clock, ring
 ├── core/          domain interfaces + domain values
 │                  codec, logger, logger/level
 └── service/       concrete implementations
@@ -110,5 +110,7 @@ After cloning, wire the in-repo hooks with `bash scripts/install-hooks.sh` (one-
 - ADR 0006 — error code registry extension (logger v2 + ring) — `docs/adr/0006-sdk-error-code-registry-extension.md`
 - ADR 0007 — release workflow + docs versioning — `docs/adr/0007-sdk-release-and-versioning.md`
 - ADR 0008 — README generation from Go doc comments — `docs/adr/0008-readme-from-code-generation.md`
+- ADR 0009 — public module `go get`-resolvability — `docs/adr/0009-pkg-public-module-resolvability.md`
+- ADR 0010 — kernel object-recycling primitive — `docs/adr/0010-kernel-recycler-primitive.md`
 - Layer placement audit — `.claude/contexts/sdk-layer-placement-audit.md`
 - Bazel adoption context — `.claude/contexts/bazel-9-go-sdk.md`

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -18,6 +18,7 @@ Long-form SDK documentation. ADRs here are the source of truth for cross-cutting
 | `adr/0007-sdk-release-and-versioning.md` | Impact-driven patch tags `pkg/<major>/vX.Y.Z`, docs versioning via tag snapshots | Accepted |
 | `adr/0008-readme-from-code-generation.md` | `README.md` generated from Go doc comments via gomarkdoc | Accepted |
 | `adr/0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible (no local `replace`) | Accepted (requirement); impl Deferred |
+| `adr/0010-kernel-recycler-primitive.md` | Generic kernel `Recycler[T]` + `CappedRecycler[T]`; `buffer` + `core/codec/scratch` become consumers | Accepted |
 
 ## ADR conventions
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -18,7 +18,7 @@ Long-form SDK documentation. ADRs here are the source of truth for cross-cutting
 | `adr/0007-sdk-release-and-versioning.md` | Impact-driven patch tags `pkg/<major>/vX.Y.Z`, docs versioning via tag snapshots | Accepted |
 | `adr/0008-readme-from-code-generation.md` | `README.md` generated from Go doc comments via gomarkdoc | Accepted |
 | `adr/0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible (no local `replace`) | Accepted (requirement); impl Deferred |
-| `adr/0010-kernel-recycler-primitive.md` | Generic kernel `Recycler[T]` + `CappedRecycler[T]`; `buffer` + `core/codec/scratch` become consumers | Accepted |
+| `adr/0010-kernel-recycler-primitive.md` | Generic kernel `Pool[T]` + `CappedPool[T]`; `buffer` + `core/codec/scratch` become consumers | Accepted |
 
 ## ADR conventions
 

--- a/docs/adr/0010-kernel-recycler-primitive.md
+++ b/docs/adr/0010-kernel-recycler-primitive.md
@@ -66,12 +66,20 @@ Capacity thresholds remain owned by the consumers: 64 KiB (`kernel/buffer`),
 
 - **Keep `Recycler[T]` as an interface (IFACE-PLUGIN), the prior kernel
   convention.** Rejected: a single-implementation interface in a kernel
-  primitive is over-abstraction; the concrete struct sharpens inlining on the
-  zero-alloc hot path. ktn-linter's `KTN-STRUCT-ROLE` flags the exported
-  struct (its name has no role suffix); a single-concept primitive whose name
-  IS its API (cf. stdlib `ring.Ring` / `list.List`) is the documented exception
-  — scoped out in `.ktn-linter.yaml`, the same way `kernel/ring` scopes the
-  generic-type-parameter false positives.
+  primitive is over-abstraction, and recycler is internal plumbing never
+  re-exported in `pkg/v1` — the interface-for-consumers convention lives at the
+  public boundary (`logger.Logger`, `codec.Codec`), not here. The concrete
+  struct also avoids an interface dispatch on the `Get`/`Put` hot path (the
+  exact ns gain is left to a benchmark, but it is strictly ≥ 0 and the 0-alloc
+  invariant holds either way). ktn-linter's `KTN-STRUCT-ROLE` flags the exported
+  struct (no role suffix); a single-concept primitive whose name IS its API (cf.
+  stdlib `ring.Ring` / `list.List`) is the legitimate exception, scoped out in
+  `.ktn-linter.yaml`. That exclusion is **temporary**: its root is an upstream
+  heuristic gap (the PNPT exemption is suppressed by a non-matching sibling —
+  filed as kodflow/ktn-linter#356), and config knobs already merged on the
+  linter's main branch (#285 `additional_suffixes`, #332 per-rule `severity`)
+  will replace the path-suppress with native config once a release > v1.34.0
+  ships them (see the TODO in `.ktn-linter.yaml`).
 - **A `worker` pool sibling now.** Deferred: a worker pool composes `ring`, not
   `recycler`, and has only one plausible consumer today (async logger). Built
   on demand, not ahead of it (no empty package).

--- a/docs/adr/0010-kernel-recycler-primitive.md
+++ b/docs/adr/0010-kernel-recycler-primitive.md
@@ -103,8 +103,19 @@ Capacity thresholds remain owned by the consumers: 64 KiB (`kernel/buffer`),
   structs by deliberate choice.
 - recycler emits no dotted-quad error codes (it panics on programmer error;
   panics are not returned errors, so ADR 0005 has no entry).
-- `worker` remains a deferred sibling until at least two concrete consumers
-  exist.
+## Breaking changes
+
+None to the public API — `pkg/v1/*` is untouched (an `internal/`-only refactor).
+The single internal-breaking change (`recycler.NewPool(nil)` panics where the
+former `buffer.NewRecycler(nil)` returned nil) is contained to the interface
+collapse commit and documented in the package `CLAUDE.md`.
+
+## Deferred
+
+- A `worker` sibling primitive (it would compose `ring`, not `recycler`) stays
+  deferred until at least two concrete consumers exist.
+- The kernel-wide zero-alloc gate over ring/clock/errs hot paths is tracked
+  separately; this ADR ships only the recycler/buffer-scoped probe.
 
 ## References
 

--- a/docs/adr/0010-kernel-recycler-primitive.md
+++ b/docs/adr/0010-kernel-recycler-primitive.md
@@ -1,0 +1,105 @@
+# ADR 0010 — Kernel object-recycling primitive
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-25
+
+## Deciders
+
+kodflow (with multi-lens design review — see `.claude/plans/kernel-recycler.md`)
+
+## Context
+
+Three object-recycling mechanisms had grown in parallel and duplicated the
+same cap-discard logic while keeping their capacity thresholds in different
+layers:
+
+| Mechanism | Layer | Type | Cap-discard | Reset |
+|---|---|---|---|---|
+| `kernel/buffer` `Get`/`Put` | kernel | `*[]byte` | 64 KiB, hand-rolled | on Put |
+| `kernel/buffer` `Recycler[T]` (interface) | kernel | `T` | none | none |
+| `core/codec/scratch` `Acquire*`/`Release*` | core | `*bytes.Buffer` + `*bytes.Reader` | 256 KiB, hand-rolled | Acquire + Release |
+
+The cap-discard *mechanism* is generic; only the *threshold* and the concrete
+*type* are domain-specific. Three copies could (and did) drift.
+
+## Decision
+
+Introduce `internal/kernel/recycler`, a minimal kernel primitive for reusable
+object recycling. It exposes **concrete types only — no public interface**:
+
+- `Recycler[T]` — owns a `sync.Pool`, performs **no reset**. Suitable for
+  consumers that reset at their own boundary (logger `Builder.Send`, async
+  `data[:0]`).
+- `CappedRecycler[T]` — composes a concrete `*Recycler[T]` and adds
+  `reset func(T)` + `capOf func(T) int` + `maxCap int`.
+
+Conventions:
+
+- **reset-on-Put**, only in `CappedRecycler`.
+- `CappedRecycler.Put` **discards oversized values BEFORE reset** — an over-cap
+  value is orphaned (never reset, never repooled). This preserves the codec
+  scratch detach contract, where an over-cap buffer's `Bytes()` has been handed
+  to the caller and must not be touched. **Reset is not a memory wipe**; a
+  consumer recycling sensitive bytes must zero them before Put.
+- `NewRecycler(nil)` **panics** (programmer error). `NewCappedRecycler` panics
+  on a nil reset/capOf or a non-positive `maxCap` (a non-positive threshold
+  would orphan every value, silently turning the pool into a never-recycling
+  allocator).
+- `Recycler.Get()` is **fail-loud** via comma-ok + panic (mirrors
+  `core/codec/scratch.poolGet`): the pool is contractually homogeneous, so a
+  wrong-typed entry is an invariant break that must surface, not hide.
+- **Generic recyclers do NOT nil-check**; public/package-level wrappers
+  (`buffer.Put`, `scratch.ReleaseBuffer`/`ReleaseReader`) keep nil guards where
+  nil is part of their accepted API — a generic `T any` cannot nil-check.
+- **Runtime-parameterized resets** (`bytes.Reader.Reset(src)`) stay
+  consumer-side on Acquire, backed by a plain `Recycler[T]`.
+
+Capacity thresholds remain owned by the consumers: 64 KiB (`kernel/buffer`),
+256 KiB (`core/codec/scratch`).
+
+## Alternatives considered
+
+- **Keep `Recycler[T]` as an interface (IFACE-PLUGIN), the prior kernel
+  convention.** Rejected: a single-implementation interface in a kernel
+  primitive is over-abstraction; the concrete struct sharpens inlining on the
+  zero-alloc hot path. ktn-linter's `KTN-STRUCT-ROLE` flags the exported
+  struct (its name has no role suffix); a single-concept primitive whose name
+  IS its API (cf. stdlib `ring.Ring` / `list.List`) is the documented exception
+  — scoped out in `.ktn-linter.yaml`, the same way `kernel/ring` scopes the
+  generic-type-parameter false positives.
+- **A `worker` pool sibling now.** Deferred: a worker pool composes `ring`, not
+  `recycler`, and has only one plausible consumer today (async logger). Built
+  on demand, not ahead of it (no empty package).
+- **Name the package `pool`.** Rejected: `recycler` names the actual mechanism
+  (reuse + reset + cap-discard) and blocks the natural drift toward stuffing a
+  worker pool into a generic `pool` package.
+
+## Consequences
+
+- `kernel/buffer` becomes a `recycler.CappedRecycler[*[]byte]` (64 KiB) wrapper;
+  `*[]byte` and the nil-safe `Put` no-op stay.
+- `core/codec/scratch` uses `recycler.CappedRecycler[*bytes.Buffer]` (256 KiB)
+  for buffers and a plain `recycler.Recycler[*bytes.Reader]` for readers; the
+  `poolGet` helper is gone. The "Why core, not kernel" rationale is revised —
+  only the mechanism migrated; the 256 KiB codec threshold stays in core.
+- `service/logger` (recordPool) and `service/logger/middleware/async` (sink
+  pool) consume `recycler.Recycler`; reset stays consumer-side.
+- The IFACE-PLUGIN convention (kernel exported types are interfaces) no longer
+  applies to `recycler`: it is the first kernel primitive shipped as concrete
+  structs by deliberate choice.
+- recycler emits no dotted-quad error codes (it panics on programmer error;
+  panics are not returned errors, so ADR 0005 has no entry).
+- `worker` remains a deferred sibling until at least two concrete consumers
+  exist.
+
+## References
+
+- `.claude/plans/kernel-recycler.md` — design + 10-lens refinement
+- `internal/kernel/CLAUDE.md` — kernel gate (stdlib-only AND generic)
+- ADR 0005 — error codes (recycler emits none)
+- Tracking issue #32 · Refs #18 (kernel/buffer benches), #23 (zero-alloc gate)

--- a/docs/adr/0010-kernel-recycler-primitive.md
+++ b/docs/adr/0010-kernel-recycler-primitive.md
@@ -21,7 +21,7 @@ layers:
 | Mechanism | Layer | Type | Cap-discard | Reset |
 |---|---|---|---|---|
 | `kernel/buffer` `Get`/`Put` | kernel | `*[]byte` | 64 KiB, hand-rolled | on Put |
-| `kernel/buffer` `Recycler[T]` (interface) | kernel | `T` | none | none |
+| `kernel/buffer` `Pool[T]` (interface) | kernel | `T` | none | none |
 | `core/codec/scratch` `Acquire*`/`Release*` | core | `*bytes.Buffer` + `*bytes.Reader` | 256 KiB, hand-rolled | Acquire + Release |
 
 The cap-discard *mechanism* is generic; only the *threshold* and the concrete
@@ -32,54 +32,55 @@ The cap-discard *mechanism* is generic; only the *threshold* and the concrete
 Introduce `internal/kernel/recycler`, a minimal kernel primitive for reusable
 object recycling. It exposes **concrete types only — no public interface**:
 
-- `Recycler[T]` — owns a `sync.Pool`, performs **no reset**. Suitable for
+- `Pool[T]` — owns a `sync.Pool`, performs **no reset**. Suitable for
   consumers that reset at their own boundary (logger `Builder.Send`, async
   `data[:0]`).
-- `CappedRecycler[T]` — composes a concrete `*Recycler[T]` and adds
+- `CappedPool[T]` — composes a concrete `*Pool[T]` and adds
   `reset func(T)` + `capOf func(T) int` + `maxCap int`.
 
 Conventions:
 
-- **reset-on-Put**, only in `CappedRecycler`.
-- `CappedRecycler.Put` **discards oversized values BEFORE reset** — an over-cap
+- **reset-on-Put**, only in `CappedPool`.
+- `CappedPool.Put` **discards oversized values BEFORE reset** — an over-cap
   value is orphaned (never reset, never repooled). This preserves the codec
   scratch detach contract, where an over-cap buffer's `Bytes()` has been handed
   to the caller and must not be touched. **Reset is not a memory wipe**; a
   consumer recycling sensitive bytes must zero them before Put.
-- `NewRecycler(nil)` **panics** (programmer error). `NewCappedRecycler` panics
+- `NewPool(nil)` **panics** (programmer error). `NewCappedPool` panics
   on a nil reset/capOf or a non-positive `maxCap` (a non-positive threshold
   would orphan every value, silently turning the pool into a never-recycling
   allocator).
-- `Recycler.Get()` is **fail-loud** via comma-ok + panic (mirrors
+- `Pool.Get()` is **fail-loud** via comma-ok + panic (mirrors
   `core/codec/scratch.poolGet`): the pool is contractually homogeneous, so a
   wrong-typed entry is an invariant break that must surface, not hide.
 - **Generic recyclers do NOT nil-check**; public/package-level wrappers
   (`buffer.Put`, `scratch.ReleaseBuffer`/`ReleaseReader`) keep nil guards where
   nil is part of their accepted API — a generic `T any` cannot nil-check.
 - **Runtime-parameterized resets** (`bytes.Reader.Reset(src)`) stay
-  consumer-side on Acquire, backed by a plain `Recycler[T]`.
+  consumer-side on Acquire, backed by a plain `Pool[T]`.
 
 Capacity thresholds remain owned by the consumers: 64 KiB (`kernel/buffer`),
 256 KiB (`core/codec/scratch`).
 
 ## Alternatives considered
 
-- **Keep `Recycler[T]` as an interface (IFACE-PLUGIN), the prior kernel
+- **Keep the primitives as interfaces (IFACE-PLUGIN), the prior kernel
   convention.** Rejected: a single-implementation interface in a kernel
   primitive is over-abstraction, and recycler is internal plumbing never
   re-exported in `pkg/v1` — the interface-for-consumers convention lives at the
-  public boundary (`logger.Logger`, `codec.Codec`), not here. The concrete
-  struct also avoids an interface dispatch on the `Get`/`Put` hot path (the
-  exact ns gain is left to a benchmark, but it is strictly ≥ 0 and the 0-alloc
-  invariant holds either way). ktn-linter's `KTN-STRUCT-ROLE` flags the exported
-  struct (no role suffix); a single-concept primitive whose name IS its API (cf.
-  stdlib `ring.Ring` / `list.List`) is the legitimate exception, scoped out in
-  `.ktn-linter.yaml`. That exclusion is **temporary**: its root is an upstream
-  heuristic gap (the PNPT exemption is suppressed by a non-matching sibling —
-  filed as kodflow/ktn-linter#356), and config knobs already merged on the
-  linter's main branch (#285 `additional_suffixes`, #332 per-rule `severity`)
-  will replace the path-suppress with native config once a release > v1.34.0
-  ships them (see the TODO in `.ktn-linter.yaml`).
+  public boundary (`logger.Logger`, `codec.Codec`), not here. Concrete structs
+  also avoid an interface dispatch on the `Get`/`Put` hot path (exact ns gain
+  left to a benchmark; the 0-alloc invariant holds either way).
+- **Name the types `Recycler` / `CappedRecycler`.** Rejected on lint grounds:
+  `recycler.CappedRecycler` is a genuine compound stutter — ktn-linter#359
+  ruled this **by-design** (`KTN-STRUCT-ROLE-STUTTER` is doing its job), so
+  carrying those names would force a permanent `.ktn-linter.yaml` exclusion.
+  Renamed to the `sync.Pool`-idiomatic `Pool[T]` / `CappedPool[T]` instead:
+  "Pool" is a recognized role suffix, so both types pass `KTN-STRUCT-ROLE` and
+  `KTN-STRUCT-ROLE-STUTTER` **natively — zero exclusion**, and independent of
+  the PNPT fix (kodflow/ktn-linter#356), so it works on the released v1.34.0
+  binary (verified). The package stays `recycler` (the mechanism); the types are
+  pools, exactly like `sync.Pool`.
 - **A `worker` pool sibling now.** Deferred: a worker pool composes `ring`, not
   `recycler`, and has only one plausible consumer today (async logger). Built
   on demand, not ahead of it (no empty package).
@@ -89,14 +90,14 @@ Capacity thresholds remain owned by the consumers: 64 KiB (`kernel/buffer`),
 
 ## Consequences
 
-- `kernel/buffer` becomes a `recycler.CappedRecycler[*[]byte]` (64 KiB) wrapper;
+- `kernel/buffer` becomes a `recycler.CappedPool[*[]byte]` (64 KiB) wrapper;
   `*[]byte` and the nil-safe `Put` no-op stay.
-- `core/codec/scratch` uses `recycler.CappedRecycler[*bytes.Buffer]` (256 KiB)
-  for buffers and a plain `recycler.Recycler[*bytes.Reader]` for readers; the
+- `core/codec/scratch` uses `recycler.CappedPool[*bytes.Buffer]` (256 KiB)
+  for buffers and a plain `recycler.Pool[*bytes.Reader]` for readers; the
   `poolGet` helper is gone. The "Why core, not kernel" rationale is revised —
   only the mechanism migrated; the 256 KiB codec threshold stays in core.
 - `service/logger` (recordPool) and `service/logger/middleware/async` (sink
-  pool) consume `recycler.Recycler`; reset stays consumer-side.
+  pool) consume `recycler.Pool`; reset stays consumer-side.
 - The IFACE-PLUGIN convention (kernel exported types are interfaces) no longer
   applies to `recycler`: it is the first kernel primitive shipped as concrete
   structs by deliberate choice.

--- a/docs/adr/CLAUDE.md
+++ b/docs/adr/CLAUDE.md
@@ -18,7 +18,7 @@ Architecture Decision Records. Each ADR captures one cross-cutting decision (lay
 | `0007-sdk-release-and-versioning.md` | Impact-driven patch tags `pkg/<major>/vX.Y.Z` + docs versioning from tag snapshots | Accepted |
 | `0008-readme-from-code-generation.md` | `README.md` generated from Go doc comments (gomarkdoc) | Accepted |
 | `0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible; release tags the whole module chain | Accepted; mechanism implemented |
-| `0010-kernel-recycler-primitive.md` | Generic `recycler.Recycler[T]` + `CappedRecycler[T]` object pools; `buffer`/`scratch` become consumers | Accepted |
+| `0010-kernel-recycler-primitive.md` | Generic `recycler.Pool[T]` + `CappedPool[T]` object pools; `buffer`/`scratch` become consumers | Accepted |
 
 ## Conventions
 

--- a/docs/adr/CLAUDE.md
+++ b/docs/adr/CLAUDE.md
@@ -18,6 +18,7 @@ Architecture Decision Records. Each ADR captures one cross-cutting decision (lay
 | `0007-sdk-release-and-versioning.md` | Impact-driven patch tags `pkg/<major>/vX.Y.Z` + docs versioning from tag snapshots | Accepted |
 | `0008-readme-from-code-generation.md` | `README.md` generated from Go doc comments (gomarkdoc) | Accepted |
 | `0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible; release tags the whole module chain | Accepted; mechanism implemented |
+| `0010-kernel-recycler-primitive.md` | Generic `recycler.Recycler[T]` + `CappedRecycler[T]` object pools; `buffer`/`scratch` become consumers | Accepted |
 
 ## Conventions
 

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -15,6 +15,15 @@
     },
     {
       "type": "feat",
+      "scope": "kernel",
+      "breaking": false,
+      "summary": "add CappedRecycler[T] (reset-on-Put + cap-discard)",
+      "sha": "d75717b61fa714072a6908f4184dbdb9000cc3e8",
+      "short": "d75717b",
+      "date": "2026-05-25T14:30:02+02:00"
+    },
+    {
+      "type": "feat",
       "scope": "release+docs",
       "breaking": false,
       "summary": "impact-driven patch tags + versioned docs (ADR 0007) (#29)",
@@ -30,15 +39,6 @@
       "sha": "45ab9fb51b8bf4b30f4c970a3f64b8a2dc295398",
       "short": "45ab9fb",
       "date": "2026-05-20T13:31:25+02:00"
-    },
-    {
-      "type": "feat",
-      "scope": "logger",
-      "breaking": false,
-      "summary": "v2 zero-alloc multi-sink architecture (#12)",
-      "sha": "7fd4c5c4f6d2dafeb70fdd4f75dac0328bc57437",
-      "short": "7fd4c5c",
-      "date": "2026-04-23T15:13:58+02:00"
     }
   ]
 }

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,9 +1,27 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-25T09:57:29.782Z",
+  "generatedAt": "2026-05-25T12:58:52.169Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
+    {
+      "type": "feat",
+      "scope": "kernel",
+      "breaking": false,
+      "summary": "add CappedRecycler[T] (reset-on-Put + cap-discard)",
+      "sha": "ab004eeb25ad266b24bdbd478c1b6c6912d743d5",
+      "short": "ab004ee",
+      "date": "2026-05-25T14:41:44+02:00"
+    },
+    {
+      "type": "fix",
+      "scope": "docs",
+      "breaking": false,
+      "summary": "make npm test glob node-version-agnostic (#31)",
+      "sha": "dcff33ba199373bcc579168f287bd783aa5b3e1f",
+      "short": "dcff33b",
+      "date": "2026-05-25T09:59:30Z"
+    },
     {
       "type": "fix",
       "scope": "docs",
@@ -12,15 +30,6 @@
       "sha": "5bff559252443700989d2507c57039696da9ded2",
       "short": "5bff559",
       "date": "2026-05-25T09:45:30Z"
-    },
-    {
-      "type": "feat",
-      "scope": "kernel",
-      "breaking": false,
-      "summary": "add CappedRecycler[T] (reset-on-Put + cap-discard)",
-      "sha": "d75717b61fa714072a6908f4184dbdb9000cc3e8",
-      "short": "d75717b",
-      "date": "2026-05-25T14:30:02+02:00"
     },
     {
       "type": "feat",

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,9 +1,18 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-25T12:58:52.169Z",
+  "generatedAt": "2026-05-25T20:06:04.965Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
+    {
+      "type": "fix",
+      "scope": "codec/scratch",
+      "breaking": false,
+      "summary": "release pooled bytes.Reader src before repooling",
+      "sha": "f9b474f865a492276cec2f579233fb24e4c542cc",
+      "short": "f9b474f",
+      "date": "2026-05-25T21:51:51+02:00"
+    },
     {
       "type": "feat",
       "scope": "kernel",
@@ -21,15 +30,6 @@
       "sha": "dcff33ba199373bcc579168f287bd783aa5b3e1f",
       "short": "dcff33b",
       "date": "2026-05-25T09:59:30Z"
-    },
-    {
-      "type": "fix",
-      "scope": "docs",
-      "breaking": false,
-      "summary": "base-path the portal for GitHub Pages project deploys + a11y/SEO (#30)",
-      "sha": "5bff559252443700989d2507c57039696da9ded2",
-      "short": "5bff559",
-      "date": "2026-05-25T09:45:30Z"
     },
     {
       "type": "feat",

--- a/internal/core/codec/scratch/BUILD.bazel
+++ b/internal/core/codec/scratch/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//:__subpackages__",
         "//internal/core:core_consumers",
     ],
+    deps = ["//internal/kernel/recycler"],
 )
 
 alias(

--- a/internal/core/codec/scratch/CLAUDE.md
+++ b/internal/core/codec/scratch/CLAUDE.md
@@ -11,12 +11,14 @@ truth for the cap-discard policy and the shared pool.
 
 ## Why core, not kernel
 
-`internal/kernel/buffer` already pools `*[]byte` at a 64 KiB cap for the
-logger's line buffers. The codec pool stores `*bytes.Buffer` at a 256 KiB
-cap — a different type and a different threshold — so it cannot reuse the
-kernel recycler. It lives in `core/codec` because it carries codec
-vocabulary (the 256 KiB codec-payload threshold) and is consumed only by
-`service/codec/*`, which sits below `core` in the layer graph.
+Since ADR 0010 the recycling MECHANISM is shared: `bufferPool` is a
+`recycler.CappedRecycler[*bytes.Buffer]` and `readerPool` a plain
+`recycler.Recycler[*bytes.Reader]`. What stays here is the codec VOCABULARY —
+the 256 KiB codec-payload threshold (`MaxRetainedBufBytes`) and the concrete
+`*bytes.Buffer` / `*bytes.Reader` types — which is why this package lives in
+`core/codec`, consumed only by `service/codec/*` below `core` in the layer
+graph. (Before ADR 0010 each codec hand-rolled its own `sync.Pool`; the
+mechanism was duplicated, the thresholds drifted.)
 
 ## Surface
 

--- a/internal/core/codec/scratch/CLAUDE.md
+++ b/internal/core/codec/scratch/CLAUDE.md
@@ -12,8 +12,8 @@ truth for the cap-discard policy and the shared pool.
 ## Why core, not kernel
 
 Since ADR 0010 the recycling MECHANISM is shared: `bufferPool` is a
-`recycler.CappedRecycler[*bytes.Buffer]` and `readerPool` a plain
-`recycler.Recycler[*bytes.Reader]`. What stays here is the codec VOCABULARY —
+`recycler.CappedPool[*bytes.Buffer]` and `readerPool` a plain
+`recycler.Pool[*bytes.Reader]`. What stays here is the codec VOCABULARY —
 the 256 KiB codec-payload threshold (`MaxRetainedBufBytes`) and the concrete
 `*bytes.Buffer` / `*bytes.Reader` types — which is why this package lives in
 `core/codec`, consumed only by `service/codec/*` below `core` in the layer

--- a/internal/core/codec/scratch/scratch.go
+++ b/internal/core/codec/scratch/scratch.go
@@ -36,7 +36,7 @@ var (
 	//: reset-on-Put (b.Reset) keeps the next caller's buffer clean; the
 	//: recycler discards before reset, so an over-cap buffer whose Bytes() the
 	//: caller still holds is orphaned untouched (detach contract preserved).
-	bufferPool = recycler.NewCappedRecycler[*bytes.Buffer](
+	bufferPool = recycler.NewCappedPool[*bytes.Buffer](
 		func() *bytes.Buffer { return new(bytes.Buffer) },
 		func(b *bytes.Buffer) { b.Reset() },
 		func(b *bytes.Buffer) int { return b.Cap() },
@@ -44,8 +44,8 @@ var (
 	)
 	//: readerPool recycles *bytes.Reader. A bytes.Reader is a fixed-size struct
 	//: repositioned by AcquireReader's Reset(src), so it needs neither
-	//: cap-discard nor reset-on-Put — a plain Recycler is the right fit.
-	readerPool = recycler.NewRecycler[*bytes.Reader](func() *bytes.Reader { return new(bytes.Reader) })
+	//: cap-discard nor reset-on-Put — a plain Pool is the right fit.
+	readerPool = recycler.NewPool[*bytes.Reader](func() *bytes.Reader { return new(bytes.Reader) })
 )
 
 // AcquireBuffer returns a clean, zero-length *bytes.Buffer from the shared
@@ -61,7 +61,7 @@ func AcquireBuffer() *bytes.Buffer {
 // Callers MUST NOT use buf — or any slice aliasing buf.Bytes() — after this
 // call; clone first if the encoded bytes must outlive the release.
 func ReleaseBuffer(buf *bytes.Buffer) {
-	//: nil-safe no-op — the generic CappedRecycler cannot nil-check *bytes.Buffer.
+	//: nil-safe no-op — the generic CappedPool cannot nil-check *bytes.Buffer.
 	if buf == nil {
 		//: nothing to recycle.
 		return

--- a/internal/core/codec/scratch/scratch.go
+++ b/internal/core/codec/scratch/scratch.go
@@ -90,6 +90,9 @@ func ReleaseReader(r *bytes.Reader) {
 		//: nothing to recycle.
 		return
 	}
+	//: drop the caller's src before pooling so an idle reader cannot keep the
+	//: backing array alive (Reset is re-applied with the real src on Acquire).
+	r.Reset(nil)
 	//: return the reader for reuse; the next AcquireReader repositions it.
 	readerPool.Put(r)
 }

--- a/internal/core/codec/scratch/scratch.go
+++ b/internal/core/codec/scratch/scratch.go
@@ -1,104 +1,95 @@
-// Package scratch provides shared, size-bounded recycling primitives for
-// the service codecs. Every codec that encodes into a transient
-// *bytes.Buffer previously declared its own sync.Pool, its own
-// 256 KiB cap-discard constant, and its own release helper — nine
-// byte-for-byte copies of the same logic. Centralising them here gives a
-// single source of truth for the cap-discard policy and a single shared
-// pool whose reuse rate is higher than nine independent pools (sync.Pool
-// is internally per-P sharded, so consolidation does not add contention).
+// Package scratch provides shared, size-bounded recycling primitives for the
+// service codecs. Every codec that encodes into a transient *bytes.Buffer
+// previously declared its own sync.Pool, its own 256 KiB cap-discard constant,
+// and its own release helper. Centralising them here gives a single source of
+// truth for the cap-discard policy and a single shared pool whose reuse rate
+// is higher than nine independent pools (sync.Pool is internally per-P
+// sharded, so consolidation does not add contention).
+//
+// The pooling MECHANISM lives in internal/kernel/recycler (ADR 0010); scratch
+// is a codec-domain consumer that keeps the 256 KiB threshold and the concrete
+// *bytes.Buffer / *bytes.Reader types here.
 //
 // Lifetime contract: a value returned by an Acquire* call is owned by the
-// caller until the matching Release* call. After Release the value — and
-// any slice aliasing it (e.g. buf.Bytes()) — MUST NOT be used; clone the
-// encoded bytes first if they need to outlive the release.
+// caller until the matching Release* call. After Release the value — and any
+// slice aliasing it (e.g. buf.Bytes()) — MUST NOT be used; clone the encoded
+// bytes first if they need to outlive the release.
 package scratch
 
 import (
 	"bytes"
-	"sync"
+
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
 // MaxRetainedBufBytes is the project-wide cap-discard threshold for pooled
-// *bytes.Buffer instances. A buffer whose capacity exceeds this is dropped
-// on release rather than re-pooled, so a one-off oversized payload cannot
-// pin a large allocation for the lifetime of the pool's GC window.
+// *bytes.Buffer instances. A buffer whose capacity exceeds this is dropped on
+// release rather than re-pooled, so a one-off oversized payload cannot pin a
+// large allocation for the lifetime of the pool's GC window.
 const MaxRetainedBufBytes int = 256 << 10
 
-// Shared recycling pools for the codecs. One shared pool per pooled type —
-// sync.Pool is internally per-P sharded, so consolidating across codecs
-// raises the reuse rate without adding contention.
+// Shared recycling pools for the codecs, backed by the kernel recycler. One
+// shared pool per pooled type — sync.Pool is internally per-P sharded, so
+// consolidating across codecs raises the reuse rate without adding contention.
 var (
-	//: bufferPool recycles *bytes.Buffer across every codec that encodes
-	//: into a transient buffer.
-	bufferPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
-
-	//: readerPool recycles *bytes.Reader for codecs that wrap caller input
-	//: in a reader for streaming decode (csv, msgpack). A bytes.Reader is a
-	//: fixed-size struct, so unlike bufferPool it needs no cap-discard.
-	readerPool = sync.Pool{New: func() any { return new(bytes.Reader) }}
+	//: bufferPool recycles *bytes.Buffer with cap-discard at MaxRetainedBufBytes.
+	//: reset-on-Put (b.Reset) keeps the next caller's buffer clean; the
+	//: recycler discards before reset, so an over-cap buffer whose Bytes() the
+	//: caller still holds is orphaned untouched (detach contract preserved).
+	bufferPool = recycler.NewCappedRecycler[*bytes.Buffer](
+		func() *bytes.Buffer { return new(bytes.Buffer) },
+		func(b *bytes.Buffer) { b.Reset() },
+		func(b *bytes.Buffer) int { return b.Cap() },
+		MaxRetainedBufBytes,
+	)
+	//: readerPool recycles *bytes.Reader. A bytes.Reader is a fixed-size struct
+	//: repositioned by AcquireReader's Reset(src), so it needs neither
+	//: cap-discard nor reset-on-Put — a plain Recycler is the right fit.
+	readerPool = recycler.NewRecycler[*bytes.Reader](func() *bytes.Reader { return new(bytes.Reader) })
 )
 
-// AcquireBuffer returns a reset *bytes.Buffer from the shared pool. The
-// caller owns it until ReleaseBuffer; the buffer is already Reset, so
-// callers append directly without re-resetting.
+// AcquireBuffer returns a clean, zero-length *bytes.Buffer from the shared
+// pool. The recycler reset the buffer on its previous Put, so callers append
+// directly without re-resetting. The caller owns it until ReleaseBuffer.
 func AcquireBuffer() *bytes.Buffer {
-	//: poolGet carries the pool-invariant guard (unit-tested directly).
-	buf := poolGet[*bytes.Buffer](&bufferPool)
-	//: start clean — pool may return a partially-filled buffer.
-	buf.Reset()
-	//: hand the clean buffer to the caller.
-	return buf
+	//: already reset on its previous Put — hand the clean buffer to the caller.
+	return bufferPool.Get()
 }
 
 // ReleaseBuffer returns buf to the shared pool unless its capacity exceeds
-// MaxRetainedBufBytes, in which case it is orphaned for the GC to reclaim.
+// MaxRetainedBufBytes, in which case the recycler orphans it for the GC.
 // Callers MUST NOT use buf — or any slice aliasing buf.Bytes() — after this
 // call; clone first if the encoded bytes must outlive the release.
 func ReleaseBuffer(buf *bytes.Buffer) {
-	//: cap-discard: drop oversized buffers, the GC reclaims them.
-	if buf.Cap() > MaxRetainedBufBytes {
-		//: orphan the buffer.
+	//: nil-safe no-op — the generic CappedRecycler cannot nil-check *bytes.Buffer.
+	if buf == nil {
+		//: nothing to recycle.
 		return
 	}
-	//: pool expects a clean buffer.
-	buf.Reset()
-	//: return for the next caller.
+	//: cap-discard + reset run inside the recycler (discard-before-reset).
 	bufferPool.Put(buf)
 }
 
 // AcquireReader returns a *bytes.Reader from the shared pool, reset to read
-// from src. The caller owns it until ReleaseReader. src must stay alive and
+// from src. The caller owns it until ReleaseReader; src must stay alive and
 // unmodified for as long as the reader is used.
 func AcquireReader(src []byte) *bytes.Reader {
-	//: poolGet carries the pool-invariant guard (unit-tested directly).
-	r := poolGet[*bytes.Reader](&readerPool)
-	//: point the reader at src and rewind its cursor.
+	//: borrow a pooled reader from the recycler.
+	r := readerPool.Get()
+	//: Reset needs the runtime src, so the reposition stays consumer-side here.
 	r.Reset(src)
 	//: hand the positioned reader to the caller.
 	return r
 }
 
-// ReleaseReader returns r to the shared pool. A bytes.Reader is fixed-size,
-// so there is no cap-discard. Callers MUST NOT use r after this call.
+// ReleaseReader returns r to the shared pool. A bytes.Reader is fixed-size, so
+// there is no cap-discard. Callers MUST NOT use r after this call.
 func ReleaseReader(r *bytes.Reader) {
-	//: no cap check needed — the struct never grows.
-	readerPool.Put(r)
-}
-
-// poolGet pops a value from p and asserts it to T — the type p's New func
-// guarantees. Extracted from the Acquire* functions so the invariant guard
-// is unit-testable (via a poisoned local pool, without disturbing the
-// package pools); a future break panics loudly rather than nil-dereferencing
-// downstream. Taking *sync.Pool (not any) keeps the assertion off a
-// narrowable parameter.
-func poolGet[T any](p *sync.Pool) T {
-	//: assert the pooled value to the type p's New func guarantees.
-	v, ok := p.Get().(T)
-	//: invariant broken — a pool only ever holds the type its New builds.
-	if !ok {
-		//: fail loud rather than nil-deref downstream.
-		panic("internal/core/codec/scratch: pool yielded unexpected type")
+	//: nil-safe no-op so callers can defer ReleaseReader unconditionally.
+	if r == nil {
+		//: nothing to recycle.
+		return
 	}
-	//: hand back the asserted value.
-	return v
+	//: return the reader for reuse; the next AcquireReader repositions it.
+	readerPool.Put(r)
 }

--- a/internal/core/codec/scratch/scratch_external_test.go
+++ b/internal/core/codec/scratch/scratch_external_test.go
@@ -34,7 +34,8 @@ func TestAcquireBuffer(t *testing.T) {
 		if got == nil {
 			t.Fatalf("%s: AcquireBuffer returned nil", tc.name)
 		}
-		//: AcquireBuffer Resets before returning, so length is always zero.
+		//: reset-on-Put cleans the buffer at ReleaseBuffer, so a re-acquired
+		//: buffer is always zero-length — no stale content leaks across uses.
 		if got.Len() != 0 {
 			t.Errorf("%s: buffer not clean: len=%d", tc.name, got.Len())
 		}

--- a/internal/core/codec/scratch/scratch_internal_test.go
+++ b/internal/core/codec/scratch/scratch_internal_test.go
@@ -1,35 +1,29 @@
 package scratch
 
-import (
-	"bytes"
-	"sync"
-	"testing"
-)
+import "testing"
 
-// Test_bufferPool_New verifies the pool's New factory yields a usable,
-// empty *bytes.Buffer — the invariant AcquireBuffer's type assertion (and
-// its panic guard) relies on. Exercised white-box because bufferPool is
-// unexported.
-func Test_bufferPool_New(t *testing.T) {
+// Test_bufferPool_recyclesCleanBuffer verifies the package-level bufferPool
+// (unexported) hands out a clean, zero-length *bytes.Buffer — the invariant
+// AcquireBuffer relies on. White-box because bufferPool is unexported.
+func Test_bufferPool_recyclesCleanBuffer(t *testing.T) {
 	t.Parallel()
 	type tc struct {
 		name string
 	}
 	tests := []tc{
-		{"new yields empty buffer"},
+		{"get yields an empty buffer"},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		//: the New factory is what guarantees Get always returns *bytes.Buffer.
-		v := bufferPool.New()
-		//: the type the whole package contract depends on.
-		buf, ok := v.(*bytes.Buffer)
-		if !ok {
-			t.Fatalf("%s: New yielded %T, want *bytes.Buffer", tc.name, v)
+		//: Get drives the recycler factory on a cold pool.
+		buf := bufferPool.Get()
+		if buf == nil {
+			t.Fatalf("%s: bufferPool.Get returned nil", tc.name)
+			return
 		}
-		//: a freshly built buffer must be empty.
+		//: a recycled or freshly built buffer must be empty.
 		if buf.Len() != 0 {
-			t.Errorf("%s: New buffer not empty: len=%d", tc.name, buf.Len())
+			t.Errorf("%s: buffer not empty: len=%d", tc.name, buf.Len())
 		}
 	}
 	for _, tc := range tests {
@@ -37,34 +31,21 @@ func Test_bufferPool_New(t *testing.T) {
 	}
 }
 
-// Test_poolGet covers both branches of the pool-invariant guard: the
-// nominal type-match pass-through and the panic on a pool whose New yields
-// the wrong type. Each case uses its own local *sync.Pool so the package
-// pools are never disturbed and the test stays parallel-safe.
-func Test_poolGet(t *testing.T) {
+// Test_readerPool_recyclesReader verifies the package-level readerPool
+// (unexported) hands out a usable *bytes.Reader.
+func Test_readerPool_recyclesReader(t *testing.T) {
 	t.Parallel()
 	type tc struct {
-		name      string
-		newFn     func() any
-		wantPanic bool
+		name string
 	}
 	tests := []tc{
-		{"valid buffer", func() any { return new(bytes.Buffer) }, false},
-		{"wrong type panics", func() any { return "not a buffer" }, true},
+		{"get yields a reader"},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		//: a local pool isolates the assertion from the package pools.
-		p := &sync.Pool{New: tc.newFn}
-		//: recover converts the expected panic into an assertion.
-		defer func() {
-			if (recover() != nil) != tc.wantPanic {
-				t.Errorf("%s: panicked != want %v", tc.name, tc.wantPanic)
-			}
-		}()
-		//: a non-panicking call must hand back a usable value.
-		if got := poolGet[*bytes.Buffer](p); !tc.wantPanic && got == nil {
-			t.Errorf("%s: got nil", tc.name)
+		//: Get drives the recycler factory on a cold pool.
+		if r := readerPool.Get(); r == nil {
+			t.Errorf("%s: readerPool.Get returned nil", tc.name)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/kernel/CLAUDE.md
+++ b/internal/kernel/CLAUDE.md
@@ -10,7 +10,8 @@ The SDK's lowest layer: **stdlib-only AND generic** primitives. A package qualif
 | Package | Purpose | Code range |
 |---|---|---|
 | `errs/` | SDK-wide typed error + dotted-quad registry (ADR 0005) | 1000-1099 (meta-codes, documentary only) |
-| `buffer/` | `sync.Pool` of `[]byte` + generic `Recycler[T]` for zero-alloc reuse | 1200-1299 (reserved) |
+| `recycler/` | generic `Recycler[T]` + `CappedRecycler[T]` object pools (ADR 0010) | (none — panics on programmer error) |
+| `buffer/` | `sync.Pool` of `[]byte` — a `recycler.CappedRecycler[*[]byte]` specialisation | 1200-1299 (reserved) |
 | `clock/` | `Clock` interface (`Now` + `Since`) for testable time | 1300-1399 (reserved) |
 | `ring/` | SPSC lock-free bounded queue (ADR 0006) | 1400-1499 (RING_FULL / RING_EMPTY / RING_CAP_ZERO emit today) |
 
@@ -32,7 +33,8 @@ As of the 2026-04-19 audit (extended by ADR 0006 to admit `ring`):
 
 - `errs` stays — every layer of the SDK uses typed errors, including kernel itself. Meta-infrastructure.
 - `clock` stays — textbook generic time abstraction.
-- `buffer` stays — byte-pool + `Recycler[T]` are generic even though `service/logger` is the heaviest consumer today (any future codec stream, HTTP body encoder, or metrics line writer can reuse them).
+- `recycler` admitted by ADR 0010 — `Recycler[T]` + `CappedRecycler[T]` are textbook generic object pools (reuse + reset + cap-discard). Any byte buffer, codec stream, HTTP body encoder, or metrics line writer can reuse the mechanism; the thresholds stay with the consumers.
+- `buffer` stays — the `[]byte` pool is generic even though `service/logger` is the heaviest consumer today. Since ADR 0010 it is a thin specialisation over `recycler.CappedRecycler[*[]byte]` (the generic `Recycler[T]` moved to `recycler`).
 - `ring` admitted by ADR 0006 — SPSC bounded queue is a textbook generic primitive. Logger's async middleware is the only consumer today; metrics batchers and codec stream pipelines are obvious future users.
 
 ## Conventions unique to kernel
@@ -40,7 +42,7 @@ As of the 2026-04-19 audit (extended by ADR 0006 to admit `ring`):
 1. **Import-only-stdlib.** Kernel packages MAY import each other (e.g. `ring` imports `errs` for its sentinels) but MUST NOT reach into `core/*` or `service/*`. No package outside of `errs` may use `fmt.Errorf` / `errors.New` in production code.
 2. **`errs` self-reference.** The `errs` package uses its own meta-codes 0.0.0.1..6 as documentary identifiers for Define-time validation failures — they are never instantiated as `*Error` sentinels.
 3. **No domain vocabulary in public APIs.** No `User`, `Request`, `Log`, `Entity` in type names. `Queue[T]`, `Recycler[T]`, `Clock`, `Error` all pass.
-4. **IFACE-PLUGIN marker.** Constructors returning an interface backed by an unexported struct (`buffer.NewRecycler`, `ring.New`) tag their interface with the `// IFACE-PLUGIN:` comment so ktn-linter recognises the swap-able-implementation pattern.
+4. **IFACE-PLUGIN marker.** Constructors returning an interface backed by an unexported struct (`ring.New`) tag their interface with the `// IFACE-PLUGIN:` comment so ktn-linter recognises the swap-able-implementation pattern. **Exception:** `recycler` ships concrete structs (`Recycler[T]` / `CappedRecycler[T]`) by deliberate choice (ADR 0010) — a single-impl interface there was over-abstraction; its `KTN-STRUCT-ROLE` exemption is scoped in `.ktn-linter.yaml`.
 
 ## Do NOT
 

--- a/internal/kernel/CLAUDE.md
+++ b/internal/kernel/CLAUDE.md
@@ -10,8 +10,8 @@ The SDK's lowest layer: **stdlib-only AND generic** primitives. A package qualif
 | Package | Purpose | Code range |
 |---|---|---|
 | `errs/` | SDK-wide typed error + dotted-quad registry (ADR 0005) | 1000-1099 (meta-codes, documentary only) |
-| `recycler/` | generic `Recycler[T]` + `CappedRecycler[T]` object pools (ADR 0010) | (none — panics on programmer error) |
-| `buffer/` | `sync.Pool` of `[]byte` — a `recycler.CappedRecycler[*[]byte]` specialisation | 1200-1299 (reserved) |
+| `recycler/` | generic `Pool[T]` + `CappedPool[T]` object pools (ADR 0010) | (none — panics on programmer error) |
+| `buffer/` | `sync.Pool` of `[]byte` — a `recycler.CappedPool[*[]byte]` specialisation | 1200-1299 (reserved) |
 | `clock/` | `Clock` interface (`Now` + `Since`) for testable time | 1300-1399 (reserved) |
 | `ring/` | SPSC lock-free bounded queue (ADR 0006) | 1400-1499 (RING_FULL / RING_EMPTY / RING_CAP_ZERO emit today) |
 
@@ -33,16 +33,16 @@ As of the 2026-04-19 audit (extended by ADR 0006 to admit `ring`):
 
 - `errs` stays — every layer of the SDK uses typed errors, including kernel itself. Meta-infrastructure.
 - `clock` stays — textbook generic time abstraction.
-- `recycler` admitted by ADR 0010 — `Recycler[T]` + `CappedRecycler[T]` are textbook generic object pools (reuse + reset + cap-discard). Any byte buffer, codec stream, HTTP body encoder, or metrics line writer can reuse the mechanism; the thresholds stay with the consumers.
-- `buffer` stays — the `[]byte` pool is generic even though `service/logger` is the heaviest consumer today. Since ADR 0010 it is a thin specialisation over `recycler.CappedRecycler[*[]byte]` (the generic `Recycler[T]` moved to `recycler`).
+- `recycler` admitted by ADR 0010 — `Pool[T]` + `CappedPool[T]` are textbook generic object pools (reuse + reset + cap-discard). Any byte buffer, codec stream, HTTP body encoder, or metrics line writer can reuse the mechanism; the thresholds stay with the consumers.
+- `buffer` stays — the `[]byte` pool is generic even though `service/logger` is the heaviest consumer today. Since ADR 0010 it is a thin specialisation over `recycler.CappedPool[*[]byte]` (the generic `Pool[T]` moved to `recycler`).
 - `ring` admitted by ADR 0006 — SPSC bounded queue is a textbook generic primitive. Logger's async middleware is the only consumer today; metrics batchers and codec stream pipelines are obvious future users.
 
 ## Conventions unique to kernel
 
 1. **Import-only-stdlib.** Kernel packages MAY import each other (e.g. `ring` imports `errs` for its sentinels) but MUST NOT reach into `core/*` or `service/*`. No package outside of `errs` may use `fmt.Errorf` / `errors.New` in production code.
 2. **`errs` self-reference.** The `errs` package uses its own meta-codes 0.0.0.1..6 as documentary identifiers for Define-time validation failures — they are never instantiated as `*Error` sentinels.
-3. **No domain vocabulary in public APIs.** No `User`, `Request`, `Log`, `Entity` in type names. `Queue[T]`, `Recycler[T]`, `Clock`, `Error` all pass.
-4. **IFACE-PLUGIN marker.** Constructors returning an interface backed by an unexported struct (`ring.New`) tag their interface with the `// IFACE-PLUGIN:` comment so ktn-linter recognises the swap-able-implementation pattern. **Exception:** `recycler` ships concrete structs (`Recycler[T]` / `CappedRecycler[T]`) by deliberate choice (ADR 0010) — a single-impl interface there was over-abstraction; its `KTN-STRUCT-ROLE` exemption is scoped in `.ktn-linter.yaml`.
+3. **No domain vocabulary in public APIs.** No `User`, `Request`, `Log`, `Entity` in type names. `Queue[T]`, `Pool[T]`, `Clock`, `Error` all pass.
+4. **IFACE-PLUGIN marker.** Constructors returning an interface backed by an unexported struct (`ring.New`) tag their interface with the `// IFACE-PLUGIN:` comment so ktn-linter recognises the swap-able-implementation pattern. **Exception:** `recycler` ships concrete structs (`Pool[T]` / `CappedPool[T]`) by deliberate choice (ADR 0010) — a single-impl interface there was over-abstraction. The `sync.Pool`-style names carry the recognized "Pool" role suffix, so they pass `KTN-STRUCT-ROLE` natively — no linter exemption needed.
 
 ## Do NOT
 

--- a/internal/kernel/buffer/BUILD.bazel
+++ b/internal/kernel/buffer/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     srcs = ["buffer.go"],
     importpath = "github.com/kitsunium/sdk/internal/kernel/buffer",
     visibility = ["//internal/kernel:kernel_consumers"],
+    deps = ["//internal/kernel/recycler"],
 )
 
 alias(

--- a/internal/kernel/buffer/CLAUDE.md
+++ b/internal/kernel/buffer/CLAUDE.md
@@ -5,9 +5,9 @@
 
 A pooled `*[]byte` for zero-alloc formatting on hot paths. Stdlib-only,
 domain-neutral. Since ADR 0010 this is a thin **byte-slice specialisation over
-`recycler.CappedRecycler[*[]byte]`**: the recycling mechanism lives in
+`recycler.CappedPool[*[]byte]`**: the recycling mechanism lives in
 `internal/kernel/recycler`; the 64-KiB threshold and the `*[]byte` type live
-here. The generic `Recycler[T]` that used to share this package moved to
+here. The generic `Pool[T]` that used to share this package moved to
 `recycler`.
 
 ## Contents
@@ -22,7 +22,7 @@ here. The generic `Recycler[T]` that used to share this package moved to
   `sync.Pool`'s `any` payload on every trip — this is what keeps the hot path
   allocation-free. Callers `*bp = b` after growth to publish the resized slice.
 - **`Put(nil)` is a safe no-op.** Callers `defer Put(bp)` unconditionally. The
-  generic `CappedRecycler` cannot nil-check a pointer-like `T`, so the guard
+  generic `CappedPool` cannot nil-check a pointer-like `T`, so the guard
   lives in `Put`.
 - **Drop-on-oversize.** Buffers whose `cap > maxRetain` (64 KiB) are dropped on
   `Put` — implemented as the recycler's discard-before-reset.
@@ -31,8 +31,8 @@ here. The generic `Recycler[T]` that used to share this package moved to
 
 - Keep a reference to a buffer after `Put`. The pool may hand it to another
   goroutine immediately.
-- Reach for a typed object pool here — that is `recycler.Recycler[T]` /
-  `recycler.CappedRecycler[T]`.
+- Reach for a typed object pool here — that is `recycler.Pool[T]` /
+  `recycler.CappedPool[T]`.
 - Add `Sleep`, timer helpers, or anything time-shaped here — that's `clock/`.
 
 ## Verification

--- a/internal/kernel/buffer/CLAUDE.md
+++ b/internal/kernel/buffer/CLAUDE.md
@@ -1,31 +1,38 @@
-<!-- updated: 2026-05-18T14:30:00Z -->
+<!-- updated: 2026-05-25T00:00:00Z -->
 # internal/kernel/buffer/
 
 ## Purpose
 
-Two complementary zero-alloc-reuse primitives for hot paths. Stdlib-only, domain-neutral. Code range `1200-1299` reserved (no sentinels emitted today). Logger v2 entries, async middleware, and any future codec stream / metrics writer can plug into either primitive without re-paying allocation cost.
+A pooled `*[]byte` for zero-alloc formatting on hot paths. Stdlib-only,
+domain-neutral. Since ADR 0010 this is a thin **byte-slice specialisation over
+`recycler.CappedRecycler[*[]byte]`**: the recycling mechanism lives in
+`internal/kernel/recycler`; the 64-KiB threshold and the `*[]byte` type live
+here. The generic `Recycler[T]` that used to share this package moved to
+`recycler`.
 
 ## Contents
 
 | Primitive | Surface | Use case |
 |---|---|---|
 | Byte pool | `Get() *[]byte` / `Put(*[]byte)` | scratch buffer for line / byte formatting (1024-byte default cap, 64-KiB drop ceiling) |
-| `Recycler[T]` | `NewRecycler[T any](newFn func() T) Recycler[T]` returning `Get() T` / `Put(v T)` | recycle ANY pointer-sized typed object — event records, attr slices, scratch structs |
 
 ## Conventions
 
-- **Pool stores `*[]byte`, not `[]byte`.** Avoids boxing the slice header on every trip. Callers `*bp = b` after growth to publish the resized slice back.
-- **`Put(nil)` is a safe no-op.** Callers `defer Put(bp)` unconditionally.
-- **Drop-on-oversize.** Byte buffers whose `cap > maxRetain` (64 KiB) are dropped on `Put` to keep pool memory bounded against rare large records.
-- **`NewRecycler(nil)` returns nil.** The constructor refuses a nil factory rather than panicking on first cache miss. Factory MUST return a non-zero T — the pool re-caches verbatim.
-- **IFACE-PLUGIN.** `Recycler[T]` is an interface backed by the unexported `objectBucket[T]`; the marker in `pool.go` lets ktn-linter recognise the swap-able backing.
-- **Steady-state benchmark.** `BenchmarkRecyclerSteadyState` reports 0 allocs/op once the pool is warm — the contract the logger v2 zero-alloc claim depends on.
+- **Pool stores `*[]byte`, not `[]byte`.** Avoids boxing the slice header into
+  `sync.Pool`'s `any` payload on every trip — this is what keeps the hot path
+  allocation-free. Callers `*bp = b` after growth to publish the resized slice.
+- **`Put(nil)` is a safe no-op.** Callers `defer Put(bp)` unconditionally. The
+  generic `CappedRecycler` cannot nil-check a pointer-like `T`, so the guard
+  lives in `Put`.
+- **Drop-on-oversize.** Buffers whose `cap > maxRetain` (64 KiB) are dropped on
+  `Put` — implemented as the recycler's discard-before-reset.
 
 ## Do NOT
 
-- Keep a reference to a value after `Put`. The pool may hand it to another goroutine immediately.
-- Call `Put` more than once on the same value.
-- Use `Recycler[T]` for value types larger than a few words — `sync.Pool` boxes everything via `any`, so non-pointer-sized T pays an allocation on every `Put`.
+- Keep a reference to a buffer after `Put`. The pool may hand it to another
+  goroutine immediately.
+- Reach for a typed object pool here — that is `recycler.Recycler[T]` /
+  `recycler.CappedRecycler[T]`.
 - Add `Sleep`, timer helpers, or anything time-shaped here — that's `clock/`.
 
 ## Verification
@@ -37,6 +44,9 @@ cd internal/kernel && GOWORK=off go test -race -cover ./buffer
 # coverage target: 90%+
 ```
 
-Tests: `buffer_external_test.go` (public contract: fresh length, oversize drop, nil-safety), `buffer_internal_test.go` (constants, `pool.New` capacity), `pool_external_test.go` (`NewRecycler` nil rejection, cold + warm paths, concurrent Get/Put under `-race`), `pool_internal_test.go` (`objectBucket.Get` happy + wrong-type fallback, `objectBucket.Put`).
+Tests: `buffer_external_test.go` (public contract: fresh length, oversize drop,
+nil-safety), `buffer_internal_test.go` (constants, fresh-buffer capacity via the
+package recycler). The zero-alloc steady-state of `Get`/`Put` is gated by
+`recycler`'s `TestZeroAllocInvariant` (race-off).
 
-A longer-form companion lives in `README.md` (typical-use snippets, benchmark numbers).
+A longer-form companion lives in `README.md`.

--- a/internal/kernel/buffer/buffer.go
+++ b/internal/kernel/buffer/buffer.go
@@ -1,7 +1,7 @@
 // Package buffer provides a pooled *[]byte for zero-alloc formatting in hot
 // paths. Consumers acquire a reusable buffer via Get and return it via Put so
 // steady-state allocations tend toward zero. It is a thin byte-slice
-// specialisation over internal/kernel/recycler.CappedRecycler (ADR 0010): the
+// specialisation over internal/kernel/recycler.CappedPool (ADR 0010): the
 // recycling mechanism lives in recycler, the 64-KiB capacity threshold and the
 // *[]byte type live here.
 package buffer
@@ -17,12 +17,12 @@ const initialCap int = 1024
 // from retaining unbounded memory after a rare large log record.
 const maxRetain int = 64 * 1024
 
-// bytePool recycles *[]byte via the kernel CappedRecycler. Storing *[]byte
+// bytePool recycles *[]byte via the kernel CappedPool. Storing *[]byte
 // (rather than []byte) avoids boxing the slice header into sync.Pool's any
 // payload on every Put, which is what keeps the hot path allocation-free.
 // reset truncates length to zero; capOf reports cap so the recycler drops any
 // buffer grown past maxRetain (discard-before-reset).
-var bytePool = recycler.NewCappedRecycler[*[]byte](
+var bytePool = recycler.NewCappedPool[*[]byte](
 	func() *[]byte { return new(make([]byte, 0, initialCap)) },
 	func(b *[]byte) { *b = (*b)[:0] },
 	func(b *[]byte) int { return cap(*b) },
@@ -37,7 +37,7 @@ func Get() *[]byte {
 
 // Put returns a buffer to the pool after use; the recycler truncates its length
 // and drops it when cap exceeds maxRetain. A nil argument is a safe no-op so
-// call sites can always defer Put — the generic CappedRecycler cannot nil-check
+// call sites can always defer Put — the generic CappedPool cannot nil-check
 // a pointer-like T, so the guard lives here.
 func Put(b *[]byte) {
 	//: nil-safe no-op so callers can defer Put unconditionally.

--- a/internal/kernel/buffer/buffer.go
+++ b/internal/kernel/buffer/buffer.go
@@ -1,9 +1,12 @@
-// Package buffer provides a sync.Pool of []byte for zero-alloc formatting
-// in hot logging paths. Consumers acquire a reusable buffer via Get and
-// return it via Put so that steady-state allocations tend toward zero.
+// Package buffer provides a pooled *[]byte for zero-alloc formatting in hot
+// paths. Consumers acquire a reusable buffer via Get and return it via Put so
+// steady-state allocations tend toward zero. It is a thin byte-slice
+// specialisation over internal/kernel/recycler.CappedRecycler (ADR 0010): the
+// recycling mechanism lives in recycler, the 64-KiB capacity threshold and the
+// *[]byte type live here.
 package buffer
 
-import "sync"
+import "github.com/kitsunium/sdk/internal/kernel/recycler"
 
 // initialCap is the starting capacity (in bytes) handed out by the pool;
 // chosen to comfortably hold a single log line without a re-alloc.
@@ -14,41 +17,34 @@ const initialCap int = 1024
 // from retaining unbounded memory after a rare large log record.
 const maxRetain int = 64 * 1024
 
-// pool holds the reusable byte buffers; storing *[]byte (rather than []byte)
-// avoids boxing the slice header each time Put returns it to the pool.
-var pool = sync.Pool{
-	New: func() (b any) {
-		//: allocate a fresh zero-length buffer and return its address.
-		return new(make([]byte, 0, initialCap))
-	},
-}
+// bytePool recycles *[]byte via the kernel CappedRecycler. Storing *[]byte
+// (rather than []byte) avoids boxing the slice header into sync.Pool's any
+// payload on every Put, which is what keeps the hot path allocation-free.
+// reset truncates length to zero; capOf reports cap so the recycler drops any
+// buffer grown past maxRetain (discard-before-reset).
+var bytePool = recycler.NewCappedRecycler[*[]byte](
+	func() *[]byte { return new(make([]byte, 0, initialCap)) },
+	func(b *[]byte) { *b = (*b)[:0] },
+	func(b *[]byte) int { return cap(*b) },
+	maxRetain,
+)
 
 // Get borrows a reusable byte buffer with zero length and capacity >= initialCap.
 func Get() *[]byte {
-	//: fetch any available buffer from the pool; New guarantees a non-nil fallback.
-	raw := pool.Get()
-	//: comma-ok assertion — defensive even though New always returns *[]byte.
-	ptr, ok := raw.(*[]byte)
-	//: unexpected pool contents — allocate a fresh buffer rather than panic.
-	if !ok {
-		//: return a freshly allocated buffer with the standard capacity.
-		return new(make([]byte, 0, initialCap))
-	}
-	//: return the borrowed buffer pointer to the caller.
-	return ptr
+	//: delegate to the recycler; its factory guarantees a non-nil *[]byte.
+	return bytePool.Get()
 }
 
-// Put returns a buffer to the pool after use, resetting its length to zero.
-// Buffers that grew beyond maxRetain are dropped to keep pool memory bounded.
-// A nil argument is a safe no-op so call sites can always defer Put.
+// Put returns a buffer to the pool after use; the recycler truncates its length
+// and drops it when cap exceeds maxRetain. A nil argument is a safe no-op so
+// call sites can always defer Put — the generic CappedRecycler cannot nil-check
+// a pointer-like T, so the guard lives here.
 func Put(b *[]byte) {
-	//: short-circuit when the buffer is nil or oversized — both drop the entry.
-	if b == nil || cap(*b) > maxRetain {
-		//: skip recycling; let GC reclaim any allocation.
+	//: nil-safe no-op so callers can defer Put unconditionally.
+	if b == nil {
+		//: nothing to recycle; let any allocation fall to the GC.
 		return
 	}
-	//: reset logical length so the next Get sees an empty buffer.
-	*b = (*b)[:0]
-	//: hand the buffer back for reuse by a future Get.
-	pool.Put(b)
+	//: hand the buffer to the recycler (reset + cap-discard happen there).
+	bytePool.Put(b)
 }

--- a/internal/kernel/buffer/buffer_internal_test.go
+++ b/internal/kernel/buffer/buffer_internal_test.go
@@ -27,19 +27,18 @@ func TestInternalPoolAllocatesFreshBuffer(t *testing.T) {
 	tests := []struct {
 		name string
 	}{
-		{"pool.New returns a *[]byte at standard capacity"},
+		{"bytePool builds a *[]byte at standard capacity"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			raw := pool.New()
-			ptr, ok := raw.(*[]byte)
-			if !ok {
-				t.Fatalf("pool.New returned %T, want *[]byte", raw)
+			ptr := bytePool.Get()
+			if ptr == nil {
+				t.Fatal("bytePool.Get returned nil")
 				return
 			}
 			if cap(*ptr) < initialCap {
-				t.Errorf("pool.New cap = %d, want >= %d", cap(*ptr), initialCap)
+				t.Errorf("fresh buffer cap = %d, want >= %d", cap(*ptr), initialCap)
 			}
 		})
 	}

--- a/internal/kernel/recycler/BUILD.bazel
+++ b/internal/kernel/recycler/BUILD.bazel
@@ -4,7 +4,10 @@ package(default_visibility = ["//internal/kernel:kernel_consumers"])
 
 go_library(
     name = "recycler",
-    srcs = ["recycler.go"],
+    srcs = [
+        "capped.go",
+        "recycler.go",
+    ],
     importpath = "github.com/kitsunium/sdk/internal/kernel/recycler",
     visibility = ["//internal/kernel:kernel_consumers"],
 )
@@ -19,6 +22,7 @@ go_test(
     name = "recycler_test",
     size = "small",
     srcs = [
+        "capped_external_test.go",
         "recycler_external_test.go",
         "recycler_internal_test.go",
     ],

--- a/internal/kernel/recycler/BUILD.bazel
+++ b/internal/kernel/recycler/BUILD.bazel
@@ -3,26 +3,26 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 package(default_visibility = ["//internal/kernel:kernel_consumers"])
 
 go_library(
-    name = "buffer",
-    srcs = ["buffer.go"],
-    importpath = "github.com/kitsunium/sdk/internal/kernel/buffer",
+    name = "recycler",
+    srcs = ["recycler.go"],
+    importpath = "github.com/kitsunium/sdk/internal/kernel/recycler",
     visibility = ["//internal/kernel:kernel_consumers"],
 )
 
 alias(
     name = "go_default_library",
-    actual = ":buffer",
+    actual = ":recycler",
     visibility = ["//internal/kernel:kernel_consumers"],
 )
 
 go_test(
-    name = "buffer_test",
+    name = "recycler_test",
     size = "small",
     srcs = [
-        "buffer_external_test.go",
-        "buffer_internal_test.go",
+        "recycler_external_test.go",
+        "recycler_internal_test.go",
     ],
-    embed = [":buffer"],
+    embed = [":recycler"],
 )
 
 filegroup(

--- a/internal/kernel/recycler/BUILD.bazel
+++ b/internal/kernel/recycler/BUILD.bazel
@@ -24,9 +24,11 @@ go_test(
     srcs = [
         "capped_external_test.go",
         "recycler_external_test.go",
+        "recycler_integration_test.go",
         "recycler_internal_test.go",
     ],
     embed = [":recycler"],
+    deps = ["//internal/kernel/buffer"],
 )
 
 filegroup(

--- a/internal/kernel/recycler/CLAUDE.md
+++ b/internal/kernel/recycler/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 The SDK's generic object-recycling primitive. Stdlib-only, domain-neutral.
-`Recycler[T]` wraps a `sync.Pool` to recycle ANY pointer-sized typed object
+`Pool[T]` wraps a `sync.Pool` to recycle ANY pointer-sized typed object
 (event records, attr slices, scratch structs) without the boxing cost on
 Get/Put. The byte-slice pool (`internal/kernel/buffer`) and the codec scratch
 buffer pool (`internal/core/codec/scratch`) are built ON this primitive — the
@@ -14,15 +14,15 @@ mechanism lives here, the capacity thresholds stay with the consumers
 
 | Primitive | Surface | Use case |
 |---|---|---|
-| `Recycler[T]` | `NewRecycler[T any](newFn func() T)` → `Get() T` / `Put(v T)` | recycle typed objects; no reset |
-| `CappedRecycler[T]` | `NewCappedRecycler[T any](newFn, resetFn, capOfFn, maxCap)` → `Get`/`Put` | adds reset-on-Put + cap-discard |
+| `Pool[T]` | `NewPool[T any](newFn func() T)` → `Get() T` / `Put(v T)` | recycle typed objects; no reset |
+| `CappedPool[T]` | `NewCappedPool[T any](newFn, resetFn, capOfFn, maxCap)` → `Get`/`Put` | adds reset-on-Put + cap-discard |
 
 ## Conventions
 
-- **Recycler[T] has no reset.** Consumers that need cleanup either reset
+- **Pool[T] has no reset.** Consumers that need cleanup either reset
   before Put (logger `Builder.Send`, async `data[:0]`) or use
-  `CappedRecycler[T]`.
-- **CappedRecycler[T] is reset-on-Put + discard-before-reset.** Over-cap
+  `CappedPool[T]`.
+- **CappedPool[T] is reset-on-Put + discard-before-reset.** Over-cap
   values are orphaned (never reset, never repooled) — this preserves the
   codec scratch detach contract. Reset is NOT a memory wipe.
 - **Generic recyclers do NOT nil-check.** Public/package-level wrappers
@@ -34,7 +34,7 @@ mechanism lives here, the capacity thresholds stay with the consumers
 ## Do NOT
 
 - Keep a reference to a value after `Put`.
-- Use `Recycler[T]` for value types larger than a few words.
+- Use `Pool[T]` for value types larger than a few words.
 - Add worker pools, queues, metrics, policy objects, or lifecycle managers
   here — this is a primitive, not a framework (ADR 0010).
 

--- a/internal/kernel/recycler/CLAUDE.md
+++ b/internal/kernel/recycler/CLAUDE.md
@@ -40,7 +40,7 @@ mechanism lives here, the capacity thresholds stay with the consumers
 
 ## Verification
 
-```
+```sh
 bazel test --config=race //internal/kernel/recycler:recycler_test
 # zero-alloc gate runs HORS race (race instrumentation perturbs allocs):
 bazel test --config=pure //internal/kernel/recycler:recycler_test

--- a/internal/kernel/recycler/CLAUDE.md
+++ b/internal/kernel/recycler/CLAUDE.md
@@ -1,0 +1,47 @@
+# internal/kernel/recycler/
+
+## Purpose
+
+The SDK's generic object-recycling primitive. Stdlib-only, domain-neutral.
+`Recycler[T]` wraps a `sync.Pool` to recycle ANY pointer-sized typed object
+(event records, attr slices, scratch structs) without the boxing cost on
+Get/Put. The byte-slice pool (`internal/kernel/buffer`) and the codec scratch
+buffer pool (`internal/core/codec/scratch`) are built ON this primitive — the
+mechanism lives here, the capacity thresholds stay with the consumers
+(ADR 0010).
+
+## Contents
+
+| Primitive | Surface | Use case |
+|---|---|---|
+| `Recycler[T]` | `NewRecycler[T any](newFn func() T)` → `Get() T` / `Put(v T)` | recycle typed objects; no reset |
+| `CappedRecycler[T]` *(commit 3)* | `NewCappedRecycler[T any](newFn, resetFn, capOfFn, maxCap)` → `Get`/`Put` | adds reset-on-Put + cap-discard |
+
+## Conventions
+
+- **Recycler[T] has no reset.** Consumers that need cleanup either reset
+  before Put (logger `Builder.Send`, async `data[:0]`) or use
+  `CappedRecycler[T]`.
+- **CappedRecycler[T] is reset-on-Put + discard-before-reset.** Over-cap
+  values are orphaned (never reset, never repooled) — this preserves the
+  codec scratch detach contract. Reset is NOT a memory wipe.
+- **Generic recyclers do NOT nil-check.** Public/package-level wrappers
+  (`buffer.Put`, `scratch.ReleaseBuffer`) keep nil guards where nil is part
+  of their accepted API — a generic `T any` cannot nil-check.
+- **Pointer-like T only.** `sync.Pool` boxes everything via `any`; a
+  non-pointer-sized T pays an allocation on every Put.
+
+## Do NOT
+
+- Keep a reference to a value after `Put`.
+- Use `Recycler[T]` for value types larger than a few words.
+- Add worker pools, queues, metrics, policy objects, or lifecycle managers
+  here — this is a primitive, not a framework (ADR 0010).
+
+## Verification
+
+```
+bazel test --config=race //internal/kernel/recycler:recycler_test
+# zero-alloc gate runs HORS race (race instrumentation perturbs allocs):
+bazel test --config=pure //internal/kernel/recycler:recycler_test
+```

--- a/internal/kernel/recycler/CLAUDE.md
+++ b/internal/kernel/recycler/CLAUDE.md
@@ -15,7 +15,7 @@ mechanism lives here, the capacity thresholds stay with the consumers
 | Primitive | Surface | Use case |
 |---|---|---|
 | `Recycler[T]` | `NewRecycler[T any](newFn func() T)` → `Get() T` / `Put(v T)` | recycle typed objects; no reset |
-| `CappedRecycler[T]` *(commit 3)* | `NewCappedRecycler[T any](newFn, resetFn, capOfFn, maxCap)` → `Get`/`Put` | adds reset-on-Put + cap-discard |
+| `CappedRecycler[T]` | `NewCappedRecycler[T any](newFn, resetFn, capOfFn, maxCap)` → `Get`/`Put` | adds reset-on-Put + cap-discard |
 
 ## Conventions
 

--- a/internal/kernel/recycler/README.md
+++ b/internal/kernel/recycler/README.md
@@ -1,0 +1,21 @@
+# recycler
+
+Generic object-recycling primitive for the SDK kernel. Stdlib-only.
+
+```go
+import "github.com/kitsunium/sdk/internal/kernel/recycler"
+
+// Plain recycler — no reset; the consumer resets if it needs to.
+r := recycler.NewRecycler[*bytes.Buffer](func() *bytes.Buffer { return new(bytes.Buffer) })
+b := r.Get()
+// ... use b ...
+b.Reset()
+r.Put(b)
+```
+
+`Recycler[T]` recycles any pointer-sized typed object through a `sync.Pool`
+without boxing on the call path. `CappedRecycler[T]` (see CLAUDE.md) layers a
+reset-on-Put + capacity-discard policy on top, used by `internal/kernel/buffer`
+(64 KiB) and `internal/core/codec/scratch` (256 KiB).
+
+See ADR 0010 for the design rationale and the layering contract.

--- a/internal/kernel/recycler/README.md
+++ b/internal/kernel/recycler/README.md
@@ -6,15 +6,15 @@ Generic object-recycling primitive for the SDK kernel. Stdlib-only.
 import "github.com/kitsunium/sdk/internal/kernel/recycler"
 
 // Plain recycler — no reset; the consumer resets if it needs to.
-r := recycler.NewRecycler[*bytes.Buffer](func() *bytes.Buffer { return new(bytes.Buffer) })
+r := recycler.NewPool[*bytes.Buffer](func() *bytes.Buffer { return new(bytes.Buffer) })
 b := r.Get()
 // ... use b ...
 b.Reset()
 r.Put(b)
 ```
 
-`Recycler[T]` recycles any pointer-sized typed object through a `sync.Pool`
-without boxing on the call path. `CappedRecycler[T]` (see CLAUDE.md) layers a
+`Pool[T]` recycles any pointer-sized typed object through a `sync.Pool`
+without boxing on the call path. `CappedPool[T]` (see CLAUDE.md) layers a
 reset-on-Put + capacity-discard policy on top, used by `internal/kernel/buffer`
 (64 KiB) and `internal/core/codec/scratch` (256 KiB).
 

--- a/internal/kernel/recycler/capped.go
+++ b/internal/kernel/recycler/capped.go
@@ -1,0 +1,79 @@
+// Package recycler — CappedRecycler[T] layers a reset-on-Put + cap-discard
+// policy on top of the plain Recycler[T] declared in recycler.go.
+package recycler
+
+// CappedRecycler wraps a concrete *Recycler[T] and layers a cap-discard policy
+// on top: on Put, a value whose reported capacity exceeds maxCap is orphaned
+// (never reset, never repooled), otherwise it is reset then repooled.
+//
+// Discard happens BEFORE reset on purpose: it preserves the codec scratch
+// detach contract, where an over-cap buffer's backing bytes have been handed
+// to the caller and must not be touched. Reset is NOT a memory wipe — a
+// consumer recycling sensitive bytes must zero them itself before Put.
+//
+// Always used behind a pointer: the embedded *Recycler owns a non-copyable
+// sync.Pool.
+type CappedRecycler[T any] struct {
+	// inner is the composed plain recycler. Concrete (not an interface) so
+	// Get/Put stay inlinable on the hot path.
+	inner *Recycler[T]
+	// reset returns a value to its reusable zero state before it is repooled.
+	reset func(T)
+	// capOf reports the value's current capacity, compared against maxCap.
+	capOf func(T) int
+	// maxCap is the cap-discard threshold; values above it are orphaned.
+	maxCap int
+}
+
+// NewCappedRecycler returns a CappedRecycler[T]. newFn builds fresh values,
+// resetFn returns a value to its reusable state, and capOfFn reports a value's
+// capacity for the discard decision. All three functions are required and a
+// nil one panics. maxCap must be positive: a non-positive threshold would
+// orphan every value, silently turning the pool into a never-recycling
+// allocator, so it panics rather than degrade.
+func NewCappedRecycler[T any](newFn func() T, resetFn func(T), capOfFn func(T) int, maxCap int) *CappedRecycler[T] {
+	//: reset is mandatory — reset-on-Put is the whole reason this variant exists.
+	if resetFn == nil {
+		//: programmer error — fail fast at construction.
+		panic("recycler: nil reset function")
+	}
+	//: capOf is mandatory — the discard decision cannot run without it.
+	if capOfFn == nil {
+		//: programmer error — fail fast at construction.
+		panic("recycler: nil cap function")
+	}
+	//: a non-positive cap orphans everything → a pool that never recycles.
+	if maxCap <= 0 {
+		//: refuse the degenerate configuration loudly.
+		panic("recycler: max capacity must be positive")
+	}
+	//: compose the plain recycler concretely; NewRecycler validates newFn.
+	return &CappedRecycler[T]{
+		inner:  NewRecycler(newFn),
+		reset:  resetFn,
+		capOf:  capOfFn,
+		maxCap: maxCap,
+	}
+}
+
+// Get borrows a value of type T from the underlying recycler, invoking the
+// factory on a cache miss. Callers own it until they hand it back via Put.
+func (c *CappedRecycler[T]) Get() T {
+	//: delegate to the composed recycler's Get.
+	return c.inner.Get()
+}
+
+// Put returns v for reuse unless its capacity exceeds maxCap, in which case v
+// is orphaned (discard-before-reset: never reset, never repooled). Otherwise v
+// is reset then repooled. Callers MUST NOT touch v after Put returns.
+func (c *CappedRecycler[T]) Put(v T) {
+	//: discard oversized values BEFORE reset — orphan them for the GC.
+	if c.capOf(v) > c.maxCap {
+		//: over-cap: caller may still alias the bytes, so never reset/repool.
+		return
+	}
+	//: under cap — return the value to its reusable state.
+	c.reset(v)
+	//: hand the clean value back to the pool for the next Get.
+	c.inner.Put(v)
+}

--- a/internal/kernel/recycler/capped.go
+++ b/internal/kernel/recycler/capped.go
@@ -1,8 +1,8 @@
-// Package recycler — CappedRecycler[T] layers a reset-on-Put + cap-discard
-// policy on top of the plain Recycler[T] declared in recycler.go.
+// Package recycler — CappedPool[T] layers a reset-on-Put + cap-discard
+// policy on top of the plain Pool[T] declared in recycler.go.
 package recycler
 
-// CappedRecycler wraps a concrete *Recycler[T] and layers a cap-discard policy
+// CappedPool wraps a concrete *Pool[T] and layers a cap-discard policy
 // on top: on Put, a value whose reported capacity exceeds maxCap is orphaned
 // (never reset, never repooled), otherwise it is reset then repooled.
 //
@@ -11,12 +11,12 @@ package recycler
 // to the caller and must not be touched. Reset is NOT a memory wipe — a
 // consumer recycling sensitive bytes must zero them itself before Put.
 //
-// Always used behind a pointer: the embedded *Recycler owns a non-copyable
+// Always used behind a pointer: the embedded *Pool owns a non-copyable
 // sync.Pool.
-type CappedRecycler[T any] struct {
+type CappedPool[T any] struct {
 	// inner is the composed plain recycler. Concrete (not an interface) so
 	// Get/Put stay inlinable on the hot path.
-	inner *Recycler[T]
+	inner *Pool[T]
 	// reset returns a value to its reusable zero state before it is repooled.
 	reset func(T)
 	// capOf reports the value's current capacity, compared against maxCap.
@@ -25,13 +25,13 @@ type CappedRecycler[T any] struct {
 	maxCap int
 }
 
-// NewCappedRecycler returns a CappedRecycler[T]. newFn builds fresh values,
+// NewCappedPool returns a CappedPool[T]. newFn builds fresh values,
 // resetFn returns a value to its reusable state, and capOfFn reports a value's
 // capacity for the discard decision. All three functions are required and a
 // nil one panics. maxCap must be positive: a non-positive threshold would
 // orphan every value, silently turning the pool into a never-recycling
 // allocator, so it panics rather than degrade.
-func NewCappedRecycler[T any](newFn func() T, resetFn func(T), capOfFn func(T) int, maxCap int) *CappedRecycler[T] {
+func NewCappedPool[T any](newFn func() T, resetFn func(T), capOfFn func(T) int, maxCap int) *CappedPool[T] {
 	//: reset is mandatory — reset-on-Put is the whole reason this variant exists.
 	if resetFn == nil {
 		//: programmer error — fail fast at construction.
@@ -47,9 +47,9 @@ func NewCappedRecycler[T any](newFn func() T, resetFn func(T), capOfFn func(T) i
 		//: refuse the degenerate configuration loudly.
 		panic("recycler: max capacity must be positive")
 	}
-	//: compose the plain recycler concretely; NewRecycler validates newFn.
-	return &CappedRecycler[T]{
-		inner:  NewRecycler(newFn),
+	//: compose the plain recycler concretely; NewPool validates newFn.
+	return &CappedPool[T]{
+		inner:  NewPool(newFn),
 		reset:  resetFn,
 		capOf:  capOfFn,
 		maxCap: maxCap,
@@ -58,7 +58,7 @@ func NewCappedRecycler[T any](newFn func() T, resetFn func(T), capOfFn func(T) i
 
 // Get borrows a value of type T from the underlying recycler, invoking the
 // factory on a cache miss. Callers own it until they hand it back via Put.
-func (c *CappedRecycler[T]) Get() T {
+func (c *CappedPool[T]) Get() T {
 	//: delegate to the composed recycler's Get.
 	return c.inner.Get()
 }
@@ -66,7 +66,7 @@ func (c *CappedRecycler[T]) Get() T {
 // Put returns v for reuse unless its capacity exceeds maxCap, in which case v
 // is orphaned (discard-before-reset: never reset, never repooled). Otherwise v
 // is reset then repooled. Callers MUST NOT touch v after Put returns.
-func (c *CappedRecycler[T]) Put(v T) {
+func (c *CappedPool[T]) Put(v T) {
 	//: discard oversized values BEFORE reset — orphan them for the GC.
 	if c.capOf(v) > c.maxCap {
 		//: over-cap: caller may still alias the bytes, so never reset/repool.

--- a/internal/kernel/recycler/capped_external_test.go
+++ b/internal/kernel/recycler/capped_external_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 // capBox is a test value whose reported capacity and reset state are both
-// observable, so CappedRecycler's discard-before-reset policy can be asserted
+// observable, so CappedPool's discard-before-reset policy can be asserted
 // directly on a held reference.
 type capBox struct {
 	cap      int
 	wasReset bool
 }
 
-// newCappedTestRecycler builds a CappedRecycler over *capBox with the given
+// newCappedTestPool builds a CappedPool over *capBox with the given
 // threshold; reset flips wasReset, capOf reports the box's cap field.
-func newCappedTestRecycler(maxCap int) *recycler.CappedRecycler[*capBox] {
-	return recycler.NewCappedRecycler[*capBox](
+func newCappedTestPool(maxCap int) *recycler.CappedPool[*capBox] {
+	return recycler.NewCappedPool[*capBox](
 		func() *capBox { return &capBox{} },
 		func(b *capBox) { b.wasReset = true },
 		func(b *capBox) int { return b.cap },
@@ -25,10 +25,10 @@ func newCappedTestRecycler(maxCap int) *recycler.CappedRecycler[*capBox] {
 	)
 }
 
-// TestNewCappedRecycler covers the fail-fast constructor contract: nil
+// TestNewCappedPool covers the fail-fast constructor contract: nil
 // reset/capOf and a non-positive maxCap are programmer errors and panic; a
 // valid configuration returns without panicking.
-func TestNewCappedRecycler(t *testing.T) {
+func TestNewCappedPool(t *testing.T) {
 	t.Parallel()
 	mk := func() *capBox { return &capBox{} }
 	tests := []struct {
@@ -36,11 +36,11 @@ func TestNewCappedRecycler(t *testing.T) {
 		runner    func()
 		wantPanic bool
 	}{
-		{"nil reset panics", func() { recycler.NewCappedRecycler[*capBox](mk, nil, func(*capBox) int { return 0 }, 8) }, true},
-		{"nil capOf panics", func() { recycler.NewCappedRecycler[*capBox](mk, func(*capBox) {}, nil, 8) }, true},
-		{"zero maxCap panics", func() { recycler.NewCappedRecycler[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, 0) }, true},
-		{"negative maxCap panics", func() { recycler.NewCappedRecycler[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, -1) }, true},
-		{"valid configuration does not panic", func() { newCappedTestRecycler(8) }, false},
+		{"nil reset panics", func() { recycler.NewCappedPool[*capBox](mk, nil, func(*capBox) int { return 0 }, 8) }, true},
+		{"nil capOf panics", func() { recycler.NewCappedPool[*capBox](mk, func(*capBox) {}, nil, 8) }, true},
+		{"zero maxCap panics", func() { recycler.NewCappedPool[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, 0) }, true},
+		{"negative maxCap panics", func() { recycler.NewCappedPool[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, -1) }, true},
+		{"valid configuration does not panic", func() { newCappedTestPool(8) }, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -57,8 +57,8 @@ func TestNewCappedRecycler(t *testing.T) {
 	}
 }
 
-// TestCappedRecycler_Get verifies Get hands out a usable value on a cold pool.
-func TestCappedRecycler_Get(t *testing.T) {
+// TestCappedPool_Get verifies Get hands out a usable value on a cold pool.
+func TestCappedPool_Get(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
@@ -68,7 +68,7 @@ func TestCappedRecycler_Get(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := newCappedTestRecycler(8)
+			r := newCappedTestPool(8)
 			if got := r.Get(); got == nil {
 				t.Fatal("Get returned nil on cold pool")
 			}
@@ -76,10 +76,10 @@ func TestCappedRecycler_Get(t *testing.T) {
 	}
 }
 
-// TestCappedRecycler_Put verifies the discard-before-reset policy: a value at
+// TestCappedPool_Put verifies the discard-before-reset policy: a value at
 // or under maxCap is reset (and repooled); an over-cap value is orphaned
 // WITHOUT reset (so a caller still aliasing its bytes is not clobbered).
-func TestCappedRecycler_Put(t *testing.T) {
+func TestCappedPool_Put(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
@@ -93,7 +93,7 @@ func TestCappedRecycler_Put(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := newCappedTestRecycler(8)
+			r := newCappedTestPool(8)
 			b := &capBox{cap: tc.cap}
 			r.Put(b)
 			//: reset runs synchronously inside Put on the under-cap path only;

--- a/internal/kernel/recycler/capped_external_test.go
+++ b/internal/kernel/recycler/capped_external_test.go
@@ -1,0 +1,106 @@
+package recycler_test
+
+import (
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
+)
+
+// capBox is a test value whose reported capacity and reset state are both
+// observable, so CappedRecycler's discard-before-reset policy can be asserted
+// directly on a held reference.
+type capBox struct {
+	cap      int
+	wasReset bool
+}
+
+// newCappedTestRecycler builds a CappedRecycler over *capBox with the given
+// threshold; reset flips wasReset, capOf reports the box's cap field.
+func newCappedTestRecycler(maxCap int) *recycler.CappedRecycler[*capBox] {
+	return recycler.NewCappedRecycler[*capBox](
+		func() *capBox { return &capBox{} },
+		func(b *capBox) { b.wasReset = true },
+		func(b *capBox) int { return b.cap },
+		maxCap,
+	)
+}
+
+// TestNewCappedRecycler covers the fail-fast constructor contract: nil
+// reset/capOf and a non-positive maxCap are programmer errors and panic; a
+// valid configuration returns without panicking.
+func TestNewCappedRecycler(t *testing.T) {
+	t.Parallel()
+	mk := func() *capBox { return &capBox{} }
+	tests := []struct {
+		name      string
+		runner    func()
+		wantPanic bool
+	}{
+		{"nil reset panics", func() { recycler.NewCappedRecycler[*capBox](mk, nil, func(*capBox) int { return 0 }, 8) }, true},
+		{"nil capOf panics", func() { recycler.NewCappedRecycler[*capBox](mk, func(*capBox) {}, nil, 8) }, true},
+		{"zero maxCap panics", func() { recycler.NewCappedRecycler[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, 0) }, true},
+		{"negative maxCap panics", func() { recycler.NewCappedRecycler[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, -1) }, true},
+		{"valid configuration does not panic", func() { newCappedTestRecycler(8) }, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				//: capture the recovered state once and match the expectation.
+				got := recover() != nil
+				if got != tc.wantPanic {
+					t.Errorf("panic = %v, want %v", got, tc.wantPanic)
+				}
+			}()
+			tc.runner()
+		})
+	}
+}
+
+// TestCappedRecycler_Get verifies Get hands out a usable value on a cold pool.
+func TestCappedRecycler_Get(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+	}{
+		{"cold pool builds via factory"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := newCappedTestRecycler(8)
+			if got := r.Get(); got == nil {
+				t.Fatal("Get returned nil on cold pool")
+			}
+		})
+	}
+}
+
+// TestCappedRecycler_Put verifies the discard-before-reset policy: a value at
+// or under maxCap is reset (and repooled); an over-cap value is orphaned
+// WITHOUT reset (so a caller still aliasing its bytes is not clobbered).
+func TestCappedRecycler_Put(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		cap       int
+		wantReset bool
+	}{
+		{"under cap is reset and repooled", 4, true},
+		{"at cap is reset and repooled", 8, true},
+		{"over cap is orphaned without reset", 9, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := newCappedTestRecycler(8)
+			b := &capBox{cap: tc.cap}
+			r.Put(b)
+			//: reset runs synchronously inside Put on the under-cap path only;
+			//: the over-cap path returns before reset, leaving wasReset false.
+			if b.wasReset != tc.wantReset {
+				t.Errorf("wasReset = %v, want %v", b.wasReset, tc.wantReset)
+			}
+		})
+	}
+}

--- a/internal/kernel/recycler/capped_external_test.go
+++ b/internal/kernel/recycler/capped_external_test.go
@@ -31,28 +31,35 @@ func newCappedTestPool(maxCap int) *recycler.CappedPool[*capBox] {
 func TestNewCappedPool(t *testing.T) {
 	t.Parallel()
 	mk := func() *capBox { return &capBox{} }
-	tests := []struct {
+	type tc struct {
 		name      string
 		runner    func()
 		wantPanic bool
-	}{
+	}
+	tests := []tc{
 		{"nil reset panics", func() { recycler.NewCappedPool[*capBox](mk, nil, func(*capBox) int { return 0 }, 8) }, true},
 		{"nil capOf panics", func() { recycler.NewCappedPool[*capBox](mk, func(*capBox) {}, nil, 8) }, true},
 		{"zero maxCap panics", func() { recycler.NewCappedPool[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, 0) }, true},
 		{"negative maxCap panics", func() { recycler.NewCappedPool[*capBox](mk, func(*capBox) {}, func(*capBox) int { return 0 }, -1) }, true},
 		{"valid configuration does not panic", func() { newCappedTestPool(8) }, false},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the deferred recover matches the case's panic expectation.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		defer func() {
+			//: capture the recovered state once and match the expectation.
+			got := recover() != nil
+			if got != tc.wantPanic {
+				t.Errorf("panic = %v, want %v", got, tc.wantPanic)
+			}
+		}()
+		tc.runner()
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			defer func() {
-				//: capture the recovered state once and match the expectation.
-				got := recover() != nil
-				if got != tc.wantPanic {
-					t.Errorf("panic = %v, want %v", got, tc.wantPanic)
-				}
-			}()
-			tc.runner()
+			runCase(t, tc)
 		})
 	}
 }
@@ -60,18 +67,23 @@ func TestNewCappedPool(t *testing.T) {
 // TestCappedPool_Get verifies Get hands out a usable value on a cold pool.
 func TestCappedPool_Get(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name string
-	}{
+	type tc struct{ name string }
+	tests := []tc{
 		{"cold pool builds via factory"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; a cold pool must still hand out a non-nil value.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		r := newCappedTestPool(8)
+		if got := r.Get(); got == nil {
+			t.Fatal("Get returned nil on cold pool")
+		}
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := newCappedTestPool(8)
-			if got := r.Get(); got == nil {
-				t.Fatal("Get returned nil on cold pool")
-			}
+			runCase(t, tc)
 		})
 	}
 }
@@ -81,26 +93,32 @@ func TestCappedPool_Get(t *testing.T) {
 // WITHOUT reset (so a caller still aliasing its bytes is not clobbered).
 func TestCappedPool_Put(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name      string
 		cap       int
 		wantReset bool
-	}{
+	}
+	tests := []tc{
 		{"under cap is reset and repooled", 4, true},
 		{"at cap is reset and repooled", 8, true},
 		{"over cap is orphaned without reset", 9, false},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; reset runs inside Put on the under-cap path only.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		r := newCappedTestPool(8)
+		b := &capBox{cap: tc.cap}
+		r.Put(b)
+		//: the over-cap path returns before reset, leaving wasReset false.
+		if b.wasReset != tc.wantReset {
+			t.Errorf("wasReset = %v, want %v", b.wasReset, tc.wantReset)
+		}
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := newCappedTestPool(8)
-			b := &capBox{cap: tc.cap}
-			r.Put(b)
-			//: reset runs synchronously inside Put on the under-cap path only;
-			//: the over-cap path returns before reset, leaving wasReset false.
-			if b.wasReset != tc.wantReset {
-				t.Errorf("wasReset = %v, want %v", b.wasReset, tc.wantReset)
-			}
+			runCase(t, tc)
 		})
 	}
 }

--- a/internal/kernel/recycler/recycler.go
+++ b/internal/kernel/recycler/recycler.go
@@ -1,10 +1,13 @@
-// Package buffer — provides Recycler[T any], a generic typed pool
-// contract backed by sync.Pool. Callers can recycle ANY pointer-sized object
-// (event records, attribute slices, scratch structs) without paying the
-// boxing cost on Get/Put. The byte-slice pool exposed by buffer.Get /
-// buffer.Put remains the idiomatic choice for raw scratch space; Recycler[T]
-// complements it for typed objects whose construction is non-trivial.
-package buffer
+// Package recycler provides Recycler[T any], a generic typed object pool
+// backed by sync.Pool. Callers recycle ANY pointer-sized object (event
+// records, attribute slices, scratch structs) without paying the boxing cost
+// on Get/Put. Stdlib-only and domain-neutral: any byte buffer, codec stream,
+// HTTP body encoder, or metrics line writer can reuse it.
+//
+// The byte-slice pool (internal/kernel/buffer) and the codec scratch buffer
+// pool (internal/core/codec/scratch) are built ON this primitive; Recycler[T]
+// is the shared mechanism, the capacity thresholds stay with the consumers.
+package recycler
 
 import "sync"
 

--- a/internal/kernel/recycler/recycler.go
+++ b/internal/kernel/recycler/recycler.go
@@ -11,72 +11,55 @@ package recycler
 
 import "sync"
 
-// Recycler describes a typed object pool that hands out values of T from an
-// internal cache and accepts them back via Put for future reuse.
-// Implementations MUST be safe for concurrent use by multiple goroutines.
-type Recycler[T any] interface {
-	// Get returns a value of type T, possibly freshly built by the factory
-	// supplied at construction time. Callers own the returned value until
-	// they hand it back via Put.
-	Get() (v T)
-	// Put returns a value to the pool for future reuse. Callers MUST NOT
-	// retain a reference to v after Put returns; the pool may hand it to
-	// another goroutine immediately.
-	Put(v T)
+// Recycler is a concrete generic object pool over sync.Pool. It performs NO
+// reset — consumers that need cleanup either reset before Put (logger
+// Builder.Send, async data[:0]) or use CappedRecycler. Safe for concurrent
+// use. Always used behind a pointer: sync.Pool must not be copied.
+type Recycler[T any] struct {
+	// pool is the underlying sync.Pool holding the recycled values.
+	pool sync.Pool
 }
 
-// objectBucket is the default Recycler implementation backed by sync.Pool.
-type objectBucket[T any] struct {
-	// p is the underlying sync.Pool that holds the recycled values.
-	p sync.Pool
-	// new is the factory invoked when p.Get triggers a cache miss; it MUST
-	// return a non-zero T because the pool re-caches the value verbatim.
-	new func() T
-}
-
-// NewRecycler constructs a Recycler[T] backed by sync.Pool. The factory is
-// invoked exactly once per cache miss; its result is stored back in the pool
-// when Put is called for the corresponding Get.
-//
-// IFACE-PLUGIN: callers receive a Recycler[T] handle so the kernel can swap
-// the backing implementation (sync.Pool today, sharded buckets tomorrow)
-// without breaking call-site code; the concrete bucket type is unexported.
-func NewRecycler[T any](newFn func() T) Recycler[T] {
-	//: refuse a nil factory — sync.Pool.Get would panic on cache miss otherwise.
+// NewRecycler returns a Recycler[T] whose factory fires on every cache miss.
+// A nil factory is a programmer error and panics at construction rather than
+// deferring the panic to sync.Pool.Get on the first cache miss, far from the
+// offending call site.
+func NewRecycler[T any](newFn func() T) *Recycler[T] {
+	//: refuse a nil factory loudly at construction, not on first Get.
 	if newFn == nil {
-		//: documented contract: caller must supply a factory.
-		return nil
+		//: programmer error — fail fast at the call site.
+		panic("recycler: nil factory")
 	}
-	//: build the bucket with a thin closure that boxes the factory output for sync.Pool.
-	bucket := &objectBucket[T]{new: newFn}
-	bucket.p.New = func() (boxed any) {
+	//: build the recycler with a thin closure boxing the factory output for sync.Pool.
+	r := &Recycler[T]{}
+	r.pool.New = func() any {
 		//: invoke the caller's factory and hand its result to sync.Pool as any.
 		return newFn()
 	}
-	//: hand the typed bucket back to the caller as the public interface.
-	return bucket
+	//: hand the concrete recycler back to the caller.
+	return r
 }
 
-// Get borrows a value of type T from the bucket, invoking the factory on a
-// cache miss. The returned value MAY be a previously Put value or a freshly
-// built one — callers MUST treat it as opaquely owned until they Put it back.
-func (b *objectBucket[T]) Get() T {
-	//: ask sync.Pool for any cached value; New fires on miss to satisfy the call.
-	raw := b.p.Get()
-	//: comma-ok defends against the (impossible-by-contract) wrong-type case.
-	val, ok := raw.(T)
-	//: unexpected pool contents — fall back on a fresh factory invocation.
+// Get borrows a value of type T, invoking the factory on a cache miss. The
+// returned value MAY be a previously Put value or a freshly built one. The
+// comma-ok assertion is fail-loud: the pool only ever holds T (both New and
+// Put are typed), so a wrong-typed entry is an internal invariant break that
+// panics rather than silently masking it (mirrors core/codec/scratch.poolGet).
+func (r *Recycler[T]) Get() T {
+	//: the pool only ever holds T — comma-ok guards the invariant.
+	v, ok := r.pool.Get().(T)
+	//: a wrong-typed entry is impossible by contract; fail loud if it happens.
 	if !ok {
-		//: callers must never observe a zero T; rebuild rather than propagate it.
-		return b.new()
+		//: never mask a broken pool invariant behind a zero value.
+		panic("recycler: pool yielded unexpected type")
 	}
-	//: return the recycled (or freshly created) value to the caller.
-	return val
+	//: return the recycled or freshly built value.
+	return v
 }
 
-// Put returns a value to the bucket for future reuse. Callers MUST NOT touch v
-// after Put returns; the bucket may hand it to another goroutine immediately.
-func (b *objectBucket[T]) Put(v T) {
-	//: hand the value back to sync.Pool — boxing here is unavoidable but cheap.
-	b.p.Put(v)
+// Put returns v to the pool for future reuse. Callers MUST NOT touch v after
+// Put returns; the pool may hand it to another goroutine immediately.
+func (r *Recycler[T]) Put(v T) {
+	//: hand the value back to sync.Pool — boxing a pointer-sized T is alloc-free.
+	r.pool.Put(v)
 }

--- a/internal/kernel/recycler/recycler.go
+++ b/internal/kernel/recycler/recycler.go
@@ -1,37 +1,37 @@
-// Package recycler provides Recycler[T any], a generic typed object pool
+// Package recycler provides Pool[T any], a generic typed object pool
 // backed by sync.Pool. Callers recycle ANY pointer-sized object (event
 // records, attribute slices, scratch structs) without paying the boxing cost
 // on Get/Put. Stdlib-only and domain-neutral: any byte buffer, codec stream,
 // HTTP body encoder, or metrics line writer can reuse it.
 //
 // The byte-slice pool (internal/kernel/buffer) and the codec scratch buffer
-// pool (internal/core/codec/scratch) are built ON this primitive; Recycler[T]
+// pool (internal/core/codec/scratch) are built ON this primitive; Pool[T]
 // is the shared mechanism, the capacity thresholds stay with the consumers.
 package recycler
 
 import "sync"
 
-// Recycler is a concrete generic object pool over sync.Pool. It performs NO
+// Pool is a concrete generic object pool over sync.Pool. It performs NO
 // reset — consumers that need cleanup either reset before Put (logger
-// Builder.Send, async data[:0]) or use CappedRecycler. Safe for concurrent
+// Builder.Send, async data[:0]) or use CappedPool. Safe for concurrent
 // use. Always used behind a pointer: sync.Pool must not be copied.
-type Recycler[T any] struct {
+type Pool[T any] struct {
 	// pool is the underlying sync.Pool holding the recycled values.
 	pool sync.Pool
 }
 
-// NewRecycler returns a Recycler[T] whose factory fires on every cache miss.
+// NewPool returns a Pool[T] whose factory fires on every cache miss.
 // A nil factory is a programmer error and panics at construction rather than
 // deferring the panic to sync.Pool.Get on the first cache miss, far from the
 // offending call site.
-func NewRecycler[T any](newFn func() T) *Recycler[T] {
+func NewPool[T any](newFn func() T) *Pool[T] {
 	//: refuse a nil factory loudly at construction, not on first Get.
 	if newFn == nil {
 		//: programmer error — fail fast at the call site.
 		panic("recycler: nil factory")
 	}
 	//: build the recycler with a thin closure boxing the factory output for sync.Pool.
-	r := &Recycler[T]{}
+	r := &Pool[T]{}
 	r.pool.New = func() any {
 		//: invoke the caller's factory and hand its result to sync.Pool as any.
 		return newFn()
@@ -45,7 +45,7 @@ func NewRecycler[T any](newFn func() T) *Recycler[T] {
 // comma-ok assertion is fail-loud: the pool only ever holds T (both New and
 // Put are typed), so a wrong-typed entry is an internal invariant break that
 // panics rather than silently masking it (mirrors core/codec/scratch.poolGet).
-func (r *Recycler[T]) Get() T {
+func (r *Pool[T]) Get() T {
 	//: the pool only ever holds T — comma-ok guards the invariant.
 	v, ok := r.pool.Get().(T)
 	//: a wrong-typed entry is impossible by contract; fail loud if it happens.
@@ -59,7 +59,7 @@ func (r *Recycler[T]) Get() T {
 
 // Put returns v to the pool for future reuse. Callers MUST NOT touch v after
 // Put returns; the pool may hand it to another goroutine immediately.
-func (r *Recycler[T]) Put(v T) {
+func (r *Pool[T]) Put(v T) {
 	//: hand the value back to sync.Pool — boxing a pointer-sized T is alloc-free.
 	r.pool.Put(v)
 }

--- a/internal/kernel/recycler/recycler_external_test.go
+++ b/internal/kernel/recycler/recycler_external_test.go
@@ -13,10 +13,11 @@ import (
 // preservation through the underlying sync.Pool.
 func TestNewPool(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name   string
 		runner func(t *testing.T)
-	}{
+	}
+	tests := []tc{
 		{
 			name: "nil factory panics",
 			runner: func(t *testing.T) {
@@ -65,10 +66,16 @@ func TestNewPool(t *testing.T) {
 			},
 		},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; each runner owns its own recover where a panic is expected.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		tc.runner(t)
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.runner(t)
+			runCase(t, tc)
 		})
 	}
 }
@@ -77,35 +84,42 @@ func TestNewPool(t *testing.T) {
 // surface data races under -race; the pool's internal sync.Pool MUST cope.
 func TestPoolConcurrentGetPut(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name        string
 		goroutines  int
 		opsPerRoute int
-	}{
+	}
+	tests := []tc{
 		{"32 goroutines × 1024 ops", 32, 1024},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; every goroutine must complete all of its Get/Put ops.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		var ops atomic.Uint64
+		factory := func() *[64]byte { return &[64]byte{} }
+		r := recycler.NewPool[*[64]byte](factory)
+		var wg sync.WaitGroup
+		for range tc.goroutines {
+			wg.Go(func() {
+				for range tc.opsPerRoute {
+					v := r.Get()
+					r.Put(v)
+					ops.Add(1)
+				}
+			})
+		}
+		wg.Wait()
+		//: every goroutine MUST have completed all of its ops.
+		want := uint64(tc.goroutines * tc.opsPerRoute)
+		if ops.Load() != want {
+			t.Errorf("ops counter = %d, want %d", ops.Load(), want)
+		}
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			var ops atomic.Uint64
-			factory := func() *[64]byte { return &[64]byte{} }
-			r := recycler.NewPool[*[64]byte](factory)
-			var wg sync.WaitGroup
-			for range tc.goroutines {
-				wg.Go(func() {
-					for range tc.opsPerRoute {
-						v := r.Get()
-						r.Put(v)
-						ops.Add(1)
-					}
-				})
-			}
-			wg.Wait()
-			//: every goroutine MUST have completed all of its ops.
-			want := uint64(tc.goroutines * tc.opsPerRoute)
-			if ops.Load() != want {
-				t.Errorf("ops counter = %d, want %d", ops.Load(), want)
-			}
+			runCase(t, tc)
 		})
 	}
 }
@@ -114,24 +128,31 @@ func TestPoolConcurrentGetPut(t *testing.T) {
 // (factory-built) path and the warm-pool (recycled) path.
 func TestPool_Get(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
 		warm bool
-	}{
+	}
+	tests := []tc{
 		{"cold pool builds via factory", false},
 		{"warm pool returns a recycled value", true},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the warm case seeds the pool to exercise the cache-hit path.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		r := recycler.NewPool[*[8]byte](func() *[8]byte { return &[8]byte{} })
+		//: seed the pool so the warm case exercises the cache-hit path.
+		if tc.warm {
+			r.Put(r.Get())
+		}
+		if got := r.Get(); got == nil {
+			t.Fatal("Get returned nil")
+		}
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := recycler.NewPool[*[8]byte](func() *[8]byte { return &[8]byte{} })
-			//: seed the pool so the warm case exercises the cache-hit path.
-			if tc.warm {
-				r.Put(r.Get())
-			}
-			if got := r.Get(); got == nil {
-				t.Fatal("Get returned nil")
-			}
+			runCase(t, tc)
 		})
 	}
 }
@@ -140,20 +161,25 @@ func TestPool_Get(t *testing.T) {
 // subsequent Get (stored in the underlying sync.Pool).
 func TestPool_Put(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name string
-	}{
+	type tc struct{ name string }
+	tests := []tc{
 		{"put then get returns a non-nil value"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; a value handed back via Put must survive to the next Get.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		r := recycler.NewPool[*int](func() *int { return new(int(0)) })
+		seed := r.Get()
+		r.Put(seed)
+		if got := r.Get(); got == nil {
+			t.Fatal("Get returned nil after Put")
+		}
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := recycler.NewPool[*int](func() *int { return new(int(0)) })
-			seed := r.Get()
-			r.Put(seed)
-			if got := r.Get(); got == nil {
-				t.Fatal("Get returned nil after Put")
-			}
+			runCase(t, tc)
 		})
 	}
 }

--- a/internal/kernel/recycler/recycler_external_test.go
+++ b/internal/kernel/recycler/recycler_external_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
-// TestNewRecycler validates the constructor across its documented contract:
+// TestNewPool validates the constructor across its documented contract:
 // nil factory rejection, cold-path factory invocation, and warm-path identity
 // preservation through the underlying sync.Pool.
-func TestNewRecycler(t *testing.T) {
+func TestNewPool(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name   string
@@ -20,14 +20,14 @@ func TestNewRecycler(t *testing.T) {
 		{
 			name: "nil factory panics",
 			runner: func(t *testing.T) {
-				//: a nil factory is a programmer error — NewRecycler must fail loud.
+				//: a nil factory is a programmer error — NewPool must fail loud.
 				defer func() {
 					//: the deferred recover turns the expected panic into a pass.
 					if recover() == nil {
-						t.Error("NewRecycler(nil) did not panic")
+						t.Error("NewPool(nil) did not panic")
 					}
 				}()
-				recycler.NewRecycler[*int](nil)
+				recycler.NewPool[*int](nil)
 			},
 		},
 		{
@@ -38,9 +38,9 @@ func TestNewRecycler(t *testing.T) {
 					calls.Add(1)
 					return new(int(calls.Load()))
 				}
-				r := recycler.NewRecycler[*int](factory)
+				r := recycler.NewPool[*int](factory)
 				if r == nil {
-					t.Fatal("NewRecycler returned nil with non-nil factory")
+					t.Fatal("NewPool returned nil with non-nil factory")
 				}
 				got := r.Get()
 				if got == nil {
@@ -55,7 +55,7 @@ func TestNewRecycler(t *testing.T) {
 			name: "Put then Get hands out a non-nil instance",
 			runner: func(t *testing.T) {
 				factory := func() *[16]byte { return &[16]byte{} }
-				r := recycler.NewRecycler[*[16]byte](factory)
+				r := recycler.NewPool[*[16]byte](factory)
 				seed := r.Get()
 				r.Put(seed)
 				got := r.Get()
@@ -73,9 +73,9 @@ func TestNewRecycler(t *testing.T) {
 	}
 }
 
-// TestRecyclerConcurrentGetPut runs many goroutines hammering the pool to
+// TestPoolConcurrentGetPut runs many goroutines hammering the pool to
 // surface data races under -race; the pool's internal sync.Pool MUST cope.
-func TestRecyclerConcurrentGetPut(t *testing.T) {
+func TestPoolConcurrentGetPut(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name        string
@@ -89,7 +89,7 @@ func TestRecyclerConcurrentGetPut(t *testing.T) {
 			t.Parallel()
 			var ops atomic.Uint64
 			factory := func() *[64]byte { return &[64]byte{} }
-			r := recycler.NewRecycler[*[64]byte](factory)
+			r := recycler.NewPool[*[64]byte](factory)
 			var wg sync.WaitGroup
 			for range tc.goroutines {
 				wg.Go(func() {
@@ -110,9 +110,9 @@ func TestRecyclerConcurrentGetPut(t *testing.T) {
 	}
 }
 
-// TestRecycler_Get verifies Get returns a usable value on both the cold-pool
+// TestPool_Get verifies Get returns a usable value on both the cold-pool
 // (factory-built) path and the warm-pool (recycled) path.
-func TestRecycler_Get(t *testing.T) {
+func TestPool_Get(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
@@ -124,7 +124,7 @@ func TestRecycler_Get(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := recycler.NewRecycler[*[8]byte](func() *[8]byte { return &[8]byte{} })
+			r := recycler.NewPool[*[8]byte](func() *[8]byte { return &[8]byte{} })
 			//: seed the pool so the warm case exercises the cache-hit path.
 			if tc.warm {
 				r.Put(r.Get())
@@ -136,9 +136,9 @@ func TestRecycler_Get(t *testing.T) {
 	}
 }
 
-// TestRecycler_Put verifies a value handed back via Put is observable on a
+// TestPool_Put verifies a value handed back via Put is observable on a
 // subsequent Get (stored in the underlying sync.Pool).
-func TestRecycler_Put(t *testing.T) {
+func TestPool_Put(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
@@ -148,7 +148,7 @@ func TestRecycler_Put(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := recycler.NewRecycler[*int](func() *int { return new(int(0)) })
+			r := recycler.NewPool[*int](func() *int { return new(int(0)) })
 			seed := r.Get()
 			r.Put(seed)
 			if got := r.Get(); got == nil {

--- a/internal/kernel/recycler/recycler_external_test.go
+++ b/internal/kernel/recycler/recycler_external_test.go
@@ -1,11 +1,11 @@
-package buffer_test
+package recycler_test
 
 import (
 	"sync"
 	"sync/atomic"
 	"testing"
 
-	"github.com/kitsunium/sdk/internal/kernel/buffer"
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
 // TestNewRecycler validates the constructor across its documented contract:
@@ -20,7 +20,7 @@ func TestNewRecycler(t *testing.T) {
 		{
 			name: "nil factory yields nil Recycler",
 			runner: func(t *testing.T) {
-				r := buffer.NewRecycler[*int](nil)
+				r := recycler.NewRecycler[*int](nil)
 				if r != nil {
 					t.Errorf("NewRecycler(nil) = %v, want nil", r)
 				}
@@ -34,7 +34,7 @@ func TestNewRecycler(t *testing.T) {
 					calls.Add(1)
 					return new(int(calls.Load()))
 				}
-				r := buffer.NewRecycler[*int](factory)
+				r := recycler.NewRecycler[*int](factory)
 				if r == nil {
 					t.Fatal("NewRecycler returned nil with non-nil factory")
 				}
@@ -51,7 +51,7 @@ func TestNewRecycler(t *testing.T) {
 			name: "Put then Get hands out a non-nil instance",
 			runner: func(t *testing.T) {
 				factory := func() *[16]byte { return &[16]byte{} }
-				r := buffer.NewRecycler[*[16]byte](factory)
+				r := recycler.NewRecycler[*[16]byte](factory)
 				seed := r.Get()
 				r.Put(seed)
 				got := r.Get()
@@ -85,7 +85,7 @@ func TestRecyclerConcurrentGetPut(t *testing.T) {
 			t.Parallel()
 			var ops atomic.Uint64
 			factory := func() *[64]byte { return &[64]byte{} }
-			r := buffer.NewRecycler[*[64]byte](factory)
+			r := recycler.NewRecycler[*[64]byte](factory)
 			var wg sync.WaitGroup
 			for range tc.goroutines {
 				wg.Go(func() {
@@ -103,22 +103,5 @@ func TestRecyclerConcurrentGetPut(t *testing.T) {
 				t.Errorf("ops counter = %d, want %d", ops.Load(), want)
 			}
 		})
-	}
-}
-
-// BenchmarkRecyclerSteadyState measures the steady-state cost of Get+Put after
-// the pool is warm. The zero-allocation claim is validated via -benchmem on
-// the asserted floor.
-func BenchmarkRecyclerSteadyState(b *testing.B) {
-	factory := func() *[64]byte { return &[64]byte{} }
-	r := buffer.NewRecycler[*[64]byte](factory)
-	//: warm the pool so we exercise the cache-hit path during the run.
-	primer := r.Get()
-	r.Put(primer)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for b.Loop() {
-		v := r.Get()
-		r.Put(v)
 	}
 }

--- a/internal/kernel/recycler/recycler_external_test.go
+++ b/internal/kernel/recycler/recycler_external_test.go
@@ -18,12 +18,16 @@ func TestNewRecycler(t *testing.T) {
 		runner func(t *testing.T)
 	}{
 		{
-			name: "nil factory yields nil Recycler",
+			name: "nil factory panics",
 			runner: func(t *testing.T) {
-				r := recycler.NewRecycler[*int](nil)
-				if r != nil {
-					t.Errorf("NewRecycler(nil) = %v, want nil", r)
-				}
+				//: a nil factory is a programmer error — NewRecycler must fail loud.
+				defer func() {
+					//: the deferred recover turns the expected panic into a pass.
+					if recover() == nil {
+						t.Error("NewRecycler(nil) did not panic")
+					}
+				}()
+				recycler.NewRecycler[*int](nil)
 			},
 		},
 		{
@@ -101,6 +105,54 @@ func TestRecyclerConcurrentGetPut(t *testing.T) {
 			want := uint64(tc.goroutines * tc.opsPerRoute)
 			if ops.Load() != want {
 				t.Errorf("ops counter = %d, want %d", ops.Load(), want)
+			}
+		})
+	}
+}
+
+// TestRecycler_Get verifies Get returns a usable value on both the cold-pool
+// (factory-built) path and the warm-pool (recycled) path.
+func TestRecycler_Get(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		warm bool
+	}{
+		{"cold pool builds via factory", false},
+		{"warm pool returns a recycled value", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := recycler.NewRecycler[*[8]byte](func() *[8]byte { return &[8]byte{} })
+			//: seed the pool so the warm case exercises the cache-hit path.
+			if tc.warm {
+				r.Put(r.Get())
+			}
+			if got := r.Get(); got == nil {
+				t.Fatal("Get returned nil")
+			}
+		})
+	}
+}
+
+// TestRecycler_Put verifies a value handed back via Put is observable on a
+// subsequent Get (stored in the underlying sync.Pool).
+func TestRecycler_Put(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+	}{
+		{"put then get returns a non-nil value"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := recycler.NewRecycler[*int](func() *int { return new(int(0)) })
+			seed := r.Get()
+			r.Put(seed)
+			if got := r.Get(); got == nil {
+				t.Fatal("Get returned nil after Put")
 			}
 		})
 	}

--- a/internal/kernel/recycler/recycler_integration_test.go
+++ b/internal/kernel/recycler/recycler_integration_test.go
@@ -20,8 +20,8 @@ var allocSink any
 // `bazel test --config=alloc //internal/kernel/recycler:recycler_test` or
 // `--config=pure`.
 func TestZeroAllocInvariant(t *testing.T) {
-	rec := recycler.NewRecycler[*[64]byte](func() *[64]byte { return &[64]byte{} })
-	capped := recycler.NewCappedRecycler[*[]byte](
+	rec := recycler.NewPool[*[64]byte](func() *[64]byte { return &[64]byte{} })
+	capped := recycler.NewCappedPool[*[]byte](
 		func() *[]byte { return new(make([]byte, 0, 1024)) },
 		func(b *[]byte) { *b = (*b)[:0] },
 		func(b *[]byte) int { return cap(*b) },
@@ -32,8 +32,8 @@ func TestZeroAllocInvariant(t *testing.T) {
 		fn   func()
 	}
 	tests := []tc{
-		{"Recycler Get+Put", func() { v := rec.Get(); allocSink = v; rec.Put(v) }},
-		{"CappedRecycler Get+Put", func() { v := capped.Get(); allocSink = v; capped.Put(v) }},
+		{"Pool Get+Put", func() { v := rec.Get(); allocSink = v; rec.Put(v) }},
+		{"CappedPool Get+Put", func() { v := capped.Get(); allocSink = v; capped.Put(v) }},
 		{"buffer Get+Put", func() { b := buffer.Get(); allocSink = b; buffer.Put(b) }},
 	}
 	runCase := func(t *testing.T, tc tc) {

--- a/internal/kernel/recycler/recycler_integration_test.go
+++ b/internal/kernel/recycler/recycler_integration_test.go
@@ -1,0 +1,51 @@
+//go:build !race
+
+package recycler_test
+
+import (
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/buffer"
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
+)
+
+// allocSink defeats dead-code elimination in the AllocsPerRun probes.
+var allocSink any
+
+// TestZeroAllocInvariant pins the documented zero-alloc steady-state hot paths
+// for the recycler primitives and the byte-pool specialisation built on them.
+// Carries //go:build !race (testing.AllocsPerRun reports +1 under -race) and no
+// t.Parallel (AllocsPerRun reads a process-global counter, so concurrent
+// allocations from sibling subtests would corrupt the measurement). Run via
+// `bazel test --config=alloc //internal/kernel/recycler:recycler_test` or
+// `--config=pure`.
+func TestZeroAllocInvariant(t *testing.T) {
+	rec := recycler.NewRecycler[*[64]byte](func() *[64]byte { return &[64]byte{} })
+	capped := recycler.NewCappedRecycler[*[]byte](
+		func() *[]byte { return new(make([]byte, 0, 1024)) },
+		func(b *[]byte) { *b = (*b)[:0] },
+		func(b *[]byte) int { return cap(*b) },
+		64<<10,
+	)
+	type tc struct {
+		name string
+		fn   func()
+	}
+	tests := []tc{
+		{"Recycler Get+Put", func() { v := rec.Get(); allocSink = v; rec.Put(v) }},
+		{"CappedRecycler Get+Put", func() { v := capped.Get(); allocSink = v; capped.Put(v) }},
+		{"buffer Get+Put", func() { b := buffer.Get(); allocSink = b; buffer.Put(b) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: warm the per-P pool so the measured runs hit the cache path.
+		tc.fn()
+		//: steady-state hot path must allocate nothing per op.
+		if got := testing.AllocsPerRun(1000, tc.fn); got != 0 {
+			t.Errorf("%s: %.1f allocs/op, want 0", tc.name, got)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { runCase(t, tc) })
+	}
+}

--- a/internal/kernel/recycler/recycler_internal_test.go
+++ b/internal/kernel/recycler/recycler_internal_test.go
@@ -1,4 +1,4 @@
-package buffer
+package recycler
 
 import "testing"
 

--- a/internal/kernel/recycler/recycler_internal_test.go
+++ b/internal/kernel/recycler/recycler_internal_test.go
@@ -9,11 +9,12 @@ import "testing"
 // white-box test.
 func Test_Pool_Get_failLoud(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name      string
 		runner    func(t *testing.T)
 		wantPanic bool
-	}{
+	}
+	tests := []tc{
 		{
 			name: "homogeneous pool returns the typed value",
 			runner: func(t *testing.T) {
@@ -36,18 +37,24 @@ func Test_Pool_Get_failLoud(t *testing.T) {
 			wantPanic: true,
 		},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the deferred recover turns a panic into an assertable bool.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		defer func() {
+			//: recover so a panic becomes an assertable outcome.
+			got := recover() != nil
+			//: the recovered state must match the case's expectation.
+			if got != tc.wantPanic {
+				t.Errorf("panic = %v, want %v", got, tc.wantPanic)
+			}
+		}()
+		tc.runner(t)
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			defer func() {
-				//: recover so a panic becomes an assertable outcome.
-				got := recover() != nil
-				//: the recovered state must match the case's expectation.
-				if got != tc.wantPanic {
-					t.Errorf("panic = %v, want %v", got, tc.wantPanic)
-				}
-			}()
-			tc.runner(t)
+			runCase(t, tc)
 		})
 	}
 }

--- a/internal/kernel/recycler/recycler_internal_test.go
+++ b/internal/kernel/recycler/recycler_internal_test.go
@@ -2,12 +2,12 @@ package recycler
 
 import "testing"
 
-// Test_Recycler_Get_failLoud covers the white-box assertion path in Get: the
+// Test_Pool_Get_failLoud covers the white-box assertion path in Get: the
 // pool is contractually homogeneous (only ever holds T), so a wrong-typed
 // entry is an internal invariant break that MUST panic rather than silently
 // degrade. Reaching it requires poisoning the unexported pool, hence a
 // white-box test.
-func Test_Recycler_Get_failLoud(t *testing.T) {
+func Test_Pool_Get_failLoud(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
@@ -17,7 +17,7 @@ func Test_Recycler_Get_failLoud(t *testing.T) {
 		{
 			name: "homogeneous pool returns the typed value",
 			runner: func(t *testing.T) {
-				r := NewRecycler[*int](func() *int { return new(int(0)) })
+				r := NewPool[*int](func() *int { return new(int(0)) })
 				if got := r.Get(); got == nil {
 					t.Fatal("Get returned nil on a healthy pool")
 				}
@@ -27,7 +27,7 @@ func Test_Recycler_Get_failLoud(t *testing.T) {
 		{
 			name: "wrong-typed pool content fails loud",
 			runner: func(t *testing.T) {
-				r := NewRecycler[*int](func() *int { return new(int(0)) })
+				r := NewPool[*int](func() *int { return new(int(0)) })
 				//: poison the factory so the next cache miss yields a non-*int.
 				r.pool.New = func() any { return "not-a-pointer-to-int" }
 				//: empty pool → Get triggers New → the assertion in Get must panic.

--- a/internal/kernel/recycler/recycler_internal_test.go
+++ b/internal/kernel/recycler/recycler_internal_test.go
@@ -2,90 +2,52 @@ package recycler
 
 import "testing"
 
-// Test_objectBucket_Get exercises both branches of objectBucket.Get: the happy
-// path where the cached value type-asserts cleanly, and the defensive fallback
-// where the underlying sync.Pool somehow returns a value of the wrong type
-// (impossible in practice, but the branch must be covered).
-func Test_objectBucket_Get(t *testing.T) {
+// Test_Recycler_Get_failLoud covers the white-box assertion path in Get: the
+// pool is contractually homogeneous (only ever holds T), so a wrong-typed
+// entry is an internal invariant break that MUST panic rather than silently
+// degrade. Reaching it requires poisoning the unexported pool, hence a
+// white-box test.
+func Test_Recycler_Get_failLoud(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name   string
-		runner func(t *testing.T)
+		name      string
+		runner    func(t *testing.T)
+		wantPanic bool
 	}{
 		{
-			name: "happy path returns the typed value from the underlying pool",
+			name: "homogeneous pool returns the typed value",
 			runner: func(t *testing.T) {
-				known := new(int(7))
-				factory := func() *int { return new(int(0)) }
-				bucket, ok := NewRecycler[*int](factory).(*objectBucket[*int])
-				if !ok {
-					t.Fatal("NewRecycler did not return *objectBucket[*int]")
-				}
-				//: override sync.Pool.New so Get deterministically receives the known instance.
-				bucket.p.New = func() any { return known }
-				got := bucket.Get()
-				if got != known {
-					t.Errorf("Get returned %p, want known %p", got, known)
+				r := NewRecycler[*int](func() *int { return new(int(0)) })
+				if got := r.Get(); got == nil {
+					t.Fatal("Get returned nil on a healthy pool")
 				}
 			},
+			wantPanic: false,
 		},
 		{
-			name: "wrong-type cache content falls back to factory",
+			name: "wrong-typed pool content fails loud",
 			runner: func(t *testing.T) {
-				var fallbackCalls int
-				factory := func() *int {
-					fallbackCalls++
-					return new(int(42))
-				}
-				bucket, ok := NewRecycler[*int](factory).(*objectBucket[*int])
-				if !ok {
-					t.Fatal("NewRecycler did not return *objectBucket[*int]")
-				}
-				//: poison the underlying sync.Pool with the wrong concrete type.
-				bucket.p.Put(new("not-a-pointer-to-int"))
-				//: drain the factory invocation triggered by NewRecycler's first New call.
-				fallbackCalls = 0
-				got := bucket.Get()
-				if got == nil {
-					t.Fatal("Get returned nil after wrong-type fallback")
-				}
-				if fallbackCalls != 1 {
-					t.Errorf("fallback factory calls = %d, want 1", fallbackCalls)
-				}
+				r := NewRecycler[*int](func() *int { return new(int(0)) })
+				//: poison the factory so the next cache miss yields a non-*int.
+				r.pool.New = func() any { return "not-a-pointer-to-int" }
+				//: empty pool → Get triggers New → the assertion in Get must panic.
+				r.Get()
 			},
+			wantPanic: true,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			defer func() {
+				//: recover so a panic becomes an assertable outcome.
+				got := recover() != nil
+				//: the recovered state must match the case's expectation.
+				if got != tc.wantPanic {
+					t.Errorf("panic = %v, want %v", got, tc.wantPanic)
+				}
+			}()
 			tc.runner(t)
-		})
-	}
-}
-
-// Test_objectBucket_Put confirms that values handed back via Put are stored in
-// the underlying sync.Pool and observable via a follow-up Get.
-func Test_objectBucket_Put(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-	}{
-		{"put then get returns a non-nil value"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			factory := func() *int { return new(int(0)) }
-			bucket, ok := NewRecycler[*int](factory).(*objectBucket[*int])
-			if !ok {
-				t.Fatal("NewRecycler did not return *objectBucket[*int]")
-			}
-			seed := factory()
-			bucket.Put(seed)
-			got := bucket.Get()
-			if got == nil {
-				t.Fatal("Get returned nil after Put")
-			}
 		})
 	}
 }

--- a/internal/service/logger/BENCH.md
+++ b/internal/service/logger/BENCH.md
@@ -1,0 +1,30 @@
+<!-- generated from internal/service/logger/builder_bench_test.go — run `go test -bench=. -benchmem -benchtime=10s ./logger/` to refresh -->
+# Benchmarks — `internal/service/logger`
+
+## Reproducibility envelope
+
+> **Numbers vary across machines.** This report stamps the box that produced
+> them so cross-machine deltas can be evaluated honestly.
+
+| Dimension | Value |
+|---|---|
+| CPU                | 12th Gen Intel(R) Core(TM) i7-1255U |
+| CPU cores          | 12 |
+| RAM                | 15 GiB |
+| OS / kernel        | Linux 6.12.88+deb13-amd64 |
+| Architecture       | amd64 |
+| Go toolchain       | go1.26.3 linux/amd64 |
+| Git branch         | refactor/kernel-recycler |
+| Git commit         | (current HEAD) |
+| Generated (UTC)    | 2026-05-25 |
+| Bench wall-clock   | `-test.benchtime=2s`, single run |
+
+## Results
+
+`BenchmarkBuild_ZeroAlloc` exercises the chainable `Build(lg, lv).Str().Int().Send()`
+hot path once the `recordPool` recycler is warm. The single alloc/op is the
+console sink's formatted line; the builder + attr accumulation are pool-backed.
+
+```
+BenchmarkBuild_ZeroAlloc-12   	3,583,167	781.4 ns/op	277 B/op	1 allocs/op
+```

--- a/internal/service/logger/BUILD.bazel
+++ b/internal/service/logger/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/kernel/buffer",
         "//internal/kernel/clock",
         "//internal/kernel/errs",
+        "//internal/kernel/recycler",
         "//internal/service/logger/encoder",
     ],
 )
@@ -35,6 +36,7 @@ go_test(
     name = "logger_test",
     size = "small",
     srcs = [
+        "builder_bench_test.go",
         "builder_external_test.go",
         "builder_internal_test.go",
         "handler_external_test.go",

--- a/internal/service/logger/CLAUDE.md
+++ b/internal/service/logger/CLAUDE.md
@@ -35,7 +35,7 @@ Logger ── Handler (genericHandler / TextHandler)
 | `builder.go`      | `Builder` interface + `chainBuilder` impl (recycled via `recordPool`) |
 | `handler.go`      | `genericHandler` (Encoder × Sink composition) + `NewHandler` |
 | `text_handler.go` | `TextHandler` legacy fused handler (`NewTextHandler`) |
-| `pool.go`         | `recordPool` — `recycler.Recycler[*chainBuilder]` with pre-sized attrs |
+| `pool.go`         | `recordPool` — `recycler.Pool[*chainBuilder]` with pre-sized attrs |
 | `codes.go`        | `Code*` constants — ADR 0005 range **0.3.1.\*** |
 | `errors.go`       | Sentinels — `WriterNil`, `HandlerNil`, `EncoderNil`, `SinkRequired`, `CtxCancelled`, `WriteFailed` |
 

--- a/internal/service/logger/CLAUDE.md
+++ b/internal/service/logger/CLAUDE.md
@@ -35,7 +35,7 @@ Logger ── Handler (genericHandler / TextHandler)
 | `builder.go`      | `Builder` interface + `chainBuilder` impl (recycled via `recordPool`) |
 | `handler.go`      | `genericHandler` (Encoder × Sink composition) + `NewHandler` |
 | `text_handler.go` | `TextHandler` legacy fused handler (`NewTextHandler`) |
-| `pool.go`         | `recordPool` — `buffer.Recycler[*chainBuilder]` with pre-sized attrs |
+| `pool.go`         | `recordPool` — `recycler.Recycler[*chainBuilder]` with pre-sized attrs |
 | `codes.go`        | `Code*` constants — ADR 0005 range **0.3.1.\*** |
 | `errors.go`       | Sentinels — `WriterNil`, `HandlerNil`, `EncoderNil`, `SinkRequired`, `CtxCancelled`, `WriteFailed` |
 

--- a/internal/service/logger/builder.go
+++ b/internal/service/logger/builder.go
@@ -1,6 +1,6 @@
 // Package logger — declares the chainable Builder API — the
 // zero-allocation hot path for callers that care about per-call cost.
-// Pulled from a recycler.Recycler[*chainBuilder], the builder accumulates
+// Pulled from a recycler.Pool[*chainBuilder], the builder accumulates
 // attrs without allocating beyond the pre-sized scratchpad and returns to
 // the pool on Send.
 package logger

--- a/internal/service/logger/builder.go
+++ b/internal/service/logger/builder.go
@@ -1,6 +1,6 @@
 // Package logger — declares the chainable Builder API — the
 // zero-allocation hot path for callers that care about per-call cost.
-// Pulled from a buffer.Recycler[*chainBuilder], the builder accumulates
+// Pulled from a recycler.Recycler[*chainBuilder], the builder accumulates
 // attrs without allocating beyond the pre-sized scratchpad and returns to
 // the pool on Send.
 package logger

--- a/internal/service/logger/builder_bench_test.go
+++ b/internal/service/logger/builder_bench_test.go
@@ -1,0 +1,28 @@
+package logger_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/core/logger/level"
+	svclogger "github.com/kitsunium/sdk/internal/service/logger"
+)
+
+// BenchmarkBuild_ZeroAlloc validates the zero-allocation claim of the
+// chainable Builder API once the recycler is warm. Run with -benchmem to
+// confirm allocs/op == 0 in steady state.
+func BenchmarkBuild_ZeroAlloc(b *testing.B) {
+	var buf bytes.Buffer
+	lg := mustBuilderLogger(b, &buf, level.Debug)
+	//: warm the pool so the steady-state path is exercised.
+	svclogger.Build(lg, level.Info).Str("k", "v").Send(b.Context(), "warm")
+	buf.Reset()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		svclogger.Build(lg, level.Info).
+			Str("k", "v").
+			Int("n", 7).
+			Send(b.Context(), "msg")
+	}
+}

--- a/internal/service/logger/builder_external_test.go
+++ b/internal/service/logger/builder_external_test.go
@@ -120,22 +120,3 @@ func TestBuild_ForeignLoggerReturnsNil(t *testing.T) {
 		})
 	}
 }
-
-// BenchmarkBuild_ZeroAlloc validates the zero-allocation claim of the
-// chainable Builder API once the recycler is warm. Run with -benchmem to
-// confirm allocs/op == 0 in steady state.
-func BenchmarkBuild_ZeroAlloc(b *testing.B) {
-	var buf bytes.Buffer
-	lg := mustBuilderLogger(b, &buf, level.Debug)
-	//: warm the pool so the steady-state path is exercised.
-	svclogger.Build(lg, level.Info).Str("k", "v").Send(b.Context(), "warm")
-	buf.Reset()
-	b.ReportAllocs()
-	b.ResetTimer()
-	for b.Loop() {
-		svclogger.Build(lg, level.Info).
-			Str("k", "v").
-			Int("n", 7).
-			Send(b.Context(), "msg")
-	}
-}

--- a/internal/service/logger/middleware/async/BUILD.bazel
+++ b/internal/service/logger/middleware/async/BUILD.bazel
@@ -21,8 +21,8 @@ go_library(
     ],
     deps = [
         "//internal/core/logger",
-        "//internal/kernel/buffer",
         "//internal/kernel/errs",
+        "//internal/kernel/recycler",
         "//internal/kernel/ring",
     ],
 )
@@ -49,7 +49,7 @@ go_test(
     deps = [
         "//internal/core/logger",
         "//internal/core/logger/level",
-        "//internal/kernel/buffer",
         "//internal/kernel/errs",
+        "//internal/kernel/recycler",
     ],
 )

--- a/internal/service/logger/middleware/async/CLAUDE.md
+++ b/internal/service/logger/middleware/async/CLAUDE.md
@@ -19,7 +19,7 @@ S3) so a backed-up drain never stalls the application.
 | `async_sink_policy.go` | `DropPolicy` enum (`DropNewest` default, `DropOldest`) |
 | `drainer.go`           | drainer goroutine: `drain` / `forward` / `drainRemaining`; `maxSaneCap` (64 KiB) bounds pool retention against attacker-influenced records |
 | `runtime.go`           | helpers — `yieldOnce`, `isClosed`, `asyncCtx`, `forwardDownstreamError`, `swallowRingError` |
-| `entry.go`             | `recordEntry` recycled through `buffer.Recycler` |
+| `entry.go`             | `recordEntry` recycled through `recycler.Recycler` |
 | `config.go`            | `Config{BufferSize, Policy, OnDrop, OnError}` |
 | `codes.go`, `errors.go`| sentinels — range 0.3.17.\* |
 

--- a/internal/service/logger/middleware/async/CLAUDE.md
+++ b/internal/service/logger/middleware/async/CLAUDE.md
@@ -19,7 +19,7 @@ S3) so a backed-up drain never stalls the application.
 | `async_sink_policy.go` | `DropPolicy` enum (`DropNewest` default, `DropOldest`) |
 | `drainer.go`           | drainer goroutine: `drain` / `forward` / `drainRemaining`; `maxSaneCap` (64 KiB) bounds pool retention against attacker-influenced records |
 | `runtime.go`           | helpers — `yieldOnce`, `isClosed`, `asyncCtx`, `forwardDownstreamError`, `swallowRingError` |
-| `entry.go`             | `recordEntry` recycled through `recycler.Recycler` |
+| `entry.go`             | `recordEntry` recycled through `recycler.Pool` |
 | `config.go`            | `Config{BufferSize, Policy, OnDrop, OnError}` |
 | `codes.go`, `errors.go`| sentinels — range 0.3.17.\* |
 

--- a/internal/service/logger/middleware/async/async_sink.go
+++ b/internal/service/logger/middleware/async/async_sink.go
@@ -35,7 +35,7 @@ type asyncSink struct {
 	// queue is the lock-free ring buffer holding pending entries.
 	queue ring.Queue[*recordEntry]
 	// pool recycles *recordEntry values to avoid per-write allocation.
-	pool *recycler.Recycler[*recordEntry]
+	pool *recycler.Pool[*recordEntry]
 	// policy selects the saturation behaviour at Write time.
 	policy DropPolicy
 	// onDrop fires for every entry discarded by the policy; never nil.
@@ -107,7 +107,7 @@ func New(downstream corelogger.Sink, cfg Config) corelogger.Sink {
 		errCallback = noopOnError
 	}
 	//: recycler keeps per-entry allocation off the hot path.
-	pool := recycler.NewRecycler[*recordEntry](newRecordEntry)
+	pool := recycler.NewPool[*recordEntry](newRecordEntry)
 	//: build the sink with channels primed for the drainer lifecycle.
 	out := &asyncSink{
 		downstream:  downstream,

--- a/internal/service/logger/middleware/async/async_sink.go
+++ b/internal/service/logger/middleware/async/async_sink.go
@@ -35,7 +35,7 @@ type asyncSink struct {
 	// queue is the lock-free ring buffer holding pending entries.
 	queue ring.Queue[*recordEntry]
 	// pool recycles *recordEntry values to avoid per-write allocation.
-	pool recycler.Recycler[*recordEntry]
+	pool *recycler.Recycler[*recordEntry]
 	// policy selects the saturation behaviour at Write time.
 	policy DropPolicy
 	// onDrop fires for every entry discarded by the policy; never nil.

--- a/internal/service/logger/middleware/async/async_sink.go
+++ b/internal/service/logger/middleware/async/async_sink.go
@@ -18,8 +18,8 @@ import (
 	"sync"
 
 	corelogger "github.com/kitsunium/sdk/internal/core/logger"
-	"github.com/kitsunium/sdk/internal/kernel/buffer"
 	"github.com/kitsunium/sdk/internal/kernel/errs"
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
 	"github.com/kitsunium/sdk/internal/kernel/ring"
 )
 
@@ -35,7 +35,7 @@ type asyncSink struct {
 	// queue is the lock-free ring buffer holding pending entries.
 	queue ring.Queue[*recordEntry]
 	// pool recycles *recordEntry values to avoid per-write allocation.
-	pool buffer.Recycler[*recordEntry]
+	pool recycler.Recycler[*recordEntry]
 	// policy selects the saturation behaviour at Write time.
 	policy DropPolicy
 	// onDrop fires for every entry discarded by the policy; never nil.
@@ -107,7 +107,7 @@ func New(downstream corelogger.Sink, cfg Config) corelogger.Sink {
 		errCallback = noopOnError
 	}
 	//: recycler keeps per-entry allocation off the hot path.
-	pool := buffer.NewRecycler[*recordEntry](newRecordEntry)
+	pool := recycler.NewRecycler[*recordEntry](newRecordEntry)
 	//: build the sink with channels primed for the drainer lifecycle.
 	out := &asyncSink{
 		downstream:  downstream,

--- a/internal/service/logger/middleware/async/async_sink_internal_test.go
+++ b/internal/service/logger/middleware/async/async_sink_internal_test.go
@@ -26,7 +26,7 @@ func (noopDownstream) Close() error                  { return nil }
 func freshSink(t testing.TB, policy DropPolicy) *asyncSink {
 	t.Helper()
 	queue := mustNewRing(4)
-	pool := recycler.NewRecycler[*recordEntry](newRecordEntry)
+	pool := recycler.NewPool[*recordEntry](newRecordEntry)
 	done := make(chan struct{})
 	close(done)
 	return &asyncSink{

--- a/internal/service/logger/middleware/async/async_sink_internal_test.go
+++ b/internal/service/logger/middleware/async/async_sink_internal_test.go
@@ -6,7 +6,7 @@ import (
 
 	corelogger "github.com/kitsunium/sdk/internal/core/logger"
 	"github.com/kitsunium/sdk/internal/core/logger/level"
-	"github.com/kitsunium/sdk/internal/kernel/buffer"
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
 // noopDownstream satisfies corelogger.Sink for white-box drainer tests
@@ -26,7 +26,7 @@ func (noopDownstream) Close() error                  { return nil }
 func freshSink(t testing.TB, policy DropPolicy) *asyncSink {
 	t.Helper()
 	queue := mustNewRing(4)
-	pool := buffer.NewRecycler[*recordEntry](newRecordEntry)
+	pool := recycler.NewRecycler[*recordEntry](newRecordEntry)
 	done := make(chan struct{})
 	close(done)
 	return &asyncSink{

--- a/internal/service/logger/middleware/async/drainer_internal_test.go
+++ b/internal/service/logger/middleware/async/drainer_internal_test.go
@@ -30,7 +30,7 @@ func liveSink(t testing.TB, down corelogger.Sink) *asyncSink {
 	s := &asyncSink{
 		downstream: down,
 		queue:      mustNewRing(8),
-		pool:       recycler.NewRecycler[*recordEntry](newRecordEntry),
+		pool:       recycler.NewPool[*recordEntry](newRecordEntry),
 		policy:     DropNewest,
 		onDrop:     noopOnDrop,
 		stop:       make(chan struct{}),

--- a/internal/service/logger/middleware/async/drainer_internal_test.go
+++ b/internal/service/logger/middleware/async/drainer_internal_test.go
@@ -8,7 +8,7 @@ import (
 
 	corelogger "github.com/kitsunium/sdk/internal/core/logger"
 	"github.com/kitsunium/sdk/internal/core/logger/level"
-	"github.com/kitsunium/sdk/internal/kernel/buffer"
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
 // countingDownstream counts every Write so drainer tests can assert that
@@ -30,7 +30,7 @@ func liveSink(t testing.TB, down corelogger.Sink) *asyncSink {
 	s := &asyncSink{
 		downstream: down,
 		queue:      mustNewRing(8),
-		pool:       buffer.NewRecycler[*recordEntry](newRecordEntry),
+		pool:       recycler.NewRecycler[*recordEntry](newRecordEntry),
 		policy:     DropNewest,
 		onDrop:     noopOnDrop,
 		stop:       make(chan struct{}),

--- a/internal/service/logger/pool.go
+++ b/internal/service/logger/pool.go
@@ -1,5 +1,5 @@
 // Package logger — declares the recycled event-record bucket consumed
-// by the Builder API. Pulling RecordEvent values from a recycler.Recycler
+// by the Builder API. Pulling RecordEvent values from a recycler.Pool
 // keeps the hot path allocation-free in steady state — combined with the
 // kind-discriminated Value union the per-call cost is dominated by the
 // encoder + sink rather than GC pressure.
@@ -18,7 +18,7 @@ const initialAttrCap int = 8
 // recordPool recycles *chainBuilder values across Log calls. The factory
 // returns a fresh chainBuilder with a pre-allocated attrs slice so the
 // steady-state cost of Build() is zero heap allocations.
-var recordPool = recycler.NewRecycler[*chainBuilder](newChainBuilder)
+var recordPool = recycler.NewPool[*chainBuilder](newChainBuilder)
 
 // newChainBuilder returns a fresh *chainBuilder with a pre-allocated attrs
 // slice.

--- a/internal/service/logger/pool.go
+++ b/internal/service/logger/pool.go
@@ -1,5 +1,5 @@
 // Package logger — declares the recycled event-record bucket consumed
-// by the Builder API. Pulling RecordEvent values from a buffer.Recycler
+// by the Builder API. Pulling RecordEvent values from a recycler.Recycler
 // keeps the hot path allocation-free in steady state — combined with the
 // kind-discriminated Value union the per-call cost is dominated by the
 // encoder + sink rather than GC pressure.
@@ -7,7 +7,7 @@ package logger
 
 import (
 	corelogger "github.com/kitsunium/sdk/internal/core/logger"
-	"github.com/kitsunium/sdk/internal/kernel/buffer"
+	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
 // initialAttrCap is the starting capacity reserved for an event's attribute
@@ -18,7 +18,7 @@ const initialAttrCap int = 8
 // recordPool recycles *chainBuilder values across Log calls. The factory
 // returns a fresh chainBuilder with a pre-allocated attrs slice so the
 // steady-state cost of Build() is zero heap allocations.
-var recordPool = buffer.NewRecycler[*chainBuilder](newChainBuilder)
+var recordPool = recycler.NewRecycler[*chainBuilder](newChainBuilder)
 
 // newChainBuilder returns a fresh *chainBuilder with a pre-allocated attrs
 // slice.

--- a/pkg/v1/codec/codec_bench_test.go
+++ b/pkg/v1/codec/codec_bench_test.go
@@ -1324,7 +1324,8 @@ func writePivotTable(b *strings.Builder, category, size string, rows []benchRepo
 		return cmp.Compare(a.NsPerOp, b.NsPerOp)
 	})
 	fmt.Fprintf(b, "#### %s — %s payload\n\n", category, size)
-	fmt.Fprintf(b,
+	fmt.Fprintf(
+		b,
 		"> **Mean baseline** across %d codecs: `%s ns/op` · `%s B/op` · `%s allocs/op` · `%s iters`. "+
 			"Green cells sit **below** the mean (faster / lighter / fewer allocs); red cells above.\n\n",
 		len(rows),

--- a/pkg/v1/logger/builder_external_test.go
+++ b/pkg/v1/logger/builder_external_test.go
@@ -135,4 +135,5 @@ type foreignLogger struct{}
 func (foreignLogger) Enabled(context.Context, logger.Level) bool                { return true }
 func (foreignLogger) Log(context.Context, logger.Level, string, ...logger.Attr) {}
 func (foreignLogger) With(...logger.Attr) logger.Logger                         { return foreignLogger{} }
-func (foreignLogger) WithGroup(string) logger.Logger                            { return foreignLogger{} }
+
+func (foreignLogger) WithGroup(string) logger.Logger { return foreignLogger{} }


### PR DESCRIPTION
## Summary

Consolidates the SDK's three duplicated object-recycling mechanisms behind one
minimal kernel primitive `internal/kernel/recycler` (ADR 0010):

- `Pool[T]` — concrete `sync.Pool` wrapper, no reset (fail-loud `Get`).
- `CappedPool[T]` — composes `*Pool[T]` + reset-on-Put + **discard-before-reset**
  cap policy (preserves the codec scratch detach contract).

Consumers become thin users; capacity thresholds + concrete types stay with them:
- `kernel/buffer` → `CappedPool[*[]byte]` @64 KiB (keeps `*[]byte` + nil-guard).
- `core/codec/scratch` → `CappedPool[*bytes.Buffer]` @256 KiB + plain `Pool[*bytes.Reader]` (10 codecs unchanged).
- `service/logger` recordPool + async sink → `Pool[T]`; reset stays consumer-side.

100% `internal/` — **no public `pkg/v1` API change**.

## Design decisions

- **Concrete structs, not interfaces.** recycler is internal plumbing (never in
  `pkg/v1`); the interface-for-consumers convention lives at the public boundary
  (`logger.Logger`, `codec.Codec`). Concrete avoids an interface dispatch on the
  `Get`/`Put` hot path. (ADR 0010 alternatives.)
- **`Pool` / `CappedPool` naming** (sync.Pool-idiomatic) so both pass
  `KTN-STRUCT-ROLE` + `STUTTER` natively — **zero linter exclusion**.
- **Fail-loud `Get`** via comma-ok + panic (mirrors `scratch.poolGet`).

## Lint config net change

Removed 2 ktn-linter exclusions, added none:
- `kernel/ring` MAKEAPPEND/SLICECAP — dead (fixed upstream, kodflow/ktn-linter#183).
- recycler STRUCT-ROLE — avoided entirely via the `Pool`/`CappedPool` rename.

## Upstream findings filed along the way

- kodflow/ktn-linter#356 — PNPT exemption suppressed by a sibling → **fixed & merged**.
- kodflow/ktn-linter#359 — compound-variant stutter → **ruled by-design** (drove the rename).

## Verification

- `bazel build //...`, `bazel test --config=race //internal/...` green.
- `bazel test --config=pure //internal/kernel/recycler:recycler_test` — zero-alloc gate green (race-off).
- kernel firewall query empty; `make lint` clean (ktn-linter v1.34.0, zero exclusions for recycler).

Closes #32
Refs #18, #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a kernel-level object-recycling primitive (generic pools) to reduce steady-state allocations across codec and logger paths.

* **Documentation**
  * Added ADR documenting the recycler design and updated architecture docs and READMEs to reflect integration and capacity thresholds.

* **Refactor**
  * Migrated package-level pooling to the new recycler primitive, simplifying buffer and scratch handling and removing legacy pool implementations.

* **Tests**
  * Added recycler unit/integration tests and benchmarks to validate zero-allocation steady-state and concurrency behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->