### PR TITLE
feat(kernel): add snapshot.Value[T] copy-on-write primitive + consolidate codec registry (ADR 0011)

### DIFF
--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -157,6 +157,34 @@ rules:
   # naming stuttered (kodflow/ktn-linter#359, by-design) and was renamed to the
   # idiomatic sync.Pool-style form instead of carrying an exclusion (ADR 0010).
 
+  # KTN-VAR-PTRINTF (warning) — "pointer to interface; use the interface directly".
+  #
+  # FALSE POSITIVE on `*T` where T is a generic type parameter constrained to
+  # `any` (kodflow/ktn-linter#365). internal/kernel/snapshot ships Value[T any],
+  # a copy-on-write container over atomic.Pointer[T]; its New/Load/Store/Swap
+  # signatures use `*T` exactly as the stdlib sync/atomic.Pointer[T] does. The
+  # rule reads T's `any` constraint as an interface and flags the pointer, but a
+  # pointer to a type parameter is a normal pointer (Value[map[…]], Value[int]).
+  # Scoped to the snapshot package; remove once #365 ships the type-parameter skip.
+  KTN-VAR-PTRINTF:
+    exclude:
+      - "**/internal/kernel/snapshot/**"
+
+  # KTN-API-MINIF (info) — "parameter uses concrete type; suggest interface".
+  #
+  # The codec registry's unexported helpers (loadAliasIndex, publishAlias) take
+  # *snapshot.Value[...], a deliberately CONCRETE kernel primitive (ADR 0011) and
+  # the direct analog of stdlib sync/atomic.Pointer[T], which this rule does NOT
+  # flag in the same role. A generic pointer-container primitive has no alternate
+  # implementation to abstract over; wrapping it in a one-method interface for two
+  # same-package helpers is the over-abstraction the kernel design rejects
+  # (ADR 0010/0011: concrete structs, no single-impl interfaces). The rule also
+  # emits a malformed suggestion message here (kodflow/ktn-linter#366). Scoped to
+  # the registry; remove once #366 aligns it with the atomic.Pointer treatment.
+  KTN-API-MINIF:
+    exclude:
+      - "**/internal/core/codec/registry.go"
+
   # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
   # Go 1.26 convention is to avoid init() in favour of explicit constructors,
   # sync.Once for lazy init, or package-level var initialisers. The codec

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,6 +26,7 @@ filegroup(
         "//internal/kernel/clock:audit_srcs",
         "//internal/kernel/errs:audit_srcs",
         "//internal/kernel/recycler:audit_srcs",
+        "//internal/kernel/snapshot:audit_srcs",
         "//internal/service/codec/asn1:audit_srcs",
         "//internal/service/codec/baseenc:audit_srcs",
         "//internal/service/codec/cbor:audit_srcs",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Go SDK providing a normed, performant toolbox for downstream applications. Two d
 ```
 internal/
 ├── kernel/        stdlib-only AND generic primitives
-│                  errs, recycler, buffer, clock, ring
+│                  errs, recycler, snapshot, buffer, clock, ring
 ├── core/          domain interfaces + domain values
 │                  codec, logger, logger/level
 └── service/       concrete implementations
@@ -112,5 +112,6 @@ After cloning, wire the in-repo hooks with `bash scripts/install-hooks.sh` (one-
 - ADR 0008 — README generation from Go doc comments — `docs/adr/0008-readme-from-code-generation.md`
 - ADR 0009 — public module `go get`-resolvability — `docs/adr/0009-pkg-public-module-resolvability.md`
 - ADR 0010 — kernel object-recycling primitive — `docs/adr/0010-kernel-recycler-primitive.md`
+- ADR 0011 — kernel copy-on-write snapshot primitive — `docs/adr/0011-kernel-snapshot-primitive.md`
 - Layer placement audit — `.claude/contexts/sdk-layer-placement-audit.md`
 - Bazel adoption context — `.claude/contexts/bazel-9-go-sdk.md`

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -19,6 +19,7 @@ Long-form SDK documentation. ADRs here are the source of truth for cross-cutting
 | `adr/0008-readme-from-code-generation.md` | `README.md` generated from Go doc comments via gomarkdoc | Accepted |
 | `adr/0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible (no local `replace`) | Accepted (requirement); impl Deferred |
 | `adr/0010-kernel-recycler-primitive.md` | Generic kernel `Pool[T]` + `CappedPool[T]`; `buffer` + `core/codec/scratch` become consumers | Accepted |
+| `adr/0011-kernel-snapshot-primitive.md` | Generic kernel `Value[T]` copy-on-write container; codec registry consolidates onto it | Accepted |
 
 ## ADR conventions
 

--- a/docs/adr/0011-kernel-snapshot-primitive.md
+++ b/docs/adr/0011-kernel-snapshot-primitive.md
@@ -1,0 +1,117 @@
+# ADR 0011 — Kernel copy-on-write snapshot primitive
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-25
+
+## Deciders
+
+kodflow
+
+## Context
+
+The codec registry (`internal/core/codec/registry.go`) hand-rolls a
+copy-on-write snapshot across **three** `atomic.Pointer[map[K]V]` fields
+(`registry`, `mimeIndex`, `extIndex`), each with its own CAS-retry writer
+(`publishCodec`, `publishAlias`) and clone helper — roughly 130 lines of
+plumbing plus two `//nolint:gocyclo` suppressions, because the CAS-retry shape
+inflates cyclomatic complexity. The pattern is read-mostly: codec packages
+register once at import, and every other access is a lock-free `Load`.
+
+That copy-on-write mechanism is generic, stdlib-only, and domain-neutral — any
+frozen-after-init or rarely-mutated table (a routing table, a feature-flag map,
+a hot-reloaded config) wants exactly the same shape. It is the same
+"duplicated mechanism, scattered thresholds" situation that justified the
+`recycler` primitive (ADR 0010): the mechanism deserves one home, the domain
+clone logic stays with the consumer.
+
+## Decision
+
+Introduce `internal/kernel/snapshot`, a minimal kernel primitive for
+read-mostly shared state. Concrete type only (no interface), matching the
+`recycler` precedent:
+
+- `Value[T any]` — a copy-on-write container over `atomic.Pointer[T]`.
+  - `Load() *T` is lock-free and allocation-free (one atomic load); the
+    returned `*T` is a shared immutable snapshot.
+  - `Store` / `Swap` / `Update` serialise on a mutex so a read-modify-write
+    publish cannot lose a concurrent write. Readers never take the lock.
+  - `Update(fn func(current *T) (next *T))` is the read-modify-write helper;
+    returning the unchanged current pointer is a no-op publish (conditional
+    abort).
+
+Conventions:
+
+- The zero value is usable — `Load` returns nil until the first `Store`; `New`
+  is call-site sugar when an initial value is known. A nil initial is a valid
+  empty container, not a programmer error (so, unlike `recycler.NewPool`,
+  construction does not panic).
+- Concrete struct by deliberate choice; a single-impl interface would be
+  over-abstraction. The `Value` role suffix passes `KTN-STRUCT-ROLE` natively.
+- The mechanism lives in kernel; the consumer keeps its domain clone logic
+  (`cloneFormatMap` / `cloneAliasMap` stay in `core/codec`).
+
+The codec registry is consolidated onto `Value[T]` in the same change so the
+primitive ships with a real consumer (no empty package). Its three
+`atomic.Pointer[map]` fields become three `snapshot.Value[map]`; the CAS-retry
+loops and both `//nolint:gocyclo` suppressions are removed — `Update` makes the
+conflict-check-and-publish atomic under the writer lock, while readers keep the
+lock-free `Load` fast path.
+
+No worker, queue, metrics, policy object, lifecycle manager, or `CompareAndSwap`
+is introduced. `snapshot` emits no dotted-quad error codes (it never returns
+errors and does not panic on use), so ADR 0005 has no entry.
+
+## Alternatives considered
+
+- **`sync.Map`** — not generic (forces `any` + type assertions on every read),
+  and its dirty-map write path adds machinery for write-mostly workloads the
+  registry never triggers. The registry microbench measured the
+  `atomic.Pointer` snapshot at 9.1 ns vs 12.8 ns for `sync.Map.Load` + the
+  assertion. Rejected for read-heavy frozen-after-init tables.
+- **`sync.RWMutex` + plain map** — every reader takes the read lock (a counter
+  CAS), defeating the lock-free read path that motivates the primitive.
+- **Raw `atomic.Pointer[T]` at each call site** — this is exactly the
+  hand-rolled CAS-loop boilerplate (×3 in the registry) the primitive
+  consolidates.
+- **Value API (`Store(T)` / `Load() (T, bool)`) backed by an internal box** —
+  avoids exposing `*T`, but allocates a box on every `Store` and copies `T` on
+  every `Load`. Rejected in favour of the pointer API, which is zero-alloc on
+  all operations and mirrors the stdlib `sync/atomic.Pointer[T]` shape.
+
+## Consequences
+
+- `internal/core/codec` becomes a consumer of `snapshot.Value[map]` for its
+  registry and the two alias indexes; ~130 lines of CAS plumbing and two
+  `//nolint:gocyclo` suppressions are removed.
+- The kernel gains a fourth generic primitive (`errs`, `recycler`, `ring`,
+  `clock` … now `snapshot`); reads stay lock-free, writes stay correct.
+- `internal/core/codec/CLAUDE.md` is revised: the "atomic.Pointer + CAS-loop"
+  rationale becomes "consumes `snapshot.Value`; the mechanism lives in kernel".
+
+## Breaking changes
+
+None. This is an `internal/`-only change; `pkg/v1/*` exported API is untouched,
+and the codec registry's observable behaviour (idempotent re-registration,
+duplicate-Name/MIME/extension panic, lock-free lookups) is preserved verbatim.
+
+## Deferred
+
+- Additional consumers (routing tables, feature-flag maps, hot-reloaded config)
+  adopt `Value[T]` as they appear; each is a one-liner, not new mechanism.
+- A `CompareAndSwap` method is omitted until a lock-free-CAS consumer needs it;
+  the mutex-serialised `Update` covers the read-modify-write case today.
+
+## References
+
+- [ADR 0010 — kernel object-recycling primitive](./0010-kernel-recycler-primitive.md) (sibling concrete-struct primitive)
+- `internal/kernel/CLAUDE.md` — kernel gate (stdlib-only AND generic)
+- `.claude/contexts/kernel-perf-primitives.md` — the primitive survey that ranked this Tier A
+- ADR 0005 — error codes (snapshot emits none)
+- Tracked upstream linter false positives suppressed for this primitive:
+  `kodflow/ktn-linter#365` (`KTN-VAR-PTRINTF` on `*T`), `kodflow/ktn-linter#366`
+  (`KTN-API-MINIF` on a concrete generic primitive)

--- a/docs/adr/0011-kernel-snapshot-primitive.md
+++ b/docs/adr/0011-kernel-snapshot-primitive.md
@@ -111,7 +111,7 @@ duplicate-Name/MIME/extension panic, lock-free lookups) is preserved verbatim.
 - [ADR 0010 — kernel object-recycling primitive](./0010-kernel-recycler-primitive.md) (sibling concrete-struct primitive)
 - `internal/kernel/CLAUDE.md` — kernel gate (stdlib-only AND generic)
 - `.claude/contexts/kernel-perf-primitives.md` — the primitive survey that ranked this Tier A
-- ADR 0005 — error codes (snapshot emits none)
+- [ADR 0005 — error codes](./0005-sdk-error-codes-dotted-quad.md) (snapshot emits none)
 - Tracked upstream linter false positives suppressed for this primitive:
   `kodflow/ktn-linter#365` (`KTN-VAR-PTRINTF` on `*T`), `kodflow/ktn-linter#366`
   (`KTN-API-MINIF` on a concrete generic primitive)

--- a/docs/adr/CLAUDE.md
+++ b/docs/adr/CLAUDE.md
@@ -19,6 +19,7 @@ Architecture Decision Records. Each ADR captures one cross-cutting decision (lay
 | `0008-readme-from-code-generation.md` | `README.md` generated from Go doc comments (gomarkdoc) | Accepted |
 | `0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible; release tags the whole module chain | Accepted; mechanism implemented |
 | `0010-kernel-recycler-primitive.md` | Generic `recycler.Pool[T]` + `CappedPool[T]` object pools; `buffer`/`scratch` become consumers | Accepted |
+| `0011-kernel-snapshot-primitive.md` | Generic `snapshot.Value[T]` copy-on-write container; codec registry consolidates onto it | Accepted |
 
 ## Conventions
 

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,27 +1,9 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-25T20:06:04.965Z",
+  "generatedAt": "2026-05-25T21:54:03.841Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
-    {
-      "type": "fix",
-      "scope": "codec/scratch",
-      "breaking": false,
-      "summary": "release pooled bytes.Reader src before repooling",
-      "sha": "f9b474f865a492276cec2f579233fb24e4c542cc",
-      "short": "f9b474f",
-      "date": "2026-05-25T21:51:51+02:00"
-    },
-    {
-      "type": "feat",
-      "scope": "kernel",
-      "breaking": false,
-      "summary": "add CappedRecycler[T] (reset-on-Put + cap-discard)",
-      "sha": "ab004eeb25ad266b24bdbd478c1b6c6912d743d5",
-      "short": "ab004ee",
-      "date": "2026-05-25T14:41:44+02:00"
-    },
     {
       "type": "fix",
       "scope": "docs",
@@ -30,6 +12,15 @@
       "sha": "dcff33ba199373bcc579168f287bd783aa5b3e1f",
       "short": "dcff33b",
       "date": "2026-05-25T09:59:30Z"
+    },
+    {
+      "type": "fix",
+      "scope": "docs",
+      "breaking": false,
+      "summary": "base-path the portal for GitHub Pages project deploys + a11y/SEO (#30)",
+      "sha": "5bff559252443700989d2507c57039696da9ded2",
+      "short": "5bff559",
+      "date": "2026-05-25T09:45:30Z"
     },
     {
       "type": "feat",
@@ -48,6 +39,15 @@
       "sha": "45ab9fb51b8bf4b30f4c970a3f64b8a2dc295398",
       "short": "45ab9fb",
       "date": "2026-05-20T13:31:25+02:00"
+    },
+    {
+      "type": "feat",
+      "scope": "logger",
+      "breaking": false,
+      "summary": "v2 zero-alloc multi-sink architecture (#12)",
+      "sha": "7fd4c5c4f6d2dafeb70fdd4f75dac0328bc57437",
+      "short": "7fd4c5c",
+      "date": "2026-04-23T15:13:58+02:00"
     }
   ]
 }

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,9 +1,18 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-25T21:54:03.841Z",
+  "generatedAt": "2026-05-25T22:06:17.306Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
+    {
+      "type": "feat",
+      "scope": "kernel",
+      "breaking": false,
+      "summary": "add snapshot.Value[T] copy-on-write primitive + consolidate codec registry (ADR 0011)",
+      "sha": "6dd281443c62835293c3f77144cff4801a79eb73",
+      "short": "6dd2814",
+      "date": "2026-05-25T23:53:33+02:00"
+    },
     {
       "type": "fix",
       "scope": "docs",
@@ -39,15 +48,6 @@
       "sha": "45ab9fb51b8bf4b30f4c970a3f64b8a2dc295398",
       "short": "45ab9fb",
       "date": "2026-05-20T13:31:25+02:00"
-    },
-    {
-      "type": "feat",
-      "scope": "logger",
-      "breaking": false,
-      "summary": "v2 zero-alloc multi-sink architecture (#12)",
-      "sha": "7fd4c5c4f6d2dafeb70fdd4f75dac0328bc57437",
-      "short": "7fd4c5c",
-      "date": "2026-04-23T15:13:58+02:00"
     }
   ]
 }

--- a/internal/core/codec/BUILD.bazel
+++ b/internal/core/codec/BUILD.bazel
@@ -13,7 +13,10 @@ go_library(
     ],
     importpath = "github.com/kitsunium/sdk/internal/core/codec",
     visibility = ["//internal/core:core_consumers"],
-    deps = ["//internal/kernel/errs"],
+    deps = [
+        "//internal/kernel/errs",
+        "//internal/kernel/snapshot",
+    ],
 )
 
 alias(
@@ -32,6 +35,7 @@ go_test(
         "registry_internal_test.go",
     ],
     embed = [":codec"],
+    deps = ["//internal/kernel/snapshot"],
 )
 
 filegroup(

--- a/internal/core/codec/CLAUDE.md
+++ b/internal/core/codec/CLAUDE.md
@@ -19,7 +19,7 @@ No format-specific knowledge lives here — concrete codecs live under `internal
 
 ## Conventions
 
-- **`atomic.Pointer[map[K]V]` not `sync.Map`** — codecs Register exactly once at import; everything else is read-many. A frozen-after-init map read via `atomic.Pointer` is ~30% faster than `sync.Map.Load` + the interface-to-Codec type assertion (microbench: 9.1 ns vs 12.8 ns). Documented at the top of `registry.go`. Register uses a CAS-loop on the snapshot pointer so concurrent first-use init (rare under Go's single-goroutine init order) loses gracefully without dropping entries.
+- **`snapshot.Value[map[K]V]` not `sync.Map`** — codecs Register exactly once at import; everything else is read-many. A frozen-after-init map read via `snapshot.Value.Load` (one `atomic.Pointer` load) is ~30% faster than `sync.Map.Load` + the interface-to-Codec type assertion (microbench: 9.1 ns vs 12.8 ns). The copy-on-write mechanism lives in `internal/kernel/snapshot` (ADR 0011); `registry.go` keeps only the domain clone logic (`cloneFormatMap` / `cloneAliasMap`). `Register` publishes via `Value.Update`, which serialises writers on a mutex — no hand-rolled CAS loop — while `Lookup*` stay lock-free via `Value.Load`.
 - **Aliases are lowercased** before indexing; MIME parameters (`; charset=utf-8`) are stripped via `mime.ParseMediaType` with a manual fallback when the header is malformed.
 - **Idempotent re-registration** of the same `Format` under the same alias is accepted; distinct codecs claiming the same name/MIME/ext **panic at boot** with the dotted-quad code in the message.
 - **`Format("")` is reserved** as the invalid zero value — `Known()` returns false; `Lookup` of empty `Format` always misses.

--- a/internal/core/codec/CLAUDE.md
+++ b/internal/core/codec/CLAUDE.md
@@ -14,7 +14,7 @@ No format-specific knowledge lives here — concrete codecs live under `internal
 | `codec_interface.go` | `Codec` (`Name` / `MIMETypes` / `Extensions` / `Marshal` / `Unmarshal`), `StreamingCodec` (adds `NewEncoder` / `NewDecoder`), `Encoder` (`Encode` / `Close`), `Decoder` (`Decode` / `More`) |
 | `appender.go` | `Appender` extension (`Append(dst, v) ([]byte, error)`) — hot-path zero-copy encode into a caller-owned buffer |
 | `format.go` | `Format` typed string + `Known()` / `String()` |
-| `registry.go` | Package-level `sync.Map` registry + `Register` / `Lookup` / `LookupMIME` / `LookupExt` / `Available`. All constructors marked `// IFACE-PLUGIN:` |
+| `registry.go` | Package-level `snapshot.Value`-backed registry (copy-on-write, ADR 0011) + `Register` / `Lookup` / `LookupMIME` / `LookupExt` / `Available`. All constructors marked `// IFACE-PLUGIN:` |
 | `codes.go` | `CodeDuplicateRegistration` (0.2.2.1) — emitted via `panic` at boot; 0.2.2.2-4 reserved for Marshal/Unmarshal sentinels |
 
 ## Conventions

--- a/internal/core/codec/registry.go
+++ b/internal/core/codec/registry.go
@@ -10,27 +10,30 @@ import (
 	"mime"
 	"slices"
 	"strings"
-	"sync/atomic"
+
+	"github.com/kitsunium/sdk/internal/kernel/snapshot"
 )
 
 // Package-level indexes + the duplicate-registration sentinel.
 //
-// atomic.Pointer[map[K]V] is the deliberate choice here over sync.Map:
+// snapshot.Value[map[K]V] is the deliberate choice here over sync.Map:
 // codec packages register themselves exactly ONCE at package import time
 // (their package-level var initializer calls Register), and every other
 // access is a read (Lookup / LookupMIME / LookupExt). A frozen-after-init
-// map read via atomic.Pointer is ~30% faster than sync.Map.Load + the
-// interface-to-Codec type assertion (microbench: 9.1 ns vs 12.8 ns) and
-// avoids the dirty-map fallback machinery sync.Map carries for write-mostly
-// workloads we never trigger.
+// map read via Value.Load (one atomic.Pointer load) is ~30% faster than
+// sync.Map.Load + the interface-to-Codec type assertion (microbench: 9.1 ns
+// vs 12.8 ns) and avoids the dirty-map fallback machinery sync.Map carries
+// for the write-mostly workloads we never trigger.
 //
-// Register uses a CAS-loop on the snapshot pointer so concurrent first-use
-// init (rare — Go package init is single-goroutine, but defensive) loses
-// gracefully without dropping entries.
+// snapshot.Value (ADR 0011) serialises writers on a mutex, so Register's
+// read-modify-write publish is race-free WITHOUT the hand-rolled CAS loop this
+// package carried before; readers stay lock-free via Value.Load. The
+// copy-on-write mechanism lives in internal/kernel/snapshot — only the domain
+// clone logic (cloneFormatMap / cloneAliasMap) stays here.
 var (
-	registry  atomic.Pointer[map[Format]Codec]
-	mimeIndex atomic.Pointer[map[string]Format]
-	extIndex  atomic.Pointer[map[string]Format]
+	registry  snapshot.Value[map[Format]Codec]
+	mimeIndex snapshot.Value[map[string]Format]
+	extIndex  snapshot.Value[map[string]Format]
 
 	//: errDuplicateRegistration is the wrappable sentinel for boot-time
 	//: duplicate-codec panics. Wrapping via %w keeps the error chain
@@ -40,15 +43,15 @@ var (
 	errDuplicateRegistration = errors.New("duplicate registration")
 )
 
-// loadRegistry returns the current registry snapshot, or an empty map
-// when no codec has registered yet (rare — service codec init order
-// runs before any application code).
+// loadRegistry returns the current registry snapshot, or nil when no codec
+// has registered yet (rare — service codec init order runs before any
+// application code).
 func loadRegistry() map[Format]Codec {
 	//: load the current snapshot pointer; nil before first Register call.
 	current := registry.Load()
 	//: nil snapshot means no codec registered yet — empty result.
 	if current == nil {
-		//: hand back a fresh empty map (caller never mutates).
+		//: hand back nil so callers see a clean miss.
 		return nil
 	}
 	//: dereference the snapshot for caller reads.
@@ -57,7 +60,7 @@ func loadRegistry() map[Format]Codec {
 
 // loadAliasIndex returns the current alias-index snapshot for mime or
 // extension lookup. Same nil-handling as loadRegistry.
-func loadAliasIndex(p *atomic.Pointer[map[string]Format]) map[string]Format {
+func loadAliasIndex(p *snapshot.Value[map[string]Format]) map[string]Format {
 	//: load the snapshot pointer; nil before first Register call.
 	current := p.Load()
 	//: nil snapshot — no aliases registered yet.
@@ -85,8 +88,7 @@ func Register(c Codec) Codec {
 	}
 	//: the canonical Format is the primary key.
 	name := Format(c.Name())
-	//: CAS-loop publishes a new snapshot that includes c. Duplicate detection
-	//: happens inside the loop so a winning racer sees the loser's panic.
+	//: publish the codec under the writer lock; duplicate Name is a hard conflict.
 	if err := publishCodec(name, c); err != nil {
 		//: surface the doc code for grep-friendly panic messages.
 		panic(err.Error())
@@ -100,51 +102,37 @@ func Register(c Codec) Codec {
 	return c
 }
 
-// publishCodec performs the CAS-loop that inserts (name → c) into the
-// registry snapshot. Returns a non-nil error when name is already
-// registered to a different codec — the caller turns the error into a
-// panic so the boot-time failure is loud and grep-friendly.
-//
-//nolint:gocyclo // CAS-retry shape inherently raises cyclomatic count.
+// publishCodec inserts (name → c) into the registry snapshot under the writer
+// lock. Returns a non-nil error when name is already registered to a different
+// codec — the caller turns the error into a panic so the boot-time failure is
+// loud and grep-friendly.
 func publishCodec(name Format, c Codec) error {
-	//: CAS loop — concurrent first-Register calls (rare under Go's
-	//: single-goroutine init order) retry until one wins. The loop
-	//: body's make() is NOT a hot allocation: every Register call is
-	//: a one-shot init-time operation, never a per-request path.
-	//: next is hoisted outside so each retry overwrites the same
-	//: stack slot rather than declaring a fresh variable per loop.
-	var next *map[Format]Codec
-	//: CAS retry loop; loop body documented inline below.
-	for {
-		//: snapshot the current registry state.
-		current := registry.Load()
-		//: duplicate detection runs on the current snapshot before any
-		//: allocation — caller's panic is grep-friendly via the code.
+	//: dupErr escapes the Update closure to signal a conflicting registration.
+	var dupErr error
+	//: Update serialises writers on the snapshot mutex, so the duplicate check
+	//: and the publish are atomic against any concurrent Register.
+	registry.Update(func(current *map[Format]Codec) *map[Format]Codec {
+		//: duplicate detection runs on the current snapshot before any allocation.
 		if current != nil {
-			//: any prior registration of `name` is a hard conflict.
+			//: any prior registration of name is a hard conflict.
 			if _, dup := (*current)[name]; dup {
-				//: wrap the sentinel so errors.Is finds the chain.
-				return fmt.Errorf("codec.Register [%d %w]: duplicate Name %q", CodeDuplicateRegistration, errDuplicateRegistration, name)
+				//: wrap the sentinel so errors.Is finds the chain, then abort.
+				dupErr = fmt.Errorf("codec.Register [%d %w]: duplicate Name %q", CodeDuplicateRegistration, errDuplicateRegistration, name)
+				//: no-op publish — republish the current snapshot unchanged.
+				return current
 			}
 		}
-		//: clone the snapshot + append the new entry. maps.Copy handles
-		//: the nil-source case so we don't need a separate branch.
-		//: new(expr) is Go 1.26+ form — heap-allocates the cloned map
-		//: in one shot, no v := expr; &v intermediate.
-		next = new(cloneFormatMap(current, name, c))
-		//: CAS publishes the new snapshot. Failure loops back to retry.
-		if registry.CompareAndSwap(current, next) {
-			//: snapshot installed atomically — readers see the new entry.
-			return nil
-		}
-	}
+		//: clone the snapshot + insert the new entry, then publish atomically.
+		//: new(expr) is Go 1.26+ form — heap-allocates the cloned map in one shot.
+		return new(cloneFormatMap(current, name, c))
+	})
+	//: surface any conflict to Register, which panics with the doc code.
+	return dupErr
 }
 
-// cloneFormatMap copies the source snapshot and inserts (name → c).
-// Hoisted out of publishCodec's CAS loop so the per-retry alloc is
-// attributed to its own stack frame (the linter's HOTLOOP rule reads
-// this as init-time work, which it is — Register is called once per
-// codec at package import).
+// cloneFormatMap copies the source snapshot and inserts (name → c). Register
+// is called once per codec at package import, so this clone is init-time,
+// one-shot work — not a per-request hot path.
 func cloneFormatMap(src *map[Format]Codec, name Format, c Codec) map[Format]Codec {
 	//: size hint = source size + 1 for the new entry; nil source → 1.
 	var size int
@@ -163,19 +151,18 @@ func cloneFormatMap(src *map[Format]Codec, name Format, c Codec) map[Format]Code
 	}
 	//: insert the new entry.
 	next[name] = c
-	//: caller installs the snapshot via CAS.
+	//: caller publishes the snapshot via Value.Update.
 	return next
 }
 
 // indexAliases stores every alias (MIME or extension) in dst, panicking
-// when a distinct codec already claims the same key. Uses the same
-// CAS-loop pattern as publishCodec for race-free first-Register.
-func indexAliases(dst *atomic.Pointer[map[string]Format], aliases []string, name Format, kind string) {
+// when a distinct codec already claims the same key.
+func indexAliases(dst *snapshot.Value[map[string]Format], aliases []string, name Format, kind string) {
 	//: iterate over every alias and publish it atomically.
 	for _, alias := range aliases {
 		//: normalise so lookups are case-insensitive.
 		key := strings.ToLower(alias)
-		//: publishAlias handles the conflict + CAS retry semantics.
+		//: publishAlias handles the conflict + atomic publish semantics.
 		if err := publishAlias(dst, key, name, kind, alias); err != nil {
 			//: distinct codec conflict — loud failure at boot.
 			panic(err.Error())
@@ -183,50 +170,41 @@ func indexAliases(dst *atomic.Pointer[map[string]Format], aliases []string, name
 	}
 }
 
-// publishAlias performs the CAS-loop that inserts (key → name) into an
-// alias index snapshot. Returns a non-nil error when key is already
-// claimed by a different Format; idempotent re-registration by the same
-// Format is accepted.
-//
-//nolint:gocyclo // CAS-retry shape inherently raises cyclomatic count.
-func publishAlias(dst *atomic.Pointer[map[string]Format], key string, name Format, kind, alias string) error {
-	//: CAS loop matches publishCodec's shape; same init-time semantics
-	//: apply (Register runs once per codec at package import).
-	//: next is hoisted outside so each retry overwrites the same slot.
-	var next *map[string]Format
-	//: CAS retry loop; loop body documented inline below.
-	for {
-		//: snapshot the current alias index.
-		current := dst.Load()
-		//: conflict + idempotent-reregistration detection runs on the
-		//: current snapshot before any allocation.
+// publishAlias inserts (key → name) into an alias index snapshot under the
+// writer lock. Returns a non-nil error when key is already claimed by a
+// different Format; idempotent re-registration by the same Format is accepted.
+func publishAlias(dst *snapshot.Value[map[string]Format], key string, name Format, kind, alias string) error {
+	//: conflictErr escapes the Update closure to signal a clashing alias.
+	var conflictErr error
+	//: Update serialises writers; the conflict check and publish are atomic.
+	dst.Update(func(current *map[string]Format) *map[string]Format {
+		//: conflict + idempotent-reregistration detection on the current snapshot.
 		if current != nil {
-			//: any prior alias under `key` is checked against `name`.
+			//: any prior alias under key is checked against name.
 			if prev, exists := (*current)[key]; exists {
 				//: idempotent same-codec re-registration is fine.
 				if prev == name {
-					//: no-op — alias already points at us.
-					return nil
+					//: no-op publish — alias already points at us.
+					return current
 				}
-				//: wrap the sentinel so errors.Is finds the chain.
-				return fmt.Errorf("codec.Register [%d %w]: %s %q already registered by %q (requested by %q)",
+				//: distinct-codec conflict — wrap the sentinel, then abort.
+				conflictErr = fmt.Errorf("codec.Register [%d %w]: %s %q already registered by %q (requested by %q)",
 					CodeDuplicateRegistration, errDuplicateRegistration, kind, alias, prev, name)
+				//: no-op publish — republish the current snapshot unchanged.
+				return current
 			}
 		}
-		//: clone + insert via the hoisted helper (same HOTLOOP rationale
-		//: as cloneFormatMap above). Go 1.26+ new(expr) form.
-		next = new(cloneAliasMap(current, key, name))
-		//: CAS publishes the new snapshot. Failure loops back to retry.
-		if dst.CompareAndSwap(current, next) {
-			//: snapshot installed atomically.
-			return nil
-		}
-	}
+		//: clone + insert via the hoisted helper, then publish atomically.
+		//: Go 1.26+ new(expr) form.
+		return new(cloneAliasMap(current, key, name))
+	})
+	//: surface any conflict to indexAliases, which panics with the doc code.
+	return conflictErr
 }
 
-// cloneAliasMap mirrors cloneFormatMap for the MIME / extension alias
-// indexes: copies the source snapshot and inserts (key → name). The
-// per-Register call shape is identical (init-time, one-shot work).
+// cloneAliasMap mirrors cloneFormatMap for the MIME / extension alias indexes:
+// copies the source snapshot and inserts (key → name). Same init-time,
+// one-shot call shape (once per codec at package import).
 func cloneAliasMap(src *map[string]Format, key string, name Format) map[string]Format {
 	//: size hint = source size + 1 for the new entry; nil source → 1.
 	var size int
@@ -244,7 +222,7 @@ func cloneAliasMap(src *map[string]Format, key string, name Format) map[string]F
 	}
 	//: insert the new entry.
 	next[key] = name
-	//: caller installs the snapshot via CAS.
+	//: caller publishes the snapshot via Value.Update.
 	return next
 }
 

--- a/internal/core/codec/registry_external_test.go
+++ b/internal/core/codec/registry_external_test.go
@@ -20,6 +20,10 @@ func (m *mockCodec) Marshal(v any) ([]byte, error)      { return []byte(m.name),
 func (m *mockCodec) Unmarshal(data []byte, v any) error { return nil }
 
 func TestRegister(t *testing.T) {
+	//: start from a clean registry so this test is isolated and survives
+	//: `go test -count=N` (the process — and package-global registry — persists
+	//: across iterations).
+	codec.ResetForTest()
 	tests := []struct {
 		name string
 		arg  *mockCodec
@@ -57,6 +61,9 @@ func TestRegister(t *testing.T) {
 }
 
 func TestRegisterPanics(t *testing.T) {
+	//: clean slate so the duplicate-Name case panics on its OWN second
+	//: registration, not on a leftover from a prior test or `-count` iteration.
+	codec.ResetForTest()
 	tests := []struct {
 		name string
 		run  func()

--- a/internal/core/codec/registry_internal_test.go
+++ b/internal/core/codec/registry_internal_test.go
@@ -69,3 +69,19 @@ func callRecoverAliases(dst *snapshot.Value[map[string]Format], aliases []string
 	//: no panic path.
 	return false, nil
 }
+
+// ResetForTest clears the process-wide codec registry and its MIME / extension
+// alias indexes back to the empty state. Exported from this white-box test file
+// so the external test package (codec_test) can isolate registry mutations: the
+// registry is package-global and `go test -count=N` reuses the process (package
+// state is NOT re-initialised between iterations), so a test that calls Register
+// must reset first or a later iteration panics on a duplicate Name. Test-only.
+func ResetForTest() {
+	//: store a nil snapshot into each Value; loadRegistry / loadAliasIndex then
+	//: report empty (Load returns nil → callers see a clean miss).
+	registry.Store(nil)
+	//: MIME alias index back to empty.
+	mimeIndex.Store(nil)
+	//: extension alias index back to empty.
+	extIndex.Store(nil)
+}

--- a/internal/core/codec/registry_internal_test.go
+++ b/internal/core/codec/registry_internal_test.go
@@ -2,8 +2,9 @@ package codec
 
 import (
 	"strings"
-	"sync/atomic"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/snapshot"
 )
 
 // Test_indexAliases covers fresh-alias, idempotent, and conflict paths of
@@ -26,7 +27,7 @@ func Test_indexAliases(t *testing.T) {
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		var dst atomic.Pointer[map[string]Format]
+		var dst snapshot.Value[map[string]Format]
 		//: seed the snapshot with the existing aliases via the same publish path.
 		if len(tc.existing) > 0 {
 			seed := make(map[string]Format, len(tc.existing))
@@ -53,7 +54,7 @@ func Test_indexAliases(t *testing.T) {
 // subtests can assert panic behaviour without using defer — t.Cleanup is
 // not usable here because we want the panic-recovery to happen before the
 // assertion runs.
-func callRecoverAliases(dst *atomic.Pointer[map[string]Format], aliases []string, name Format, kind string) (panicked bool, recovered any) {
+func callRecoverAliases(dst *snapshot.Value[map[string]Format], aliases []string, name Format, kind string) (panicked bool, recovered any) {
 	//: classic recover pattern isolated in a helper so the caller stays flat.
 	defer func() {
 		//: capture the recover value inline.

--- a/internal/kernel/CLAUDE.md
+++ b/internal/kernel/CLAUDE.md
@@ -11,6 +11,7 @@ The SDK's lowest layer: **stdlib-only AND generic** primitives. A package qualif
 |---|---|---|
 | `errs/` | SDK-wide typed error + dotted-quad registry (ADR 0005) | 1000-1099 (meta-codes, documentary only) |
 | `recycler/` | generic `Pool[T]` + `CappedPool[T]` object pools (ADR 0010) | (none — panics on programmer error) |
+| `snapshot/` | generic `Value[T]` copy-on-write container (ADR 0011) | (none — never returns errors) |
 | `buffer/` | `sync.Pool` of `[]byte` — a `recycler.CappedPool[*[]byte]` specialisation | 1200-1299 (reserved) |
 | `clock/` | `Clock` interface (`Now` + `Since`) for testable time | 1300-1399 (reserved) |
 | `ring/` | SPSC lock-free bounded queue (ADR 0006) | 1400-1499 (RING_FULL / RING_EMPTY / RING_CAP_ZERO emit today) |
@@ -36,6 +37,7 @@ As of the 2026-04-19 audit (extended by ADR 0006 to admit `ring`):
 - `recycler` admitted by ADR 0010 — `Pool[T]` + `CappedPool[T]` are textbook generic object pools (reuse + reset + cap-discard). Any byte buffer, codec stream, HTTP body encoder, or metrics line writer can reuse the mechanism; the thresholds stay with the consumers.
 - `buffer` stays — the `[]byte` pool is generic even though `service/logger` is the heaviest consumer today. Since ADR 0010 it is a thin specialisation over `recycler.CappedPool[*[]byte]` (the generic `Pool[T]` moved to `recycler`).
 - `ring` admitted by ADR 0006 — SPSC bounded queue is a textbook generic primitive. Logger's async middleware is the only consumer today; metrics batchers and codec stream pipelines are obvious future users.
+- `snapshot` admitted by ADR 0011 — `Value[T]` is a textbook generic copy-on-write container (lock-free `Load` + mutex-serialised writers). The codec registry consolidated its three hand-rolled `atomic.Pointer[map]` + CAS loops onto it; routing tables, feature-flag maps, and hot-reloaded config are obvious future consumers.
 
 ## Conventions unique to kernel
 
@@ -65,6 +67,8 @@ GOWORK=off go test -race -cover ./...
 ## Subtree
 
 - `errs/` — see `internal/kernel/errs/CLAUDE.md`
+- `recycler/` — see `internal/kernel/recycler/CLAUDE.md`
+- `snapshot/` — see `internal/kernel/snapshot/CLAUDE.md`
 - `buffer/` — see `internal/kernel/buffer/CLAUDE.md`
 - `clock/` — see `internal/kernel/clock/CLAUDE.md`
 - `ring/` — see `internal/kernel/ring/CLAUDE.md`

--- a/internal/kernel/snapshot/BUILD.bazel
+++ b/internal/kernel/snapshot/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//internal/kernel:kernel_consumers"])
+
+go_library(
+    name = "snapshot",
+    srcs = ["snapshot.go"],
+    importpath = "github.com/kitsunium/sdk/internal/kernel/snapshot",
+    visibility = ["//internal/kernel:kernel_consumers"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":snapshot",
+    visibility = ["//internal/kernel:kernel_consumers"],
+)
+
+go_test(
+    name = "snapshot_test",
+    size = "small",
+    srcs = [
+        "snapshot_external_test.go",
+        "snapshot_integration_test.go",
+    ],
+    deps = [":snapshot"],
+)
+
+filegroup(
+    name = "audit_srcs",
+    srcs = glob(["*.go"]),
+    visibility = ["//:__pkg__"],
+)

--- a/internal/kernel/snapshot/CLAUDE.md
+++ b/internal/kernel/snapshot/CLAUDE.md
@@ -1,0 +1,46 @@
+# internal/kernel/snapshot/
+
+## Purpose
+
+The SDK's copy-on-write container primitive. Stdlib-only, domain-neutral.
+`Value[T]` wraps `atomic.Pointer[T]` so readers `Load` the current snapshot
+lock-free and allocation-free, while writers (`Store` / `Swap` / `Update`)
+serialise on a mutex for a race-free read-modify-write publish. The codec
+registry (`internal/core/codec`) is built ON this primitive — the mechanism
+lives here, the domain clone logic stays with the consumer (ADR 0011).
+
+## Contents
+
+| Primitive | Surface | Use case |
+|---|---|---|
+| `Value[T]` | `New[T any](initial *T)` → `Load` / `Store` / `Swap` / `Update` | read-mostly shared state: registries, routing tables, hot-reloaded config |
+
+## Conventions
+
+- **Load is the hot path.** One `atomic.Pointer` load — zero alloc, no lock.
+  The returned `*T` is shared with every other reader and MUST be treated as
+  immutable: mutate a clone and publish it via `Store` / `Update`.
+- **Writers serialise on a mutex.** `Store` / `Swap` / `Update` take the lock
+  so a read-modify-write (`Update`) cannot lose a concurrent write. Readers
+  never take the lock.
+- **The zero value is usable.** `var v Value[T]` reads nil until the first
+  `Store`; `New` is call-site sugar when an initial value is known.
+- **Concrete struct, no interface.** Like `recycler` (ADR 0010), snapshot ships
+  a concrete struct by deliberate choice — a single-impl interface would be
+  over-abstraction (ADR 0011). The `Value` role suffix passes `KTN-STRUCT-ROLE`
+  natively.
+
+## Do NOT
+
+- Mutate the value returned by `Load` — other goroutines hold the same pointer.
+- Call `Store` / `Swap` / `Update` from inside an `Update` fn — it deadlocks.
+- Use it for write-heavy state — every write clones. It is a read-mostly COW
+  container, not a concurrent map (reach for `sync.Map` if writes dominate).
+
+## Verification
+
+```sh
+bazel test --config=race //internal/kernel/snapshot:snapshot_test
+# zero-alloc gate runs HORS race (race instrumentation perturbs allocs):
+bazel test --config=pure //internal/kernel/snapshot:snapshot_test
+```

--- a/internal/kernel/snapshot/README.md
+++ b/internal/kernel/snapshot/README.md
@@ -1,0 +1,37 @@
+# snapshot
+
+Copy-on-write container primitive for the SDK kernel. Stdlib-only.
+
+```go
+import (
+	"maps"
+
+	"github.com/kitsunium/sdk/internal/kernel/snapshot"
+)
+
+// Read-mostly shared state: lock-free Load, mutex-serialised writers.
+var routes snapshot.Value[map[string]int]
+
+// Publish a new snapshot under the writer lock (copy-on-write).
+routes.Update(func(cur *map[string]int) *map[string]int {
+	next := map[string]int{}
+	if cur != nil {
+		maps.Copy(next, *cur)
+	}
+	next["/health"] = 200
+	return &next
+})
+
+// Read without locking — one atomic load, zero allocation.
+if m := routes.Load(); m != nil {
+	_ = (*m)["/health"]
+}
+```
+
+`Value[T]` holds a `*T` behind an `atomic.Pointer[T]`: `Load` is lock-free and
+allocation-free, while `Store` / `Swap` / `Update` serialise on a mutex so a
+read-modify-write publish is race-free. The codec registry
+(`internal/core/codec`) is built on it — three `atomic.Pointer[map]` fields with
+hand-rolled CAS loops collapse to three `Value[map]` fields.
+
+See ADR 0011 for the design rationale and the layering contract.

--- a/internal/kernel/snapshot/snapshot.go
+++ b/internal/kernel/snapshot/snapshot.go
@@ -1,0 +1,95 @@
+// Package snapshot provides Value[T any], a copy-on-write container for
+// read-mostly shared state. Load is lock-free and allocation-free (a single
+// atomic.Pointer load); writers (Store / Swap / Update) serialise on a mutex
+// so a read-modify-write publish never loses a concurrent update. Stdlib-only
+// and domain-neutral: any frozen-after-init or rarely-mutated table — a codec
+// registry, a routing table, a feature-flag map, a hot-reloaded config — can
+// reuse it.
+//
+// The codec registry (internal/core/codec) is built ON this primitive: three
+// atomic.Pointer[map] fields with hand-rolled CAS-loop writers collapse to
+// three Value[map] fields. The mechanism lives here; the domain clone logic
+// stays with the consumer (ADR 0011).
+package snapshot
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Value is a copy-on-write container for a *T. Readers call Load with no lock;
+// writers replace the whole pointer under a mutex so concurrent
+// read-modify-write publishes cannot lose updates. The zero value is ready to
+// use — Load returns nil until the first Store. Always used behind a pointer:
+// the embedded mutex and atomic.Pointer must not be copied.
+type Value[T any] struct {
+	// mu serialises writers so Update's read-modify-write is atomic against
+	// other writers. Readers (Load) never take it.
+	mu sync.Mutex
+	// p holds the current value pointer; Load reads it without the lock.
+	p atomic.Pointer[T]
+}
+
+// New returns a Value holding initial. A nil initial is valid and leaves the
+// container empty (Load returns nil), the same state as the zero value —
+// offered as call-site sugar when an initial value is already known.
+func New[T any](initial *T) *Value[T] {
+	//: build the empty container; the zero value is already usable.
+	v := &Value[T]{}
+	//: a nil initial is a legitimate empty snapshot, not a programmer error.
+	if initial != nil {
+		//: seed the container so the first Load observes initial.
+		v.p.Store(initial)
+	}
+	//: hand the container back to the caller.
+	return v
+}
+
+// Load returns the current value pointer without taking the lock — a single
+// atomic load, zero allocation. This is the hot path. The returned *T is
+// shared with every other reader and MUST be treated as immutable: mutate a
+// clone and publish it via Store or Update instead.
+func (v *Value[T]) Load() *T {
+	//: lock-free read — the entire point of the copy-on-write container.
+	return v.p.Load()
+}
+
+// Store atomically replaces the current value with next. It takes the writer
+// lock so a Store cannot interleave with an in-flight Update's
+// read-modify-write and clobber it.
+func (v *Value[T]) Store(next *T) {
+	//: serialise against other writers (Update / Swap) before publishing.
+	v.mu.Lock()
+	//: defer the unlock so a panic in any future guarded step still releases it
+	//: (matches Swap / Update; keeps the writer lock panic-safe).
+	defer v.mu.Unlock()
+	//: publish atomically — concurrent Loads observe either old or next, never torn.
+	v.p.Store(next)
+}
+
+// Swap atomically replaces the current value with next and returns the
+// previous value pointer (nil when the container was empty). Takes the writer
+// lock for the same reason as Store.
+func (v *Value[T]) Swap(next *T) *T {
+	//: serialise against other writers before the swap.
+	v.mu.Lock()
+	//: release the writer lock once the swap has published next.
+	defer v.mu.Unlock()
+	//: atomic swap hands back the pointer we are displacing.
+	return v.p.Swap(next)
+}
+
+// Update runs fn under the writer lock and publishes its result. fn receives
+// the current value (nil when empty) and returns the replacement; it MUST NOT
+// mutate the value it is handed — other goroutines may be reading it — and
+// should build and return a fresh *T. fn MUST NOT call Store / Swap / Update
+// on the same Value, which would deadlock. Returning the unchanged current
+// pointer is a no-op publish, which lets fn abort a conditional update.
+func (v *Value[T]) Update(fn func(current *T) (next *T)) {
+	//: serialise the read-modify-write so concurrent writers cannot lose updates.
+	v.mu.Lock()
+	//: release the writer lock after publishing fn's result.
+	defer v.mu.Unlock()
+	//: read under the lock, transform, and publish the result atomically.
+	v.p.Store(fn(v.p.Load()))
+}

--- a/internal/kernel/snapshot/snapshot_external_test.go
+++ b/internal/kernel/snapshot/snapshot_external_test.go
@@ -1,0 +1,234 @@
+package snapshot_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/snapshot"
+)
+
+// TestNew validates the constructor contract: a nil initial yields an empty
+// container (Load returns nil), a non-nil initial is observable on first Load.
+func TestNew(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		initial *int
+		wantNil bool
+	}
+	tests := []tc{
+		{"nil initial is an empty container", nil, true},
+		{"non-nil initial is observable", new(42), false},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the constructed container must reflect the initial argument.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		v := snapshot.New(tc.initial)
+		got := v.Load()
+		//: nil-initial path: Load must observe the empty (nil) state.
+		if tc.wantNil {
+			//: an empty container hands back nil until the first Store.
+			if got != nil {
+				t.Fatalf("Load() = %v, want nil", got)
+			}
+			return
+		}
+		//: seeded path: Load must hand back the exact initial pointer.
+		if got != tc.initial {
+			t.Fatalf("Load() = %p, want %p", got, tc.initial)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestValue_ZeroValueUsable pins the documented contract that the zero value
+// is ready to use: Load returns nil before any Store, and a subsequent Store
+// becomes observable.
+func TestValue_ZeroValueUsable(t *testing.T) {
+	t.Parallel()
+	type tc struct{ name string }
+	tests := []tc{
+		{"zero value loads nil then accepts a store"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; a zero-value Value must behave like an empty container.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		var v snapshot.Value[int]
+		//: an unstored zero value must read as empty.
+		if got := v.Load(); got != nil {
+			t.Fatalf("zero-value Load() = %v, want nil", got)
+		}
+		want := 7
+		v.Store(&want)
+		//: after Store the same pointer must be observable.
+		if got := v.Load(); got != &want {
+			t.Fatalf("Load() = %p, want %p", got, &want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestValue_Swap verifies Swap installs the new pointer and returns the
+// previous one (nil when the container was empty).
+func TestValue_Swap(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		seeded    bool
+		wantOlder bool
+	}
+	tests := []tc{
+		{"swap on empty returns nil old", false, false},
+		{"swap on seeded returns prior old", true, true},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; Swap must return the displaced pointer and install the new one.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		older, newer := 1, 2
+		var v snapshot.Value[int]
+		//: seed the container only for the "prior value" case.
+		if tc.seeded {
+			v.Store(&older)
+		}
+		old := v.Swap(&newer)
+		//: the empty case must report no displaced value.
+		if !tc.wantOlder {
+			//: nothing was seeded, so Swap returns nil.
+			if old != nil {
+				t.Fatalf("Swap() old = %v, want nil", old)
+			}
+		}
+		//: the seeded case must return the exact prior pointer.
+		if tc.wantOlder && old != &older {
+			t.Fatalf("Swap() old = %p, want %p", old, &older)
+		}
+		//: the new pointer must be installed regardless of the prior state.
+		if got := v.Load(); got != &newer {
+			t.Fatalf("Load() after Swap = %p, want %p", got, &newer)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestValue_Update verifies Update transforms the current value and that
+// returning the unchanged current pointer is a no-op publish (conditional
+// abort).
+func TestValue_Update(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name  string
+		abort bool
+		want  int
+	}
+	tests := []tc{
+		{"transform publishes the new value", false, 11},
+		{"returning current is a no-op abort", true, 10},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; an abort leaves the prior value installed unchanged.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		v := snapshot.New(new(10))
+		v.Update(func(current *int) *int {
+			//: the abort case returns the current pointer unchanged.
+			if tc.abort {
+				//: no-op publish — the prior value stays installed.
+				return current
+			}
+			//: build a fresh value so readers of the old pointer are unaffected.
+			next := *current + 1
+			return &next
+		})
+		//: the observable value must match the expected post-Update state.
+		if got := *v.Load(); got != tc.want {
+			t.Fatalf("Load() = %d, want %d", got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestValue_ConcurrentUpdateLoad hammers the container with concurrent writers
+// and readers to surface races under -race: every Update must be serialised
+// (no lost increments) while Loads run lock-free.
+func TestValue_ConcurrentUpdateLoad(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		writers int
+		perW    int
+	}
+	tests := []tc{
+		{"16 writers x 256 increments + readers", 16, 256},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the final count must equal the total number of Update calls.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		v := snapshot.New(new(0))
+		var reads atomic.Uint64
+		var wg sync.WaitGroup
+		//: spawn writer goroutines that each increment via serialised Update.
+		for range tc.writers {
+			wg.Go(func() {
+				for range tc.perW {
+					v.Update(func(current *int) *int {
+						//: build a fresh int so concurrent Loads never see a torn write.
+						next := *current + 1
+						return &next
+					})
+				}
+			})
+		}
+		//: spawn reader goroutines that race lock-free Loads against the writers.
+		for range tc.writers {
+			wg.Go(func() {
+				for range tc.perW {
+					//: Load must never return nil here — the container was seeded.
+					if v.Load() != nil {
+						reads.Add(1)
+					}
+				}
+			})
+		}
+		wg.Wait()
+		//: serialised Updates must produce exactly writers*perW increments.
+		want := tc.writers * tc.perW
+		if got := *v.Load(); got != want {
+			t.Errorf("final value = %d, want %d (lost updates)", got, want)
+		}
+		//: every Load observed a non-nil seeded snapshot.
+		if reads.Load() != uint64(want) {
+			t.Errorf("non-nil reads = %d, want %d", reads.Load(), want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/kernel/snapshot/snapshot_integration_test.go
+++ b/internal/kernel/snapshot/snapshot_integration_test.go
@@ -1,0 +1,47 @@
+//go:build !race
+
+package snapshot_test
+
+import (
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/snapshot"
+)
+
+// allocSink defeats dead-code elimination in the AllocsPerRun probes.
+var allocSink any
+
+// TestZeroAllocInvariant pins the documented zero-alloc steady-state hot paths
+// for the snapshot container: Load, Store, and Swap of a pre-built pointer
+// must allocate nothing per op (only the writer's own clone allocates, and
+// that is the caller's, not the container's). Carries //go:build !race
+// (testing.AllocsPerRun reports +1 under -race) and no t.Parallel (AllocsPerRun
+// reads a process-global counter, so concurrent allocations from sibling
+// subtests would corrupt the measurement). Run via
+// `bazel test --config=alloc //internal/kernel/snapshot:snapshot_test` or
+// `--config=pure`.
+func TestZeroAllocInvariant(t *testing.T) {
+	a, b := 1, 2
+	v := snapshot.New(&a)
+	type tc struct {
+		name string
+		fn   func()
+	}
+	tests := []tc{
+		{"Load", func() { allocSink = v.Load() }},
+		{"Store", func() { v.Store(&b) }},
+		{"Swap", func() { allocSink = v.Swap(&a) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: warm the path once so the measured runs hit steady state.
+		tc.fn()
+		//: steady-state hot path must allocate nothing per op.
+		if got := testing.AllocsPerRun(1000, tc.fn); got != 0 {
+			t.Errorf("%s: %.1f allocs/op, want 0", tc.name, got)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { runCase(t, tc) })
+	}
+}


### PR DESCRIPTION
## Summary

Adds `internal/kernel/snapshot` — a stdlib-only, generic **copy-on-write** primitive — and consolidates the codec registry onto it (**ADR 0011**). This is **Tier A** from the kernel-perf-primitives survey: the one candidate that consolidates existing hand-rolled duplication, in the same spirit as `recycler` (ADR 0010).

- `Value[T]` = `sync.Mutex` + `atomic.Pointer[T]`: **lock-free, zero-alloc `Load`**; `Store`/`Swap`/`Update` serialise writers so a read-modify-write publish never loses a concurrent update. Zero value usable; concrete struct by design (no single-impl interface).
- Codec registry's three `atomic.Pointer[map]` fields + two CAS-loop writers collapse to three `Value[map]`; the CAS boilerplate and both `//nolint:gocyclo` suppressions are removed. Behaviour preserved verbatim (idempotent same-codec re-register, distinct-codec conflict panic, lock-free `Lookup*`).
- Internal-only refactor — `pkg/v1` API untouched.

## "All tiers" disposition (`.claude/contexts/kernel-perf-primitives.md`)

The goal was to address every tier. Faithful to the kernel gate (ADR 0010/0011: stdlib-only, generic, primitive-not-framework, ≥2-consumer, not stdlib-redundant), that means **build A; execute the documented verdict for B/C/D** — building the rest as kernel primitives would fail the gate and CI:

- **Tier A — shipped here**: `snapshot.Value[T]` + registry consolidation.
- **Tier B (watchlist, gated on a 2nd consumer)**: SPMC/MPSC queue, worker pool (already ADR-0010-deferred), `varint`, `deadline.Budget` — no 2nd concrete consumer exists yet; building now is the exact anti-pattern ADR 0010 forbids.
- **Tier C (modern stdlib already covers — do NOT wrap)**: `Lazy`→`sync.OnceValue` (1.21), interner→`unique.Make` (1.23), zero-copy→`unsafe.String/Slice` (1.20), memoize→`OnceValue`/`sync.Map`, semaphore→buffered `chan`, future→`chan`+`Once`. No real adoption site in the tree today.
- **Tier D (policy, wrong layer)**: backoff, rate-limiter, LRU, circuit-breaker → belong in a future `core/<domain>` or `pkg/v1/resilience`, not the kernel.

## ktn-linter false positives (filed upstream)

Surfaced during implementation, reported, and suppressed with scoped, tracked excludes:
- **kodflow/ktn-linter#365** — `KTN-VAR-PTRINTF` fires on `*T` where `T` is a generic type parameter (the `sync/atomic.Pointer[T]` pattern); a pointer to a type parameter is not a pointer-to-interface.
- **kodflow/ktn-linter#366** — `KTN-API-MINIF` emits a malformed message (`%!(EXTRA …)`) and flags a deliberately-concrete generic primitive, inconsistently with the stdlib `atomic.Pointer[T]` it does not flag.

## Test plan

- [x] `bazel build //...` — 140 targets green
- [x] `bazel test --config=race //...` — 37/37 test targets pass
- [x] zero-alloc gate `bazel test --config=pure //internal/kernel/snapshot:snapshot_test` — `Load`/`Store`/`Swap` at 0 allocs/op
- [x] kernel firewall: `bazel query 'kind("go_library", deps(//internal/kernel/...)) except //internal/kernel/...'` → empty
- [x] `ktn-linter lint --phases=all ./...` → "No issues found"; `gofumpt` clean
- [x] `go test -race -count=2 ./codec/...` → green (test-isolation fix, see below)
- [x] developer-specialist-go audit verdict: **SOUND** — memory model (lock-free Load + mutex-serialised writers) and registry semantics-preservation confirmed under sustained race-stress

## Also fixed (pre-existing, surfaced by the audit)

`TestRegister` / `TestRegisterPanics` were not idempotent under `go test -count=2`: the registry is package-global and the process is reused across iterations, so a second run panicked on a duplicate Name (and the dup-panic test passed for the wrong reason). Fixed by a white-box `ResetForTest` (exported from `registry_internal_test.go`, visible to the external `codec_test`) called at the start of both registering tests. The old `atomic.Pointer` registry had the same latent issue; Bazel runs each target once so CI never hit it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced snapshot primitive (Value[T]) for efficient copy-on-write shared state management
  * Refactored codec registry to use snapshot for lock-free reads

* **Documentation**
  * Added ADR 0011 documenting the snapshot primitive design and implementation
  * Updated kernel and codec architecture documentation

* **Tests**
  * Added comprehensive tests for snapshot primitive functionality and concurrent behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->