### PR TITLE
test(sdk): drive package coverage toward 100% with credible fixtures

### DIFF
--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -185,6 +185,23 @@ rules:
     exclude:
       - "**/internal/core/codec/registry.go"
 
+  # KTN-TEST-PARALLEL (warning) — "test function must call t.Parallel()".
+  #
+  # Scoped exception: pkg/v1/logger/version_external_test.go's
+  # TestFrameworkVersionInjected MUST be serial. It covers the non-fallback
+  # arm of FrameworkVersion() by stamping the package-global `Version` (the
+  # ldflags / Bazel --stamp injection point) and asserting it is returned
+  # verbatim. Every other test in the package reads FrameworkVersion()
+  # concurrently under t.Parallel(); a parallel mutator would be a data race
+  # under `-race`. Running serially, the mutate→assert→restore completes
+  # while the parallel readers are still paused, so the shared global is
+  # never observed mid-write. This is the only safe way to cover the
+  # injected-Version branch — t.Parallel() here is mutually exclusive with
+  # correctness, not merely inconvenient. Scoped to the one file.
+  KTN-TEST-PARALLEL:
+    exclude:
+      - "**/pkg/v1/logger/version_external_test.go"
+
   # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
   # Go 1.26 convention is to avoid init() in favour of explicit constructors,
   # sync.Once for lazy init, or package-level var initialisers. The codec

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -127,84 +127,27 @@ rules:
       - "**/internal/service/logger/**"
       - "**/pkg/v1/logger/**"
 
-  # (Removed) KTN-VAR-MAKEAPPEND + KTN-VAR-SLICECAP ring exclusion: the
-  # generic fixed-length-storage false positive it covered was fixed upstream
-  # in ktn-linter (append-reachability gating, kodflow/ktn-linter#183) and is
-  # no longer reproducible on v1.34.0 — verified by lint-with-exclusion-removed.
-  # Re-add a scoped exclusion only if a future binary regresses the heuristic.
-
-  # KTN-TEST-SUFFIX + KTN-TEST-TABLE — scoped exception for the codec
-  # benchmark file. Normally Test* functions must live in
-  # _internal_test.go / _external_test.go (TEST-SUFFIX) and follow the
-  # table-driven pattern (TEST-TABLE). pkg/v1/codec/codec_bench_test.go
-  # hosts a single `TestGenerateBenchMD` whose only job is to drive the
-  # full bench matrix (via testing.Benchmark on the same package-local
-  # make<Op>Bench helpers used by every Benchmark* function in the file)
-  # and write pkg/v1/codec/BENCH.md. Moving the Test out would either
-  # duplicate the helpers or expose them across files; a single-shot
-  # report generator is also a poor fit for the table-driven pattern.
-  KTN-TEST-SUFFIX:
-    exclude:
-      - "**/pkg/v1/codec/codec_bench_test.go"
-  KTN-TEST-TABLE:
-    exclude:
-      - "**/pkg/v1/codec/codec_bench_test.go"
-
-  # (No recycler exclusion.) internal/kernel/recycler ships Pool[T] +
-  # CappedPool[T]: "Pool" is a recognized role suffix, so both pass
-  # KTN-STRUCT-ROLE and KTN-STRUCT-ROLE-STUTTER natively — no path-suppress and
-  # no dependency on the PNPT fix (#356). The earlier Recycler/CappedRecycler
-  # naming stuttered (kodflow/ktn-linter#359, by-design) and was renamed to the
-  # idiomatic sync.Pool-style form instead of carrying an exclusion (ADR 0010).
-
-  # KTN-VAR-PTRINTF (warning) — "pointer to interface; use the interface directly".
+  # ── Audit 2026-05-28 — all five scoped overrides RETIRED (ktn-linter v1.34.5) ─
+  # Every exclusion that used to live here was removed and the linter re-run on
+  # v1.34.5 (current latest). With v1.34.5 + one code refactor, ALL FIVE are gone;
+  # only the KTN-INTERFACE-ANYUSE domain exception above remains.
   #
-  # FALSE POSITIVE on `*T` where T is a generic type parameter constrained to
-  # `any` (kodflow/ktn-linter#365). internal/kernel/snapshot ships Value[T any],
-  # a copy-on-write container over atomic.Pointer[T]; its New/Load/Store/Swap
-  # signatures use `*T` exactly as the stdlib sync/atomic.Pointer[T] does. The
-  # rule reads T's `any` constraint as an interface and flags the pointer, but a
-  # pointer to a type parameter is a normal pointer (Value[map[…]], Value[int]).
-  # Scoped to the snapshot package; remove once #365 ships the type-parameter skip.
-  KTN-VAR-PTRINTF:
-    exclude:
-      - "**/internal/kernel/snapshot/**"
-
-  # KTN-API-MINIF (info) — "parameter uses concrete type; suggest interface".
+  # • KTN-VAR-PTRINTF — false positive on a generic `*T` (kodflow/ktn-linter#365).
+  #   v1.34.5 no longer flags internal/kernel/snapshot's Value[T] *T signatures.
+  # • KTN-API-MINIF — false positive on *snapshot.Value[...] params + a malformed
+  #   message (#366). v1.34.5 no longer flags internal/core/codec/registry.go.
+  # • KTN-TEST-PARALLEL — false positive: a serial test mutating the package
+  #   global logger.Version (FrameworkVersion injection) was wrongly required to
+  #   call t.Parallel() (a data race). Fixed by #379 (Closes #376) — NOPARALLEL
+  #   now detects `pkg.Var = x` selector writes, so PARALLEL exempts the safe
+  #   serial mutator. version_external_test.go lints clean serial.
+  # • KTN-TEST-SUFFIX + KTN-TEST-TABLE — the codec BENCH.md generator
+  #   (TestGenerateBenchMD in codec_bench_test.go). Fixed by #377 (Closes #375) —
+  #   a benchmark-orchestrator Test* (transitively drives testing.Benchmark and
+  #   makes NO t.* assertion) is now allowed in *_bench_test.go and skipped by
+  #   TABLE/PARALLEL/ASSERT. Code change: the generator panics on a write error
+  #   instead of t.Fatalf, so it qualifies as a pure orchestrator.
   #
-  # The codec registry's unexported helpers (loadAliasIndex, publishAlias) take
-  # *snapshot.Value[...], a deliberately CONCRETE kernel primitive (ADR 0011) and
-  # the direct analog of stdlib sync/atomic.Pointer[T], which this rule does NOT
-  # flag in the same role. A generic pointer-container primitive has no alternate
-  # implementation to abstract over; wrapping it in a one-method interface for two
-  # same-package helpers is the over-abstraction the kernel design rejects
-  # (ADR 0010/0011: concrete structs, no single-impl interfaces). The rule also
-  # emits a malformed suggestion message here (kodflow/ktn-linter#366). Scoped to
-  # the registry; remove once #366 aligns it with the atomic.Pointer treatment.
-  KTN-API-MINIF:
-    exclude:
-      - "**/internal/core/codec/registry.go"
-
-  # KTN-TEST-PARALLEL (warning) — "test function must call t.Parallel()".
-  #
-  # Scoped exception: pkg/v1/logger/version_external_test.go's
-  # TestFrameworkVersionInjected MUST be serial. It covers the non-fallback
-  # arm of FrameworkVersion() by stamping the package-global `Version` (the
-  # ldflags / Bazel --stamp injection point) and asserting it is returned
-  # verbatim. Every other test in the package reads FrameworkVersion()
-  # concurrently under t.Parallel(); a parallel mutator would be a data race
-  # under `-race`. Running serially, the mutate→assert→restore completes
-  # while the parallel readers are still paused, so the shared global is
-  # never observed mid-write. This is the only safe way to cover the
-  # injected-Version branch — t.Parallel() here is mutually exclusive with
-  # correctness, not merely inconvenient. Scoped to the one file.
-  KTN-TEST-PARALLEL:
-    exclude:
-      - "**/pkg/v1/logger/version_external_test.go"
-
-  # KTN-FUNC-NOINIT stays ACTIVE everywhere — no exclusion.
-  # Go 1.26 convention is to avoid init() in favour of explicit constructors,
-  # sync.Once for lazy init, or package-level var initialisers. The codec
-  # registry will follow that: each codec subpackage registers itself via
-  # `var Codec codec.Codec = codec.Register(&fooCodec{})` (named singleton,
-  # not init()), or via an explicit constructor the facade invokes.
+  # KTN-FUNC-NOINIT stays ACTIVE everywhere (no exclusion) — Go 1.26 avoids init()
+  # in favour of explicit constructors; the codec registry uses
+  # `var Codec = codec.Register(&fooCodec{})` named singletons.

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,17 +1,17 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-25T22:06:17.306Z",
+  "generatedAt": "2026-05-27T14:33:16.872Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
     {
       "type": "feat",
       "scope": "kernel",
       "breaking": false,
-      "summary": "add snapshot.Value[T] copy-on-write primitive + consolidate codec registry (ADR 0011)",
-      "sha": "6dd281443c62835293c3f77144cff4801a79eb73",
-      "short": "6dd2814",
-      "date": "2026-05-25T23:53:33+02:00"
+      "summary": "add snapshot.Value[T] copy-on-write primitive + consolidate codec registry (ADR 0011) (#34)",
+      "sha": "7cdda6956418834f17a92ffcf3620fc7591bf4be",
+      "short": "7cdda69",
+      "date": "2026-05-26T01:38:33+02:00"
     },
     {
       "type": "fix",

--- a/internal/core/codec/registry_external_test.go
+++ b/internal/core/codec/registry_external_test.go
@@ -190,3 +190,105 @@ func TestAvailable(t *testing.T) {
 		})
 	}
 }
+
+// TestRegistryHitPaths covers the success arms the miss-only tables above
+// never reach: a resolved Lookup / LookupMIME / LookupExt, MIME-parameter
+// stripping, the malformed-MIME manual fallback, and case-insensitive
+// extension matching. Sequential — it mutates the process-wide registry.
+func TestRegistryHitPaths(t *testing.T) {
+	//: clean slate so the assertions below see exactly the one codec we add.
+	codec.ResetForTest()
+	mc := &mockCodec{
+		name: "cov-hit",
+		mime: []string{"application/x-cov"},
+		ext:  []string{".cov"},
+	}
+	codec.Register(mc)
+	tests := []struct {
+		name   string
+		lookup func() (codec.Codec, bool)
+		wantOK bool
+	}{
+		{"Lookup resolves the registered Format", func() (codec.Codec, bool) {
+			return codec.Lookup(codec.Format("cov-hit"))
+		}, true},
+		{"LookupMIME resolves the bare media type", func() (codec.Codec, bool) {
+			return codec.LookupMIME("application/x-cov")
+		}, true},
+		{"LookupMIME strips the charset parameter", func() (codec.Codec, bool) {
+			return codec.LookupMIME("application/x-cov; charset=utf-8")
+		}, true},
+		{"LookupMIME on a malformed header falls back and resolves", func() (codec.Codec, bool) {
+			return codec.LookupMIME("application/x-cov; =bad")
+		}, true},
+		{"LookupExt resolves the registered extension", func() (codec.Codec, bool) {
+			return codec.LookupExt(".cov")
+		}, true},
+		{"LookupExt matches case-insensitively", func() (codec.Codec, bool) {
+			return codec.LookupExt(".COV")
+		}, true},
+		//: index is seeded but the key is absent — exercises the !found arm
+		//: that the m==nil empty-registry test never reaches.
+		{"LookupMIME misses an absent key on a populated index", func() (codec.Codec, bool) {
+			return codec.LookupMIME("application/x-absent")
+		}, false},
+		{"LookupExt misses an absent key on a populated index", func() (codec.Codec, bool) {
+			return codec.LookupExt(".absent")
+		}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			//: sequential — shares the process-wide registry seeded above.
+			if _, ok := tc.lookup(); ok != tc.wantOK {
+				t.Errorf("%s: ok=%v want %v", tc.name, ok, tc.wantOK)
+			}
+		})
+	}
+	//: Available must now surface the freshly registered Format.
+	found := false
+	for _, f := range codec.Available() {
+		//: scan for our codec among the sorted Formats.
+		if f == codec.Format("cov-hit") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Available() = %v, want it to contain cov-hit", codec.Available())
+	}
+}
+
+// TestRegistryEmptyMisses covers the nil-snapshot arms of every reader:
+// before any Register (the documented init-order edge), loadRegistry and
+// loadAliasIndex return nil so each lookup is a clean miss and Available is
+// nil. Sequential — parallel tables only resume after the sequential phase,
+// so resetting the global here never races a concurrent reader.
+func TestRegistryEmptyMisses(t *testing.T) {
+	//: drive all three snapshots back to nil to hit the absence branches.
+	codec.ResetForTest()
+	tests := []struct {
+		name   string
+		lookup func() (codec.Codec, bool)
+	}{
+		{"Lookup misses on empty registry", func() (codec.Codec, bool) {
+			return codec.Lookup(codec.Format("cov-hit"))
+		}},
+		{"LookupMIME misses on empty index", func() (codec.Codec, bool) {
+			return codec.LookupMIME("application/x-cov")
+		}},
+		{"LookupExt misses on empty index", func() (codec.Codec, bool) {
+			return codec.LookupExt(".cov")
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			//: every reader must report a miss against the nil snapshot.
+			if _, ok := tc.lookup(); ok {
+				t.Errorf("%s: ok=true, want false on empty registry", tc.name)
+			}
+		})
+	}
+	//: Available must return the documented nil slice when nothing is registered.
+	if got := codec.Available(); got != nil {
+		t.Errorf("Available() = %v, want nil on empty registry", got)
+	}
+}

--- a/internal/core/codec/scratch/scratch_external_test.go
+++ b/internal/core/codec/scratch/scratch_external_test.go
@@ -79,6 +79,35 @@ func TestReleaseBuffer(t *testing.T) {
 	}
 }
 
+// TestReleaseNilIsNoOp covers the nil-safe guards: the documented contract
+// lets callers `defer scratch.ReleaseBuffer(b)` / `ReleaseReader(r)` before
+// the acquire could have failed, so a nil argument must be a silent no-op
+// rather than a panic.
+func TestReleaseNilIsNoOp(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		release func()
+	}{
+		{"ReleaseBuffer(nil)", func() { scratch.ReleaseBuffer(nil) }},
+		{"ReleaseReader(nil)", func() { scratch.ReleaseReader(nil) }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: a recovered panic is the failure signal — a nil release must
+			//: complete cleanly, so any panic here fails the assertion.
+			defer func() {
+				//: recover surfaces a panic as an explicit test failure.
+				if rec := recover(); rec != nil {
+					t.Errorf("%s panicked: %v", tc.name, rec)
+				}
+			}()
+			tc.release()
+		})
+	}
+}
+
 // TestBufferPoolConcurrent hammers Acquire/Release from many goroutines so
 // the race detector can prove the shared pool is safe for concurrent use.
 func TestBufferPoolConcurrent(t *testing.T) {

--- a/internal/kernel/errs/accessors_external_test.go
+++ b/internal/kernel/errs/accessors_external_test.go
@@ -165,6 +165,33 @@ func TestFieldsOf(t *testing.T) {
 	}
 }
 
+// TestFieldsOfAbsent covers the absence arm of FieldsOf: a chain carrying no
+// *Error layer must yield nil rather than an empty-but-non-nil slice.
+func TestFieldsOfAbsent(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   func(tb testing.TB) error
+	}
+	tests := []tc{
+		{"stdlib error", func(_ testing.TB) error { return errors.New("plain") }},
+		{"nil error", func(_ testing.TB) error { return nil }},
+	}
+	runCase := func(t *testing.T, c tc) {
+		t.Helper()
+		//: no sdk layer present → the accessor returns a nil slice.
+		if got := errs.FieldsOf(c.in(t)); got != nil {
+			t.Errorf("FieldsOf = %v, want nil", got)
+		}
+	}
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, c)
+		})
+	}
+}
+
 func TestHTTPStatusOf(t *testing.T) {
 	t.Parallel()
 	type tc struct {
@@ -261,6 +288,9 @@ func TestHasReason(t *testing.T) {
 		{"direct match", func(tb testing.TB) error { return newAccessorsSentinel(tb) }, "WRITER_NIL_ACC", true},
 		{"miss", func(tb testing.TB) error { return newAccessorsSentinel(tb) }, "OTHER", false},
 		{"nil", func(tb testing.TB) error { return nil }, "ANY", false},
+		//: stdlib error in the chain — the AsType walk hits a non-*Error and
+		//: must stop without a match (exercises the !ok exhaustion branch).
+		{"stdlib has no sdk layer", func(tb testing.TB) error { return errors.New("plain") }, "ANY", false},
 	}
 	runCase := func(t *testing.T, c tc) {
 		t.Helper()

--- a/internal/kernel/errs/error_external_test.go
+++ b/internal/kernel/errs/error_external_test.go
@@ -645,3 +645,156 @@ func TestError_Is(t *testing.T) {
 		})
 	}
 }
+
+// TestError_Error_RendersTrail covers the non-empty-trail formatting arm of
+// Error(): wrapping an *Error with a non-zero wrap Code appends a trail entry,
+// so the rendered header carries the origin code, the " <- " separator, the
+// wrap-site code, then the inherited Reason and public message.
+func TestError_Error_RendersTrail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+	}{
+		{"single wrap renders one <- separated trail code"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: 0x00_03_0F_70 = origin slot; 0x00_03_0F_71 = wrap-site slot.
+			origin := errs.Define(0x00_03_0F_70, "ORIGIN_TRAIL",
+				"origin public", "origin private")
+			wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_03_0F_71})
+			got := wrapped.Error()
+			//: a populated trail must render the ASCII wrap separator.
+			if !strings.Contains(got, " <- ") {
+				t.Errorf("Error() = %q, want ' <- ' trail separator", got)
+			}
+			//: origin-wins — Reason and public come from the wrapped cause.
+			if !strings.Contains(got, "ORIGIN_TRAIL") || !strings.Contains(got, "origin public") {
+				t.Errorf("Error() = %q, want origin reason + public", got)
+			}
+			//: Private must never leak into the rendered form.
+			if strings.Contains(got, "origin private") {
+				t.Errorf("Error() leaked Private: %q", got)
+			}
+		})
+	}
+}
+
+// TestError_Error_RendersTruncated drives the trail past its cap so the
+// monotonic truncation marker " (truncated)" is rendered before the Reason.
+func TestError_Error_RendersTruncated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		wraps int
+	}{
+		{"forty wraps overflow the trail cap", 40},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: 0x00_03_0F_72 = origin slot for the truncation walk.
+			var err error = errs.Define(0x00_03_0F_72, "TRUNC_ORIGIN",
+				"trunc public", "trunc private")
+			//: each wrap adds one distinct non-zero trail code; well past the
+			//: documented cap of 16 this must flip trailTruncated.
+			for i := range tc.wraps {
+				//: 0x00_07_01_xx — distinct non-zero wrap codes in layer 7.
+				err = errs.Wrap(err, errs.WrapParams{Code: errs.Code(0x00_07_01_00 + i + 1)})
+			}
+			got := err.Error()
+			//: overflow must surface the verbatim marker operators grep for.
+			if !strings.Contains(got, "(truncated)") {
+				t.Errorf("Error() = %q, want '(truncated)' marker", got)
+			}
+		})
+	}
+}
+
+// TestWrap_TypedNilErrorCause covers the typed-nil guard in Wrap: a
+// (*errs.Error)(nil) cause must collapse to the stdlib path with a nil source
+// rather than dereferencing the nil receiver.
+func TestWrap_TypedNilErrorCause(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+	}{
+		{"typed-nil *Error cause yields a params-driven error with nil source"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: a typed-nil *Error is the classic interface-holding-nil trap.
+			var cause *errs.Error
+			//: 0x00_03_0F_73 = wrap slot for the typed-nil path.
+			wrapped := errs.Wrap(cause, errs.WrapParams{
+				Code: 0x00_03_0F_73, Reason: "TYPED_NIL_WRAP",
+				Public: "typed nil collapses to stdlib path", Private: "debug",
+			})
+			//: params apply because no *Error was inherited from the cause.
+			if wrapped.Code() != 0x00_03_0F_73 {
+				t.Errorf("Code = %s, want params code", wrapped.Code())
+			}
+			//: the collapsed path carries no wrapped cause.
+			if wrapped.Source() != nil {
+				t.Errorf("Source = %v, want nil", wrapped.Source())
+			}
+		})
+	}
+}
+
+// TestError_Is_MatchesTrailPrefix covers the trail-walk arm of matchesPrefix:
+// the origin code falls outside the matcher's subnet but a wrap-site trail
+// code falls inside it, so errors.Is must still report a hit.
+func TestError_Is_MatchesTrailPrefix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+	}{
+		{"prefix matches a trail entry the origin misses"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: origin sits in layer 3; the matcher targets layer 7.
+			origin := errs.Define(0x00_03_0F_74, "PREFIX_TRAIL_ORIGIN",
+				"prefix trail public", "prefix trail private")
+			//: wrap with a layer-7 code so only the trail entry can match.
+			wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_07_01_01})
+			//: subnet over major+layer == 0.7 — origin (layer 3) misses it.
+			matcher := errs.NewPrefixMatcher(0x00_07_00_00, errs.MaskByLayer)
+			if !errors.Is(wrapped, matcher) {
+				t.Errorf("errors.Is(wrapped, layer-7 matcher) = false, want true via trail")
+			}
+		})
+	}
+}
+
+// TestHasCode_MultiUnwrap covers the multi-error Unwrap arm of HasCode: an
+// errors.Join aggregate exposes Unwrap() []error, and HasCode must recurse
+// through every branch to find a matching *Error code.
+func TestHasCode_MultiUnwrap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		code errs.Code
+		want bool
+	}{
+		{"code present in a joined branch", 0x00_03_0F_75, true},
+		{"code absent from every branch", 0x00_03_0F_76, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: 0x00_03_0F_75 = the sdk branch buried inside the join.
+			sdk := errs.Define(0x00_03_0F_75, "JOINED_SDK",
+				"joined public", "joined private")
+			//: errors.Join exposes Unwrap() []error, forcing the multi walk.
+			joined := errors.Join(errors.New("plain branch"), sdk)
+			if got := errs.HasCode(joined, tc.code); got != tc.want {
+				t.Errorf("HasCode(joined, %s) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/kernel/errs/field_external_test.go
+++ b/internal/kernel/errs/field_external_test.go
@@ -169,6 +169,9 @@ func TestFieldValue_StringValue(t *testing.T) {
 		{"int", func() errs.FieldValue { return errs.Int("k", 42) }, "42"},
 		{"bool", func() errs.FieldValue { return errs.Bool("k", true) }, "true"},
 		{"float", func() errs.FieldValue { return errs.Float("k", 0.5) }, "0.5"},
+		//: zero-value FieldValue was never built through a constructor — its
+		//: fieldInvalid kind must degrade to "" rather than panic.
+		{"zero-value degrades to empty", func() errs.FieldValue { return errs.FieldValue{} }, ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/kernel/snapshot/CLAUDE.md
+++ b/internal/kernel/snapshot/CLAUDE.md
@@ -13,7 +13,7 @@ lives here, the domain clone logic stays with the consumer (ADR 0011).
 
 | Primitive | Surface | Use case |
 |---|---|---|
-| `Value[T]` | `New[T any](initial *T)` → `Load` / `Store` / `Swap` / `Update` | read-mostly shared state: registries, routing tables, hot-reloaded config |
+| `Value[T]` | `NewValue[T any](initial *T)` → `Load` / `Store` / `Swap` / `Update` | read-mostly shared state: registries, routing tables, hot-reloaded config |
 
 ## Conventions
 
@@ -24,7 +24,7 @@ lives here, the domain clone logic stays with the consumer (ADR 0011).
   so a read-modify-write (`Update`) cannot lose a concurrent write. Readers
   never take the lock.
 - **The zero value is usable.** `var v Value[T]` reads nil until the first
-  `Store`; `New` is call-site sugar when an initial value is known.
+  `Store`; `NewValue` is call-site sugar when an initial value is known.
 - **Concrete struct, no interface.** Like `recycler` (ADR 0010), snapshot ships
   a concrete struct by deliberate choice — a single-impl interface would be
   over-abstraction (ADR 0011). The `Value` role suffix passes `KTN-STRUCT-ROLE`

--- a/internal/kernel/snapshot/snapshot.go
+++ b/internal/kernel/snapshot/snapshot.go
@@ -30,10 +30,10 @@ type Value[T any] struct {
 	p atomic.Pointer[T]
 }
 
-// New returns a Value holding initial. A nil initial is valid and leaves the
-// container empty (Load returns nil), the same state as the zero value —
+// NewValue returns a Value holding initial. A nil initial is valid and leaves
+// the container empty (Load returns nil), the same state as the zero value —
 // offered as call-site sugar when an initial value is already known.
-func New[T any](initial *T) *Value[T] {
+func NewValue[T any](initial *T) *Value[T] {
 	//: build the empty container; the zero value is already usable.
 	v := &Value[T]{}
 	//: a nil initial is a legitimate empty snapshot, not a programmer error.

--- a/internal/kernel/snapshot/snapshot_external_test.go
+++ b/internal/kernel/snapshot/snapshot_external_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/kitsunium/sdk/internal/kernel/snapshot"
 )
 
-// TestNew validates the constructor contract: a nil initial yields an empty
-// container (Load returns nil), a non-nil initial is observable on first Load.
-func TestNew(t *testing.T) {
+// TestNewValue validates the constructor contract: a nil initial yields an
+// empty container (Load returns nil), a non-nil initial is observable on first
+// Load.
+func TestNewValue(t *testing.T) {
 	t.Parallel()
 	type tc struct {
 		name    string
@@ -25,7 +26,7 @@ func TestNew(t *testing.T) {
 	//: branch; the constructed container must reflect the initial argument.
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		v := snapshot.New(tc.initial)
+		v := snapshot.NewValue(tc.initial)
 		got := v.Load()
 		//: nil-initial path: Load must observe the empty (nil) state.
 		if tc.wantNil {
@@ -147,7 +148,7 @@ func TestValue_Update(t *testing.T) {
 	//: branch; an abort leaves the prior value installed unchanged.
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		v := snapshot.New(new(10))
+		v := snapshot.NewValue(new(10))
 		v.Update(func(current *int) *int {
 			//: the abort case returns the current pointer unchanged.
 			if tc.abort {
@@ -188,7 +189,7 @@ func TestValue_ConcurrentUpdateLoad(t *testing.T) {
 	//: branch; the final count must equal the total number of Update calls.
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		v := snapshot.New(new(0))
+		v := snapshot.NewValue(new(0))
 		var reads atomic.Uint64
 		var wg sync.WaitGroup
 		//: spawn writer goroutines that each increment via serialised Update.

--- a/internal/kernel/snapshot/snapshot_integration_test.go
+++ b/internal/kernel/snapshot/snapshot_integration_test.go
@@ -22,7 +22,7 @@ var allocSink any
 // `--config=pure`.
 func TestZeroAllocInvariant(t *testing.T) {
 	a, b := 1, 2
-	v := snapshot.New(&a)
+	v := snapshot.NewValue(&a)
 	type tc struct {
 		name string
 		fn   func()

--- a/internal/service/codec/baseenc/buffering_writer_internal_test.go
+++ b/internal/service/codec/baseenc/buffering_writer_internal_test.go
@@ -2,8 +2,25 @@ package baseenc
 
 import (
 	"bytes"
+	"errors"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
+
+// errFlushWriter rejects every Write with a fixed error, used to drive the
+// bufferingWriter.Close writer-error arm (distinct from the short-write arm
+// which the shortWriter in codec_internal_test.go covers).
+type errFlushWriter struct{}
+
+// Write always fails so Close's flush surfaces the wrapped writer error.
+func (errFlushWriter) Write(p []byte) (n int, err error) {
+	//: any non-nil error is sufficient to drive the wrap branch.
+	return 0, errFlushFailed
+}
+
+// errFlushFailed is the sentinel returned by errFlushWriter.Write.
+var errFlushFailed = errors.New("flush writer failed (synthetic)")
 
 // Test_bufferingWriter_Write exercises the buffered Write path across
 // distinct payload shapes to confirm the underlying bytes.Buffer
@@ -66,6 +83,44 @@ func Test_bufferingWriter_Close(t *testing.T) {
 		wantLen := len(tc.payload) * 2
 		if sink.Len() != wantLen {
 			t.Errorf("%s: Close emitted %d bytes, want %d", tc.name, sink.Len(), wantLen)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
+// Test_bufferingWriter_Close_writerError drives the Close writer-error arm:
+// a sink that rejects every Write makes the flush fail, so Close wraps the
+// underlying error with CodeBaseEncMarshalFailed. Distinct from the
+// short-write arm (Test_bufferingWriter_ShortWrite_C2) where the writer
+// accepts only part of the payload.
+func Test_bufferingWriter_Close_writerError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		payload []byte
+	}
+	tests := []tc{{"flush failure wraps marshal-failed", []byte("data")}}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &baseencCodec{variant: variantBase16}
+		w := &bufferingWriter{dst: errFlushWriter{}, codec: c}
+		if _, err := w.Write(tc.payload); err != nil {
+			t.Fatalf("%s: Write err=%v", tc.name, err)
+		}
+		err := w.Close()
+		if err == nil {
+			t.Fatalf("%s: expected error on flush failure", tc.name)
+		}
+		//: the wrap must carry the typed dotted-quad code.
+		if !errs.HasCode(err, CodeBaseEncMarshalFailed) {
+			t.Errorf("%s: expected CodeBaseEncMarshalFailed, got %v", tc.name, err)
+		}
+		//: the synthetic sink error must survive the wrap so errors.Is keeps
+		//: resolving the underlying cause.
+		if !errors.Is(err, errFlushFailed) {
+			t.Errorf("%s: expected errFlushFailed in chain, got %v", tc.name, err)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/baseenc/codec_internal_test.go
+++ b/internal/service/codec/baseenc/codec_internal_test.go
@@ -780,6 +780,56 @@ func Test_baseencCodec_streamReader(t *testing.T) {
 	}
 }
 
+// Test_baseencCodec_unknownVariant_defaults exercises the defensive
+// fall-through return in every variant-dispatch switch (encodeBytes,
+// decodeBytes, appendEncode, streamWriter, streamReader). These arms are
+// unreachable in production because Register only stores the six known
+// variants, but a white-box test can construct an out-of-range value to
+// prove the defaults behave as documented (nil / dst-unchanged / pass-through).
+// The sentinel is built inline as variant(0xFF) rather than a named const so
+// it is not treated as an enumerated member by KTN-SWITCH-EXHAUSTIVE.
+func Test_baseencCodec_unknownVariant_defaults(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"unknown variant hits every dispatch default"}}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: 0xFF is past the last registered iota variant, so every dispatch
+		//: switch falls through to its defensive return.
+		c := &baseencCodec{variant: variant(0xFF)}
+		//: encodeBytes default returns nil for an unknown variant.
+		if got := c.encodeBytes([]byte("x")); got != nil {
+			t.Errorf("%s: encodeBytes(unknown)=%q, want nil", tc.name, got)
+		}
+		//: decodeBytes default returns (nil, nil) — no decode, no error.
+		dec, derr := c.decodeBytes([]byte("x"))
+		if dec != nil || derr != nil {
+			t.Errorf("%s: decodeBytes(unknown)=(%q,%v), want (nil,nil)", tc.name, dec, derr)
+		}
+		//: appendEncode default returns dst unchanged.
+		dst := []byte("prefix")
+		if got := c.appendEncode(slices.Clone(dst), []byte("x")); !bytes.Equal(got, dst) {
+			t.Errorf("%s: appendEncode(unknown)=%q, want %q", tc.name, got, dst)
+		}
+		//: streamWriter default wraps w in a nopWriteCloser.
+		var sink bytes.Buffer
+		w := c.streamWriter(&sink)
+		if _, ok := w.(nopWriteCloser); !ok {
+			t.Errorf("%s: streamWriter(unknown) type=%T, want nopWriteCloser", tc.name, w)
+		}
+		//: streamReader default returns the source reader verbatim.
+		src := bytes.NewReader(nil)
+		if r := c.streamReader(src); r != src {
+			t.Errorf("%s: streamReader(unknown) did not pass through the reader", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
 // TestWrapDecode verifies the (bytes, error) → BASE_ENC_DECODE_FAILED
 // adapter passes the success path through verbatim and wraps failures
 // with the typed sentinel.

--- a/internal/service/codec/baseenc/decoder_internal_test.go
+++ b/internal/service/codec/baseenc/decoder_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	stdjson "encoding/json"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
 
 // Test_baseencDecoder_More reports availability before any Decode call so
@@ -66,6 +68,83 @@ func Test_baseencDecoder_Decode(t *testing.T) {
 		}
 		if got["n"] != 42 {
 			t.Errorf("%s: Decode got=%v, want n=42", tc.name, got)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
+// Test_baseencDecoder_Decode_badJSON drives the Decode error arm: a valid
+// base-N envelope wrapping non-JSON bytes lets the base-N reader succeed
+// while the inner json.Decoder rejects the payload, surfacing
+// CodeBaseEncUnmarshalFailed.
+func Test_baseencDecoder_Decode_badJSON(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		v    variant
+	}
+	tests := []tc{
+		{"base64 bad inner", variantBase64},
+		{"base32 bad inner", variantBase32},
+		{"hex bad inner", variantHex},
+		{"ascii85 bad inner", variantASCII85},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &baseencCodec{variant: tc.v}
+		//: encode malformed JSON so the base-N layer decodes cleanly and the
+		//: json.Decoder trips on the recovered bytes.
+		envelope := c.encodeBytes([]byte("{not-json"))
+		d := c.NewDecoder(bytes.NewReader(envelope))
+		var got map[string]int
+		err := d.Decode(&got)
+		if !errs.HasCode(err, CodeBaseEncUnmarshalFailed) {
+			t.Errorf("%s: expected CodeBaseEncUnmarshalFailed, got %v", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
+// Test_baseencDecoder_More_afterDecode drives the stdlib-delegation arm of
+// More: once Decode has lazily wired the json.Decoder, More reports the
+// presence of a second record in the stream rather than the pre-init
+// src!=nil shortcut.
+func Test_baseencDecoder_More_afterDecode(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		v    variant
+	}
+	tests := []tc{
+		{"base64 more after decode", variantBase64},
+		{"hex more after decode", variantHex},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &baseencCodec{variant: tc.v}
+		//: two JSON records back-to-back so More() returns true after the
+		//: first Decode and false once the stream is drained.
+		stream := c.encodeBytes([]byte(`{"n":1}` + "\n" + `{"n":2}`))
+		d := c.NewDecoder(bytes.NewReader(stream))
+		var first map[string]int
+		if err := d.Decode(&first); err != nil {
+			t.Fatalf("%s: first Decode err=%v", tc.name, err)
+		}
+		//: jsonDec is now non-nil; More must delegate to the stdlib decoder.
+		if !d.More() {
+			t.Errorf("%s: More()=false after first Decode, want true", tc.name)
+		}
+		var second map[string]int
+		if err := d.Decode(&second); err != nil {
+			t.Fatalf("%s: second Decode err=%v", tc.name, err)
+		}
+		//: after draining both records the stdlib decoder reports no more.
+		if d.More() {
+			t.Errorf("%s: More()=true after draining stream, want false", tc.name)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/baseenc/encoder_internal_test.go
+++ b/internal/service/codec/baseenc/encoder_internal_test.go
@@ -2,8 +2,26 @@ package baseenc
 
 import (
 	"bytes"
+	"errors"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
+
+// errEncSink always fails its Write, used to force the streaming encoder's
+// JSON-encode (hex) and base-N Close-flush (base64) error arms. base64
+// buffers a tiny payload until Close, so the failure surfaces from Close;
+// hex writes straight through, so the failure surfaces from Encode.
+type errEncSink struct{}
+
+// Write always rejects the buffer so the encode pipeline cannot complete.
+func (errEncSink) Write(p []byte) (n int, err error) {
+	//: any non-nil error path is sufficient to drive the wrap branch.
+	return 0, errEncSinkFailed
+}
+
+// errEncSinkFailed is the sentinel returned by errEncSink.Write.
+var errEncSinkFailed = errors.New("encoder sink failed (synthetic)")
 
 // Test_baseencEncoder_Encode drives the streaming encoder over every
 // variant so a regression in the json/base-N pipeline wiring fails
@@ -36,6 +54,107 @@ func Test_baseencEncoder_Encode(t *testing.T) {
 		}
 		if sink.Len() == 0 {
 			t.Errorf("%s: Encode+Close produced no bytes", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
+// Test_baseencEncoder_Close_writerError drives the Close error arm. base64
+// buffers a tiny payload internally during Encode and flushes the tail on
+// Close, so a writer that rejects every Write lets Encode succeed yet trips
+// the base-N writer's Close — surfacing CodeBaseEncMarshalFailed.
+func Test_baseencEncoder_Close_writerError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		v    variant
+	}
+	tests := []tc{
+		{"base64 close flush fails", variantBase64},
+		{"base64url close flush fails", variantBase64URL},
+		{"base32 close flush fails", variantBase32},
+		{"ascii85 close flush fails", variantASCII85},
+		{"base16 close flush fails", variantBase16},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &baseencCodec{variant: tc.v}
+		enc := c.NewEncoder(errEncSink{})
+		//: a 1-byte JSON value stays inside the base-N encoder's internal
+		//: buffer, so Encode succeeds and the rejected flush only lands on
+		//: Close where the wrap branch lives.
+		if err := enc.Encode(1); err != nil {
+			t.Fatalf("%s: Encode err=%v (expected buffered success)", tc.name, err)
+		}
+		err := enc.Close()
+		if !errs.HasCode(err, CodeBaseEncMarshalFailed) {
+			t.Errorf("%s: expected CodeBaseEncMarshalFailed, got %v", tc.name, err)
+		}
+		//: the synthetic sink error must survive the wrap.
+		if !errors.Is(err, errEncSinkFailed) {
+			t.Errorf("%s: expected errEncSinkFailed in chain, got %v", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
+// Test_baseencEncoder_Encode_jsonRejected drives the Encode error arm: a
+// chan value is non-encodable by encoding/json so the wrap branch surfaces
+// CodeBaseEncMarshalFailed regardless of the underlying writer.
+func Test_baseencEncoder_Encode_jsonRejected(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		v    variant
+	}
+	tests := []tc{
+		{"base64 rejects chan", variantBase64},
+		{"ascii85 rejects chan", variantASCII85},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &baseencCodec{variant: tc.v}
+		var sink bytes.Buffer
+		enc := c.NewEncoder(&sink)
+		//: chan int is the canonical non-encodable value; json.Encode trips
+		//: before any base-N byte reaches the sink.
+		err := enc.Encode(make(chan int))
+		if !errs.HasCode(err, CodeBaseEncMarshalFailed) {
+			t.Errorf("%s: expected CodeBaseEncMarshalFailed, got %v", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
+	}
+}
+
+// Test_baseencEncoder_Encode_writerError drives the Encode error arm via a
+// writer that rejects every Write. The hex variant streams JSON bytes
+// straight through with no internal buffering, so the failure surfaces
+// from Encode rather than Close.
+func Test_baseencEncoder_Encode_writerError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		v    variant
+	}
+	tests := []tc{{"hex surfaces writer error from Encode", variantHex}}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &baseencCodec{variant: tc.v}
+		enc := c.NewEncoder(errEncSink{})
+		err := enc.Encode(1)
+		if !errs.HasCode(err, CodeBaseEncMarshalFailed) {
+			t.Errorf("%s: expected CodeBaseEncMarshalFailed, got %v", tc.name, err)
+		}
+		//: the synthetic sink error must survive the wrap so errors.Is keeps
+		//: working for callers matching the underlying cause.
+		if !errors.Is(err, errEncSinkFailed) {
+			t.Errorf("%s: expected errEncSinkFailed in chain, got %v", tc.name, err)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/csv/codec_internal_test.go
+++ b/internal/service/codec/csv/codec_internal_test.go
@@ -205,6 +205,134 @@ func Test_csvCodec_Append(t *testing.T) {
 	}
 }
 
+// Test_isPromotionShape covers every branch of the 2x1 promotion-shape
+// guard: the matching shape (header "_json", one body cell), plus each
+// rejecting mismatch (wrong row count, wrong column count on either row,
+// wrong header literal). The matching case is what the existing public
+// tests never produced, leaving the `return true` arm uncovered.
+func Test_isPromotionShape(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		records [][]string
+		want    bool
+	}
+	tests := []tc{
+		//: exact canonical promotion shape — header literal + single body cell.
+		{"canonical promotion shape matches", [][]string{{promotionHeaderCell}, {"{}"}}, true},
+		//: one row only — fails the row-count guard.
+		{"single row rejected", [][]string{{promotionHeaderCell}}, false},
+		//: three rows — fails the row-count guard from the high side.
+		{"three rows rejected", [][]string{{promotionHeaderCell}, {"a"}, {"b"}}, false},
+		//: header row has two columns — fails the header column-count guard.
+		{"wide header rejected", [][]string{{promotionHeaderCell, "x"}, {"a"}}, false},
+		//: body row has two columns — fails the body column-count guard.
+		{"wide body rejected", [][]string{{promotionHeaderCell}, {"a", "b"}}, false},
+		//: correct shape but the wrong header literal — fails the final guard.
+		{"wrong header literal rejected", [][]string{{"other"}, {"a"}}, false},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		if got := isPromotionShape(tc.records); got != tc.want {
+			t.Errorf("%s: isPromotionShape=%v want %v", tc.name, got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// Test_marshalPromotionShape covers the hand-rolled promotion encoder,
+// asserting RFC 4180 framing (header line + quoted body) and the only
+// escape it performs: `"` → `""`. The plain-byte body and the
+// quote-bearing body together exercise both arms of the per-byte loop.
+func Test_marshalPromotionShape(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		body string
+		want string
+	}
+	tests := []tc{
+		//: plain JSON body — exercises only the passthrough loop arm.
+		{"plain body quoted verbatim", `{"a":1}`, "_json\n\"{\"\"a\"\":1}\"\n"},
+		//: body free of quotes — every byte takes the passthrough arm.
+		{"quote-free body", "abc", "_json\n\"abc\"\n"},
+		//: empty body — the loop never runs; framing only.
+		{"empty body", "", "_json\n\"\"\n"},
+		//: lone double-quote — exercises only the `\"` → `\"\"` doubling arm.
+		{"lone quote doubled", `"`, "_json\n\"\"\"\"\n"},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		if got := string(marshalPromotionShape(tc.body)); got != tc.want {
+			t.Errorf("%s: marshalPromotionShape=%q want %q", tc.name, got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// Test_csvCodec_Marshal_PromotionFastPath asserts that Marshal routes the
+// canonical 2x1 promotion shape through marshalPromotionShape (the
+// `!escapeFormulas && isPromotionShape` arm) and that the emitted bytes
+// round-trip back through Unmarshal to the identical matrix. The escape
+// variant of the same shape must NOT take the fast-path (escapeFormulas
+// gates it), so it still produces valid CSV via the writer path.
+func Test_csvCodec_Marshal_PromotionFastPath(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name  string
+		codec *csvCodec
+		body  string
+		fast  bool
+	}
+	tests := []tc{
+		//: default codec (escape off) takes the hand-rolled fast-path.
+		{"default codec uses fast-path", &csvCodec{}, `{"k":"v"}`, true},
+		//: escape-on codec bypasses the fast-path even on the promotion shape.
+		{"escape codec bypasses fast-path", &csvCodec{escapeFormulas: true}, `{"k":"v"}`, false},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		in := [][]string{{promotionHeaderCell}, {tc.body}}
+		out, err := tc.codec.Marshal(in)
+		if err != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, err)
+		}
+		//: the fast-path emits exactly what marshalPromotionShape would;
+		//: assert byte-equality only on that arm so a routing regression
+		//: (fast-path silently skipped) is caught.
+		if tc.fast {
+			want := string(marshalPromotionShape(tc.body))
+			if string(out) != want {
+				t.Errorf("%s: fast-path bytes=%q want %q", tc.name, out, want)
+			}
+		}
+		//: both arms must round-trip back to the original matrix.
+		var got [][]string
+		if uerr := tc.codec.Unmarshal(out, &got); uerr != nil {
+			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
+		}
+		if len(got) != 2 || got[0][0] != promotionHeaderCell || got[1][0] != tc.body {
+			t.Errorf("%s: round-trip=%v want [[%q] [%q]]", tc.name, got, promotionHeaderCell, tc.body)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
 // Test_detachAndRelease covers the size-aware release paths.
 func Test_detachAndRelease(t *testing.T) {
 	t.Parallel()

--- a/internal/service/codec/flatbuffers/codec_internal_test.go
+++ b/internal/service/codec/flatbuffers/codec_internal_test.go
@@ -2,6 +2,7 @@ package flatbuffers
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/kitsunium/sdk/internal/kernel/errs"
@@ -114,6 +115,59 @@ func Test_flatbuffersCodec_Extensions(t *testing.T) {
 	}
 }
 
+// Test_flatbuffersCodec_Marshal exercises Marshal directly: the
+// PromotionMagic fast-path (recognise our own wrapper bytes and skip
+// resolve+validate), the regular []byte validation route, and the
+// shape-rejection branch.
+func Test_flatbuffersCodec_Marshal(t *testing.T) {
+	t.Parallel()
+	//: stamp a buffer whose LE uint32 header == PromotionMagic so Marshal
+	//: takes the promotion fast-path (lines 99-102).
+	promoted := make([]byte, 8)
+	binary.LittleEndian.PutUint32(promoted, PromotionMagic)
+	type tc struct {
+		name    string
+		in      any
+		wantLen int
+		wantErr string
+	}
+	tests := []tc{
+		//: promotion-sentinel fast-path — bytes returned verbatim.
+		{"promotion-magic-fast-path", promoted, len(promoted), ""},
+		//: regular route — a valid 4-byte buffer passes resolve+validate.
+		{"regular-bytes-validated", []byte{1, 2, 3, 4}, 4, ""},
+		//: shape rejection — int is neither []byte nor BytesProvider.
+		{"bad-type-rejected", 42, 0, "FLATBUFFERS_BAD_TYPE"},
+		//: truncated regular buffer fails validation (not promotion-marked).
+		{"truncated-rejected", []byte{1, 2}, 0, "FLATBUFFERS_TRUNCATED"},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := &flatbuffersCodec{}
+		got, err := c.Marshal(tc.in)
+		//: error branch — assert the reason and that no bytes leak out.
+		if tc.wantErr != "" {
+			if !errs.HasReason(err, tc.wantErr) {
+				t.Errorf("%s: expected %s, got %v", tc.name, tc.wantErr, err)
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, err)
+		}
+		//: success branch — passthrough returns the bytes verbatim.
+		if len(got) != tc.wantLen {
+			t.Errorf("%s: len=%d want %d", tc.name, len(got), tc.wantLen)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
 // Test_validateBuffer exercises the size invariants directly.
 func Test_validateBuffer(t *testing.T) {
 	t.Parallel()
@@ -126,6 +180,9 @@ func Test_validateBuffer(t *testing.T) {
 		{"exact header passes", []byte{0, 0, 0, 0}, ""},
 		{"empty buffer surfaces FLATBUFFERS_TRUNCATED", nil, "FLATBUFFERS_TRUNCATED"},
 		{"three bytes surfaces FLATBUFFERS_TRUNCATED", []byte{1, 2, 3}, "FLATBUFFERS_TRUNCATED"},
+		//: one byte past the 64 MiB ceiling trips the max-size guard
+		//: (lines 205-213) — the CWE-400 blast-radius cap.
+		{"over-cap surfaces FLATBUFFERS_TRUNCATED", make([]byte, maxFlatBuffersBytes+1), "FLATBUFFERS_TRUNCATED"},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()

--- a/internal/service/codec/json/codec_internal_test.go
+++ b/internal/service/codec/json/codec_internal_test.go
@@ -83,18 +83,43 @@ func Test_jsonCodec_Extensions(t *testing.T) {
 	}
 }
 
-// Test_jsonCodec_Marshal exercises the Marshal path with a single canonical case.
+// Test_jsonCodec_Marshal exercises the Marshal path: the reflect route,
+// the RawMessage pre-encoded fast-path, and the wrapped-error branch.
 func Test_jsonCodec_Marshal(t *testing.T) {
 	t.Parallel()
 	type tc struct {
-		name string
+		name    string
+		in      any
+		want    string
+		wantErr bool
 	}
-	tests := []tc{{"canonical marshal"}}
+	tests := []tc{
+		//: reflect route — map encodes via stdjson.Marshal.
+		{"reflect-route", map[string]int{"a": 1}, `{"a":1}`, false},
+		//: RawMessage fast-path — Marshal returns the pre-encoded bytes
+		//: verbatim (lines 55-58) instead of the reflect round-trip.
+		{"raw-message-fast-path", stdjson.RawMessage(`{"pre":true}`), `{"pre":true}`, false},
+		//: error route — a channel cannot be JSON-encoded, so stdjson.Marshal
+		//: fails and Marshal wraps it (lines 67-72).
+		{"unsupported-value-wraps-error", make(chan int), "", true},
+	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
 		c := &jsonCodec{}
-		if _, err := c.Marshal(map[string]int{"a": 1}); err != nil {
+		out, err := c.Marshal(tc.in)
+		//: error branch — verify failure surfaced, value bytes irrelevant.
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+			return
+		}
+		if err != nil {
 			t.Fatalf("%s: Marshal err=%v", tc.name, err)
+		}
+		//: success branch — assert exact wire bytes for both routes.
+		if string(out) != tc.want {
+			t.Errorf("%s: Marshal=%q want %q", tc.name, out, tc.want)
 		}
 	}
 	for _, tc := range tests {
@@ -184,6 +209,9 @@ func Test_jsonCodec_Append(t *testing.T) {
 	tests := []tc{
 		{"appends to empty buffer", nil, map[string]int{"k": 1}, []byte(`{"k":1}`), false},
 		{"appends to non-empty buffer", []byte("prefix:"), 7, []byte("prefix:7"), false},
+		//: RawMessage fast-path — Append writes the pre-encoded bytes onto
+		//: dst directly (lines 139-142), skipping the scratch encoder.
+		{"raw-message-fast-path", []byte("pre:"), stdjson.RawMessage(`{"x":1}`), []byte(`pre:{"x":1}`), false},
 		{"unsupported value yields error", nil, make(chan int), nil, true},
 	}
 	runCase := func(t *testing.T, tc tc) {

--- a/internal/service/codec/msgpack/codec_internal_test.go
+++ b/internal/service/codec/msgpack/codec_internal_test.go
@@ -3,6 +3,8 @@ package msgpack
 import (
 	"bytes"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
 
 // Test_msgpackCodec_Name covers the canonical identifier returned by the codec.
@@ -108,15 +110,26 @@ func Test_msgpackCodec_Marshal(t *testing.T) {
 func Test_msgpackCodec_Unmarshal(t *testing.T) {
 	t.Parallel()
 	type tc struct {
-		name string
+		name    string
+		data    []byte
+		wantErr string
 	}
-	tests := []tc{{"canonical unmarshal"}}
+	tests := []tc{
+		//: malformed byte 0xc1 (reserved/never-used) drives the library
+		//: decode error → UNMARSHAL_FAILED wrap.
+		{"malformed-byte-fails", []byte{0xc1}, "UNMARSHAL_FAILED"},
+		//: input one byte past maxMsgPackBytes trips the size-cap guard
+		//: (lines 116-124) before any decode — the DoS defence branch.
+		{"over-cap-rejected", make([]byte, maxMsgPackBytes+1), "UNMARSHAL_FAILED"},
+	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
 		c := &msgpackCodec{}
 		var out map[string]int
-		if err := c.Unmarshal([]byte{0xc1}, &out); err == nil {
-			t.Errorf("%s: expected Unmarshal error", tc.name)
+		err := c.Unmarshal(tc.data, &out)
+		//: every case here expects a failure — assert the reason matches.
+		if !errs.HasReason(err, tc.wantErr) {
+			t.Errorf("%s: expected %s, got %v", tc.name, tc.wantErr, err)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/ndjson/codec_internal_test.go
+++ b/internal/service/codec/ndjson/codec_internal_test.go
@@ -86,18 +86,42 @@ func Test_ndjsonCodec_Extensions(t *testing.T) {
 	}
 }
 
-// Test_ndjsonCodec_Marshal exercises the Marshal path with a single canonical case.
+// Test_ndjsonCodec_Marshal exercises the Marshal path: the reflect slice
+// route, the pre-encoded raw-slice fast-path, and the VALUE_INVALID branch.
 func Test_ndjsonCodec_Marshal(t *testing.T) {
 	t.Parallel()
 	type tc struct {
-		name string
+		name    string
+		in      any
+		want    string
+		wantErr bool
 	}
-	tests := []tc{{"canonical marshal"}}
+	tests := []tc{
+		//: reflect route — []int encodes per-element via stdjson.Marshal.
+		{"reflect-slice-route", []int{1, 2}, "1\n2\n", false},
+		//: raw-slice fast-path — []json.RawMessage bypasses the reflect
+		//: walk (lines 73-76), the exact shape promote.go produces.
+		{"raw-message-fast-path", []stdjson.RawMessage{[]byte(`{"a":1}`), []byte(`{"b":2}`)}, "{\"a\":1}\n{\"b\":2}\n", false},
+		//: non-slice argument trips the VALUE_INVALID shape guard.
+		{"non-slice-rejected", 42, "", true},
+	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
 		c := &ndjsonCodec{}
-		if _, err := c.Marshal([]int{1, 2}); err != nil {
+		out, err := c.Marshal(tc.in)
+		//: error branch — assert failure, ignore bytes.
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+			return
+		}
+		if err != nil {
 			t.Fatalf("%s: Marshal err=%v", tc.name, err)
+		}
+		//: success branch — exact wire bytes for both routes.
+		if string(out) != tc.want {
+			t.Errorf("%s: Marshal=%q want %q", tc.name, out, tc.want)
 		}
 	}
 	for _, tc := range tests {
@@ -143,6 +167,9 @@ func Test_asSlice(t *testing.T) {
 		{"direct slice", []int{1}, true},
 		{"pointer to slice", &[]int{1}, true},
 		{"non-slice value", 42, false},
+		//: nil typed pointer trips the IsNil guard (lines 410-413) — a nil
+		//: pointer cannot carry a slice, so the helper rejects it.
+		{"nil pointer rejected", (*[]int)(nil), false},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
@@ -196,12 +223,16 @@ func Test_decodeLines(t *testing.T) {
 		wantLen int
 		wantErr bool
 	}
+	//: a single record one byte past scannerMaxCapacity (no '\n') trips
+	//: the per-record size guard (lines 298-306) BEFORE any decode.
+	oversizeLine := string(bytes.Repeat([]byte{'a'}, scannerMaxCapacity+1))
 	tests := []tc{
 		{"two valid records", "1\n2\n", 2, false},
 		{"bad JSON surfaces error", "not json\n", 0, true},
 		{"trailing record without newline", "1\n2", 2, false},
 		{"empty input", "", 0, false},
 		{"blank lines skipped", "\n1\n\n2\n", 2, false},
+		{"oversize record exceeds cap", oversizeLine, 0, true},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
@@ -273,6 +304,9 @@ func Test_ndjsonCodec_Append(t *testing.T) {
 	tests := []tc{
 		{"appends one record per slice element", nil, []int{1, 2}, []byte("1\n2\n"), false},
 		{"appends to non-empty buffer", []byte("prefix:"), []int{3}, []byte("prefix:3\n"), false},
+		//: raw-slice fast-path — []json.RawMessage writes pre-encoded rows
+		//: straight onto dst (lines 361-364), skipping the reflect walk.
+		{"raw-message-fast-path", []byte("pre:"), []stdjson.RawMessage{[]byte(`{"a":1}`)}, []byte("pre:{\"a\":1}\n"), false},
 		{"non-slice value yields error", nil, 7, nil, true},
 		{"per-record marshal failure surfaces error", nil, []any{make(chan int)}, nil, true},
 	}

--- a/internal/service/codec/pem/codec_external_test.go
+++ b/internal/service/codec/pem/codec_external_test.go
@@ -1,6 +1,7 @@
 package pem_test
 
 import (
+	"bytes"
 	stdpem "encoding/pem"
 	"testing"
 
@@ -48,6 +49,14 @@ func TestMarshal(t *testing.T) {
 		{"valid block round-trips", &stdpem.Block{Type: "TEST", Bytes: []byte("hello")}, ""},
 		{"wrong type surfaces VALUE_INVALID", "nope", "VALUE_INVALID"},
 		{"nil block surfaces VALUE_INVALID", (*stdpem.Block)(nil), "VALUE_INVALID"},
+		//: Type=="JSON" + no headers is the promotion shape — Marshal takes
+		//: the hand-written fast-path (marshalPromotionBlock).
+		{"promotion-shape block uses fast-path", &stdpem.Block{Type: "JSON", Bytes: []byte("hello")}, ""},
+		//: a header KEY containing a colon makes encoding/pem.Encode return
+		//: a non-writer error (pem.go: "header key that contains a colon"),
+		//: driving the MARSHAL_FAILED wrap. Headers != 0 so it bypasses the
+		//: promotion fast-path and reaches stdpem.Encode.
+		{"colon header key surfaces MARSHAL_FAILED", &stdpem.Block{Type: "CERT", Headers: map[string]string{"bad:key": "v"}, Bytes: []byte("x")}, "MARSHAL_FAILED"},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
@@ -97,6 +106,60 @@ func TestUnmarshal(t *testing.T) {
 		}
 		if tc.wantErr != "" && !errs.HasReason(err, tc.wantErr) {
 			t.Errorf("%s: expected %s, got %v", tc.name, tc.wantErr, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestMarshalPromotionShape pins the promotion fast-path
+// (marshalPromotionBlock + insertNewlinesEvery64): for a "JSON"-typed
+// block with no headers, Marshal MUST emit bytes byte-identical to
+// encoding/pem.EncodeToMemory (the production comment guarantees this),
+// and the result MUST round-trip back to the same block. Payload sizes
+// are chosen to hit every line-split shape: zero bytes, a single short
+// line, an exact 48-byte input (one full 64-char base64 line), and a
+// multi-line payload whose final line is partial.
+func TestMarshalPromotionShape(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		payload []byte
+	}
+	tests := []tc{
+		//: empty payload — bodyLen 0, lineCount 0 (loop body never runs).
+		{"empty payload", []byte{}},
+		//: short payload — one partial base64 line (< 64 chars).
+		{"short single line", []byte("hello")},
+		//: 48 input bytes encode to exactly 64 base64 chars = one full line.
+		{"exact one full line", bytes.Repeat([]byte{0xAB}, 48)},
+		//: 100 input bytes span multiple 64-char lines with a partial tail —
+		//: forces the multi-iteration backwards walk in insertNewlinesEvery64.
+		{"multi-line partial tail", bytes.Repeat([]byte{0x5A}, 100)},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		block := &stdpem.Block{Type: "JSON", Bytes: tc.payload}
+		got, err := pem.New().Marshal(block)
+		if err != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, err)
+		}
+		//: byte-identity contract — the fast-path must equal stdlib output.
+		want := stdpem.EncodeToMemory(block)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s: promotion bytes diverge from pem.EncodeToMemory\n got=%q\nwant=%q", tc.name, got, want)
+		}
+		//: round-trip contract — decoding the fast-path bytes recovers the payload.
+		var back *stdpem.Block
+		if uerr := pem.New().Unmarshal(got, &back); uerr != nil {
+			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
+		}
+		if back.Type != "JSON" || !bytes.Equal(back.Bytes, tc.payload) {
+			t.Errorf("%s: round-trip mismatch: type=%q bytes=%q", tc.name, back.Type, back.Bytes)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/tlv/BUILD.bazel
+++ b/internal/service/codec/tlv/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "encoder_internal_test.go",
         "helpers_internal_test.go",
         "typeinfo_internal_test.go",
+        "types_internal_test.go",
     ],
     embed = [":tlv"],
     deps = [

--- a/internal/service/codec/tlv/codec_external_test.go
+++ b/internal/service/codec/tlv/codec_external_test.go
@@ -403,3 +403,819 @@ func TestRegisteredViaImport(t *testing.T) {
 		})
 	}
 }
+
+// TestDecodeTruncationMatrix marshals a representative value of every wire
+// family, then feeds every strict byte-prefix of the encoding back to
+// Unmarshal. A truncated record must always surface an error (never a
+// panic, never a silent success) — this drives the truncation arms of
+// readTag / readUvarint / readOneRecord / assembleRecord / decodeValue /
+// decodeInt / decodeUint / decodeFloat / decodeString / decodeMap /
+// decodeStruct / decodeFieldName at once.
+func TestDecodeTruncationMatrix(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   any
+	}
+	tests := []tc{
+		{"int64 wide", int64(-1 << 60)},
+		{"uint64 wide", uint64(1 << 60)},
+		{"float64", 2.718281828},
+		{"float32", float32(0.5)},
+		{"string", "hello truncation"},
+		{"bytes", []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		{"slice", []any{int64(1), "two", true}},
+		{"map", map[string]int64{"a": 1, "b": 2}},
+		{"nested struct", rtOuter{
+			Name:  "x",
+			Inner: rtInner{X: 1, Y: "y"},
+			Items: []rtInner{{X: 2}},
+		}},
+		//: a richly nested composite (slice→map→slice→map) so truncation walks
+		//: the deepest generic decode arms (decodeSlice/decodeMap recursion).
+		{"deep nested composite", []any{
+			map[string]any{"rows": []any{
+				map[string]any{"X": int64(1), "Y": "a"},
+				map[string]any{"X": int64(2), "Y": "b"},
+			}},
+		}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: the seed value must encode cleanly before we truncate it.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		//: every strict prefix is a truncated record and must fail to decode.
+		for n := range len(encoded) {
+			var out any
+			//: a truncated buffer must surface an error, never panic or succeed.
+			if err := c.Unmarshal(encoded[:n], &out); err == nil {
+				t.Errorf("%s: Unmarshal of %d/%d bytes succeeded, want error",
+					tc.name, n, len(encoded))
+			}
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeMalformedRecords covers the non-truncation decode errors: an
+// unknown tag byte, trailing bytes after a complete record, and a
+// non-pointer Unmarshal target.
+func TestDecodeMalformedRecords(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name   string
+		decode func(c interface {
+			Unmarshal([]byte, any) error
+			Marshal(any) ([]byte, error)
+		}) error
+	}
+	tests := []tc{
+		{
+			name: "unknown tag byte",
+			decode: func(c interface {
+				Unmarshal([]byte, any) error
+				Marshal(any) ([]byte, error)
+			},
+			) error {
+				var out any
+				//: 0xFF is not a defined tag — decodeScalarByTag default arm.
+				return c.Unmarshal([]byte{0xFF, 0x00}, &out)
+			},
+		},
+		{
+			name: "trailing bytes after one record",
+			decode: func(c interface {
+				Unmarshal([]byte, any) error
+				Marshal(any) ([]byte, error)
+			},
+			) error {
+				//: two concatenated records — Unmarshal expects exactly one.
+				one, merr := c.Marshal(int64(1))
+				//: a Marshal failure here is itself a decode-setup error.
+				if merr != nil {
+					return merr
+				}
+				two := append(append([]byte{}, one...), one...)
+				var out any
+				return c.Unmarshal(two, &out)
+			},
+		},
+		{
+			name: "non-pointer target",
+			decode: func(c interface {
+				Unmarshal([]byte, any) error
+				Marshal(any) ([]byte, error)
+			},
+			) error {
+				one, merr := c.Marshal(int64(1))
+				//: a Marshal failure here is itself a decode-setup error.
+				if merr != nil {
+					return merr
+				}
+				//: a value (non-pointer) target violates the decode contract.
+				var out int64
+				return c.Unmarshal(one, out)
+			},
+		},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		//: every malformed input must surface a non-nil decode error.
+		if err := tc.decode(c); err == nil {
+			t.Errorf("%s: expected a decode error, got nil", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestTypedDecodeTruncation feeds every strict byte-prefix of a valid
+// encoding into a CONCRETE typed target (not interface{}). This drives the
+// error-propagation arms of the typed fast path (decoder_typed.go):
+// decodeStructInto / decodeFieldValue / decodeSliceElement / decodeMapInto /
+// assignMapPair / walkScalarSlice* / narrowAndSet — each of which forwards a
+// read failure the generic path never reaches.
+func TestTypedDecodeTruncation(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		in        any
+		newTarget func() any
+	}
+	tests := []tc{
+		{"scalar into *int64", int64(-1 << 40), func() any { return new(int64) }},
+		{"scalar into *string", "truncate me", func() any { return new(string) }},
+		{"slice of scalar into *[]int64", []int64{1, 2, 3, 4}, func() any { return new([]int64) }},
+		{"slice of struct into *[]rtInner", []rtInner{{X: 1, Y: "a"}, {X: 2}}, func() any { return new([]rtInner) }},
+		{"map into *map[string]int64", map[string]int64{"a": 1, "b": 2}, func() any { return new(map[string]int64) }},
+		{"map of struct into *map[string]rtInner", map[string]rtInner{"k": {X: 1}}, func() any { return new(map[string]rtInner) }},
+		{"nested struct into *rtOuter", rtOuter{
+			Name:   "n",
+			Inner:  rtInner{X: 1, Y: "y"},
+			Items:  []rtInner{{X: 2}},
+			Lookup: map[string]int64{"z": 9},
+			Ptr:    &rtInner{X: 3},
+		}, func() any { return new(rtOuter) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: the seed must encode cleanly before truncation.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		//: every strict prefix into the typed target must fail to decode.
+		for n := range len(encoded) {
+			target := tc.newTarget()
+			//: a truncated typed decode must error, never panic or succeed.
+			if err := c.Unmarshal(encoded[:n], target); err == nil {
+				t.Errorf("%s: typed Unmarshal of %d/%d bytes succeeded, want error",
+					tc.name, n, len(encoded))
+			}
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestTypedDecodeMismatch decodes a complete, valid encoding into a typed
+// target of an incompatible shape. The typed fast path falls back and the
+// generic projector then fails the conversion — driving the incompatible-type
+// arms of convertValue / project* / narrowAndSet.
+func TestTypedDecodeMismatch(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		in        any
+		newTarget func() any
+	}
+	tests := []tc{
+		//: string wire value into a numeric target — cross-shape narrowing fails
+		//: (reflect rejects string→int, unlike the legal int→string rune cast).
+		{"string into *int64", "not a number", func() any { return new(int64) }},
+		//: map wire value into a slice target — composite-shape mismatch.
+		{"map into *[]int64", map[string]int64{"a": 1}, func() any { return new([]int64) }},
+		//: slice wire value into a struct target.
+		{"slice into *rtInner", []any{int64(1), int64(2)}, func() any { return new(rtInner) }},
+		//: struct wire value into a slice target.
+		{"struct into *[]int64", rtInner{X: 1}, func() any { return new([]int64) }},
+		//: struct field whose wire value cannot convert to the field type.
+		{"string field value into int field", map[string]any{"X": "oops"}, func() any { return new(rtInner) }},
+		//: typed map root whose wire value cannot narrow — assignMapPair value
+		//: conversion error inside decodeMapInto.
+		{"map bad value into *map[string]int64", map[string]any{"a": "bad"}, func() any { return new(map[string]int64) }},
+		//: typed map root whose wire key cannot narrow — assignMapPair key
+		//: conversion error.
+		{"map string key into *map[int64]int64", map[string]any{"a": int64(1)}, func() any { return new(map[int64]int64) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: the seed must encode cleanly before the mismatched decode.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		target := tc.newTarget()
+		//: decoding into an incompatible shape must surface an error.
+		if err := c.Unmarshal(encoded, target); err == nil {
+			t.Errorf("%s: mismatched Unmarshal succeeded, want error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeNestedMismatch decodes composites whose NESTED element/value
+// cannot convert to the typed destination. Nesting the offending value
+// inside an outer slice forces the generic projection path (the typed fast
+// path only handles flat roots), so these drive the per-element/value
+// conversion-failure arms of projectSliceToTyped / projectMapToTyped /
+// projectCompositeSlice / projectCompositeMap.
+func TestDecodeNestedMismatch(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		in        any
+		newTarget func() any
+	}
+	tests := []tc{
+		//: a string element cannot narrow to int64 — projectSliceToTyped.
+		{"mixed slice into *[]int64", []any{int64(1), "two"}, func() any { return new([]int64) }},
+		//: slice-of-map with a non-numeric value — projectCompositeSlice →
+		//: projectCompositeMap → projectMapToTyped value error.
+		{"slice of bad map into *[]map", []any{map[string]any{"a": "bad"}}, func() any { return new([]map[string]int64) }},
+		//: slice-of-slice with a bad inner element — projectCompositeSlice
+		//: recursion error.
+		{"slice of bad slice into *[][]int64", []any{[]any{"x"}}, func() any { return new([][]int64) }},
+		//: slice of struct-shaped map with a bad field — projectCompositeSlice
+		//: → projectCompositeStruct → projectMapToStruct conversion error.
+		{"slice of bad struct into *[]struct", []any{map[string]any{"X": "bad"}}, func() any { return new([]rtInner) }},
+		//: slice of pointer-to-struct with a bad field — drives
+		//: projectCompositePointer's error-bubble arm.
+		{"slice of bad ptr-struct into *[]*struct", []any{map[string]any{"X": "bad"}}, func() any { return new([]*rtInner) }},
+		//: a scalar element decoded into a []struct target — decodeSliceElement
+		//: falls back and convertValue(int64 → struct) fails.
+		{"scalar element into *[]struct", []any{int64(1)}, func() any { return new([]rtInner) }},
+		//: a non-slice wire value into a []struct target — typed slice path
+		//: falls back and the generic projector rejects the shape.
+		{"non-slice into *[]struct", int64(5), func() any { return new([]rtInner) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: the seed encodes cleanly; only the typed decode should fail.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		//: the nested conversion failure must surface as a decode error.
+		if err := c.Unmarshal(encoded, tc.newTarget()); err == nil {
+			t.Errorf("%s: nested-mismatch Unmarshal succeeded, want error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeNestedNilProjection covers the nil-source arms of the generic
+// projection helpers: a nil field inside a struct, a nil element inside a
+// slice, and a nil value inside a map — each must project to the typed
+// zero value rather than erroring. Nesting inside an outer slice forces the
+// generic projector (projectMapToStruct / projectSliceToTyped /
+// projectMapToTyped nil branches).
+func TestDecodeNestedNilProjection(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		in        any
+		newTarget func() any
+	}
+	tests := []tc{
+		//: nil slice element — projectSliceToTyped nil branch.
+		{"nil slice element", []any{[]any{nil, int64(2)}}, func() any { return new([][]int64) }},
+		//: nil map value — projectMapToTyped nil branch.
+		{"nil map value", []any{map[string]any{"a": nil}}, func() any { return new([]map[string]int64) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: the seed encodes cleanly; nil sub-values are legal on the wire.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		//: the nil sub-value must project to a zero, not fail the decode.
+		if err := c.Unmarshal(encoded, tc.newTarget()); err != nil {
+			t.Errorf("%s: Unmarshal err=%v, want nil (nil → zero)", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeUnknownStructField drives the lenient unknown-field skip arm of
+// decodeFieldValue: a struct wire record carrying a field absent from the Go
+// target must decode successfully, discarding the unknown field's value.
+func TestDecodeUnknownStructField(t *testing.T) {
+	t.Parallel()
+	type wide struct {
+		X     int64
+		Extra string
+		Y     string
+	}
+	type narrow struct {
+		X int64
+		Y string
+	}
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"unknown field is skipped on the typed path"}}
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(wide{X: 1, Extra: "drop me", Y: "keep"})
+		//: the wide struct must encode cleanly.
+		if merr != nil {
+			t.Fatalf("Marshal err=%v", merr)
+		}
+		var out narrow
+		//: decoding into the narrower struct must skip the unknown field.
+		if uerr := c.Unmarshal(encoded, &out); uerr != nil {
+			t.Fatalf("Unmarshal err=%v", uerr)
+		}
+		//: the known fields must survive the unknown-field skip.
+		if out.X != 1 || out.Y != "keep" {
+			t.Errorf("decoded = %#v, want {X:1 Y:keep}", out)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeDepthExceeded drives the decode-side CWE-674 guard: a deeply
+// nested encoded payload must surface DEPTH_EXCEEDED on Unmarshal.
+func TestDecodeDepthExceeded(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name   string
+		levels int
+	}
+	tests := []tc{
+		{"forty nested slices overflow decode depth", 40},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: hand-build a nested-slice payload deeper than the cap so the
+		//: encoder (which shares the cap) is bypassed; each layer is a
+		//: tagSlice (0x50) with element count 1, leaf is a tagNil (0x01) record.
+		payload := []byte{0x01, 0x00} // tagNil leaf (tag + zero length).
+		for range tc.levels {
+			//: prepend a slice header (tagSlice=0x50, length=1) per level.
+			payload = append([]byte{0x50, 0x01}, payload...)
+		}
+		var out any
+		//: decode must refuse the over-deep payload with the depth sentinel.
+		if err := tlv.New().Unmarshal(payload, &out); !errs.HasReason(err, "DEPTH_EXCEEDED") {
+			t.Errorf("%s: err = %v, want DEPTH_EXCEEDED", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// rtInner is a small nested struct reused across the typed round-trip
+// matrix. Its fields span the scalar tag families so a single round trip
+// exercises int / float / string / bytes / bool re-narrowing.
+type rtInner struct {
+	X int64
+	Y string
+	Z float64
+}
+
+// rtOuter nests every composite field kind the typed-struct decode path
+// recurses into: a nested struct, a nested slice-of-struct (drives
+// decodeNestedSliceOfStruct), a nested map (drives decodeNestedMap), and a
+// pointer field — so one round trip lights up the field-recursion fan-out.
+type rtOuter struct {
+	Name   string
+	Inner  rtInner
+	Items  []rtInner
+	Lookup map[string]int64
+	Ptr    *rtInner
+	Blob   []byte
+	On     bool
+}
+
+// rtScalars carries one field of every scalar reflect.Kind so a single
+// round trip exercises every arm of encodeFieldValue (the per-field scalar
+// dispatch) and every width branch of the decode-side narrowAndSet.
+type rtScalars struct {
+	I    int
+	I8   int8
+	I16  int16
+	I32  int32
+	I64  int64
+	U    uint
+	U8   uint8
+	U16  uint16
+	U32  uint32
+	U64  uint64
+	F32  float32
+	F64  float64
+	S    string
+	B    bool
+	Data []byte
+}
+
+// TestRoundTripAllScalarKinds round-trips a struct populated with every
+// scalar kind so the per-field encoder dispatch and the typed decode
+// narrowing cover all integer/float widths in one pass.
+func TestRoundTripAllScalarKinds(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   rtScalars
+	}
+	tests := []tc{
+		{"min/zero spread", rtScalars{
+			I: -1, I8: -128, I16: -32768, I32: -2147483648, I64: -1 << 60,
+			U: 1, U8: 255, U16: 65535, U32: 4294967295, U64: 1 << 60,
+			F32: 0.5, F64: 2.5, S: "s", B: true, Data: []byte{1, 2},
+		}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: every scalar field must encode without error.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		var out rtScalars
+		//: decode must reconstruct every width back into its typed field.
+		if uerr := c.Unmarshal(encoded, &out); uerr != nil {
+			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
+		}
+		//: the round trip must reproduce every scalar field exactly.
+		if !reflect.DeepEqual(tc.in, out) {
+			t.Errorf("%s: mismatch\n in=%#v\nout=%#v", tc.name, tc.in, out)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestRoundTripNilForms covers the nil short-circuits of the encoder
+// (untyped nil and a nil pointer both emit a tagNil record) and the decode
+// side that turns tagNil back into a nil/zero value.
+func TestRoundTripNilForms(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   any
+	}
+	tests := []tc{
+		{"untyped nil", nil},
+		{"typed nil pointer", (*rtInner)(nil)},
+		{"nil inside a slice", []any{nil, int64(1)}},
+		{"nil inside a map", map[string]any{"k": nil}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: a nil (untyped or typed) must encode as a tagNil record, not error.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		var out any
+		//: decoding a nil-bearing record must succeed.
+		if uerr := c.Unmarshal(encoded, &out); uerr != nil {
+			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestTypedRoundTrip drives Marshal→Unmarshal into a concrete typed target
+// for a matrix of Go shapes. The typed fast path (decoder_typed.go) handles
+// root struct / []struct / []scalar / map / scalar; the harder composite
+// shapes (pointers, slice-of-pointer, slice-of-map, nested slices, maps with
+// composite values) fall through to the generic projection path
+// (decoder.go project*). Every row asserts an exact DeepEqual round trip.
+func TestTypedRoundTrip(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   any
+		// newTarget returns a fresh pointer to the typed destination so each
+		// subtest decodes into its own zero value.
+		newTarget func() any
+	}
+	tests := []tc{
+		//: typed scalar targets — Phase-7 direct-set path.
+		{"scalar int", int64(-7), func() any { return new(int64) }},
+		{"scalar uint", uint64(9), func() any { return new(uint64) }},
+		{"scalar float", 2.5, func() any { return new(float64) }},
+		{"scalar string", "hi", func() any { return new(string) }},
+		{"scalar bool", true, func() any { return new(bool) }},
+		//: typed []scalar targets — Phase-6 slice-of-scalar path.
+		{"slice of int64", []int64{1, 2, 3}, func() any { return new([]int64) }},
+		{"slice of string", []string{"a", "b"}, func() any { return new([]string) }},
+		{"bytes", []byte{9, 8, 7}, func() any { return new([]byte) }},
+		//: typed map targets — Phase-4 typed-map path.
+		{"map string→int64", map[string]int64{"a": 1, "b": 2}, func() any { return new(map[string]int64) }},
+		{"map string→string", map[string]string{"k": "v"}, func() any { return new(map[string]string) }},
+		//: typed struct target — Phase-1 struct fast path.
+		{"flat struct", rtInner{X: 5, Y: "y", Z: 1.5}, func() any { return new(rtInner) }},
+		//: []struct — Phase-2 slice-of-struct path.
+		{"slice of struct", []rtInner{{X: 1}, {X: 2, Y: "two"}}, func() any { return new([]rtInner) }},
+		//: deeply nested struct — drives decodeNestedSliceOfStruct (Items),
+		//: decodeNestedMap (Lookup), tryTypedFieldRecursion (Inner/Ptr).
+		{"nested struct fan-out", rtOuter{
+			Name:   "outer",
+			Inner:  rtInner{X: 1, Y: "in", Z: 0.5},
+			Items:  []rtInner{{X: 10}, {X: 20, Y: "twenty"}},
+			Lookup: map[string]int64{"one": 1, "two": 2},
+			Ptr:    &rtInner{X: 99, Y: "ptr"},
+			Blob:   []byte("bytes"),
+			On:     true,
+		}, func() any { return new(rtOuter) }},
+		//: pointer-to-struct root — generic projectCompositePointer +
+		//: projectCompositeStruct + projectMapToStruct.
+		{"pointer to struct", &rtInner{X: 3, Y: "p"}, func() any { return new(*rtInner) }},
+		//: slice of pointer — typed slice path falls back; projection builds
+		//: each *rtInner element.
+		{"slice of pointer to struct", []*rtInner{{X: 1}, {X: 2}}, func() any { return new([]*rtInner) }},
+		//: slice of map — projectCompositeSlice → projectCompositeMap →
+		//: projectMapToTyped per element.
+		{"slice of map", []map[string]int64{{"a": 1}, {"b": 2}}, func() any { return new([]map[string]int64) }},
+		//: slice of slice — projectCompositeSlice recursion.
+		{"slice of slice", [][]int64{{1, 2}, {3}}, func() any { return new([][]int64) }},
+		//: map with struct values — projectMapToTyped → projectMapToStruct.
+		{"map string→struct", map[string]rtInner{"a": {X: 1}, "b": {X: 2, Y: "b"}}, func() any { return new(map[string]rtInner) }},
+		//: map with slice values — projectMapToTyped → projectSliceToTyped.
+		{"map string→slice", map[string][]int64{"xs": {1, 2, 3}}, func() any { return new(map[string][]int64) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := tlv.New()
+		encoded, merr := c.Marshal(tc.in)
+		//: the matrix only carries encodable values — a Marshal error is a bug.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		target := tc.newTarget()
+		//: Unmarshal must reconstruct the value into the typed destination.
+		if uerr := c.Unmarshal(encoded, target); uerr != nil {
+			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
+		}
+		//: dereference the destination pointer to compare the decoded value.
+		got := reflect.ValueOf(target).Elem().Interface()
+		//: the round trip must reproduce the input exactly after re-narrowing.
+		if !reflect.DeepEqual(tc.in, got) {
+			t.Errorf("%s: round trip mismatch\n in=%#v\nout=%#v", tc.name, tc.in, got)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// badChanField is a struct carrying an unsupported exported field so the
+// struct encoder's per-field error arm is exercised.
+type badChanField struct {
+	Ch chan int
+}
+
+// TestEncodeRejectsUnsupported drives the UNSUPPORTED_TYPE arm of every
+// composite encoder: a chan / func / complex value at the root and nested
+// inside a slice, a map value, a map key, and a struct field must each
+// surface the documented sentinel rather than panic.
+func TestEncodeRejectsUnsupported(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   any
+	}
+	tests := []tc{
+		//: root scalar rejections — encodeValue → encodeByKind.
+		{"root chan", make(chan int)},
+		{"root func", func() {}},
+		{"root complex128", complex128(1 + 2i)},
+		{"root complex64", complex64(1 + 2i)},
+		//: nested in a slice — encodeSliceDirect → encodeFieldValue.
+		{"slice element chan", []any{make(chan int)}},
+		//: nested in a map value — encodeMapDirect value leg.
+		{"map value func", map[string]any{"f": func() {}}},
+		//: nested in a map key — encodeMapDirect key leg.
+		{"map key complex", map[complex128]int{complex(1, 0): 1}},
+		//: nested in a struct field — encodeStructDirect → encodeFieldValue.
+		{"struct field chan", badChanField{Ch: make(chan int)}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		_, err := tlv.New().Marshal(tc.in)
+		//: every unsupported shape must surface the UNSUPPORTED_TYPE reason.
+		if !errs.HasReason(err, "UNSUPPORTED_TYPE") {
+			t.Errorf("%s: err = %v, want UNSUPPORTED_TYPE", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestEncodeDepthExceeded drives the CWE-674 depth guard: nesting beyond
+// maxTLVDepth (32) must surface DEPTH_EXCEEDED rather than recurse without
+// bound.
+func TestEncodeDepthExceeded(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name   string
+		levels int
+	}
+	tests := []tc{
+		{"forty nested slices overflow the depth cap", 40},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: wrap a scalar in tc.levels slice layers so the encoder recurses
+		//: past maxTLVDepth.
+		var deep any = int64(1)
+		for range tc.levels {
+			//: each layer adds one composite level to the recursion.
+			deep = []any{deep}
+		}
+		_, err := tlv.New().Marshal(deep)
+		//: the depth guard must fire before unbounded recursion.
+		if !errs.HasReason(err, "DEPTH_EXCEEDED") {
+			t.Errorf("%s: err = %v, want DEPTH_EXCEEDED", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestAppendRollbackOnError pins the Appender contract: a mid-encode failure
+// must roll dst back to its original length so callers never observe a torn
+// buffer.
+func TestAppendRollbackOnError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"unsupported value leaves the prior buffer intact"}}
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		ap, ok := tlv.New().(codec.Appender)
+		//: the TLV codec must advertise the Appender extension.
+		if !ok {
+			t.Fatal("codec does not implement Appender")
+		}
+		prefill := []byte{0xAA, 0xBB, 0xCC}
+		out, err := ap.Append(prefill, make(chan int))
+		//: the encode must fail on the unsupported value.
+		if err == nil {
+			t.Fatal("expected an encode error, got nil")
+		}
+		//: rollback contract — the returned buffer is byte-for-byte the prior
+		//: prefix: neither truncated/grown (length) nor mutated (content).
+		if !bytes.Equal(out, prefill) {
+			t.Errorf("Append did not roll back: out=%v, want %v", out, prefill)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// failWriter fails every Write with its configured error so the streaming
+// encoder's writer-error arm is exercised.
+type failWriter struct {
+	err error
+}
+
+func (f failWriter) Write(_ []byte) (int, error) {
+	return 0, f.err
+}
+
+// shortWriter reports one byte fewer than handed with a nil error so the
+// encoder's short-write detection (io.ErrShortWrite) fires.
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	//: report a short count so n != len(buf) with a nil error.
+	return len(p) - 1, nil
+}
+
+// TestStreamingEncodeErrors covers the three failure arms of the streaming
+// Encode: an unsupported value, a writer that errors, and a writer that
+// reports a short write.
+func TestStreamingEncodeErrors(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		writer    io.Writer
+		value     any
+		wantWrite bool // true when the failure originates in the writer
+	}
+	boom := errors.New("writer boom")
+	tests := []tc{
+		{"unsupported value fails before any write", io.Discard, make(chan int), false},
+		{"writer error wraps as MARSHAL_FAILED", failWriter{err: boom}, int64(1), true},
+		{"short write surfaces io.ErrShortWrite", shortWriter{}, int64(1 << 40), true},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		sc, ok := tlv.New().(codec.StreamingCodec)
+		//: the TLV codec must advertise the StreamingCodec extension.
+		if !ok {
+			t.Fatal("codec does not implement StreamingCodec")
+		}
+		err := sc.NewEncoder(tc.writer).Encode(tc.value)
+		//: every arm must surface a non-nil error.
+		if err == nil {
+			t.Fatalf("%s: expected an error, got nil", tc.name)
+		}
+		//: writer-origin failures wrap as MARSHAL_FAILED; the value-origin
+		//: failure surfaces UNSUPPORTED_TYPE.
+		if tc.wantWrite {
+			//: writer errors carry the marshal-failure reason.
+			if !errs.HasReason(err, "MARSHAL_FAILED") {
+				t.Errorf("%s: err = %v, want MARSHAL_FAILED", tc.name, err)
+			}
+		} else if !errs.HasReason(err, "UNSUPPORTED_TYPE") {
+			t.Errorf("%s: err = %v, want UNSUPPORTED_TYPE", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/service/codec/tlv/types_internal_test.go
+++ b/internal/service/codec/tlv/types_internal_test.go
@@ -1,0 +1,621 @@
+package tlv
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/core/codec"
+	"github.com/kitsunium/sdk/internal/kernel/errs"
+)
+
+// craftedHugeLength is a declared structural length well past maxTLVBytes
+// (10 MiB) so the per-record length cap fires while the crafted buffer
+// itself stays tiny — the OUTER input-size cap never triggers.
+const craftedHugeLength uint64 = 20_000_000
+
+// errReader fails every Read with a non-EOF error so the streaming
+// decoder's wrapped-read-failure arms are exercised.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("read boom")
+}
+
+// scriptReader delivers head bytes across reads, then fails with a non-EOF
+// error — letting a failure land mid-value (after a valid header) so
+// assembleRecord's ReadFrom-error arm is reached.
+type scriptReader struct {
+	head []byte
+	pos  int
+}
+
+func (s *scriptReader) Read(p []byte) (int, error) {
+	//: deliver the scripted header bytes first.
+	if s.pos < len(s.head) {
+		n := copy(p, s.head[s.pos:])
+		s.pos += n
+		return n, nil
+	}
+	//: header drained — fail mid-value with a non-EOF error.
+	return 0, errors.New("mid-value boom")
+}
+
+// TestStreamingDecodeErrors drives the streaming reader's failure arms
+// (readTag / readUvarint / assembleRecord / readOneRecord / Decode) which
+// the byte-slice Unmarshal path never touches: a failing reader, a truncated
+// value, a missing/overlong length varint, and an oversize declared length.
+func TestStreamingDecodeErrors(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name   string
+		reader func() io.Reader
+	}
+	tests := []tc{
+		//: reader errors on the tag byte — readTag wrap + Decode bail.
+		{"reader fails on tag", func() io.Reader { return errReader{} }},
+		//: valid bytes header but the reader fails before the value bytes
+		//: arrive — assembleRecord ReadFrom error.
+		{"reader fails mid-value", func() io.Reader {
+			return &scriptReader{head: appendTagLen(nil, tagBytes, 5)}
+		}},
+		//: truncated value — declared 5 bytes, only 2 delivered.
+		{"short value", func() io.Reader {
+			rec := appendTagLen(nil, tagBytes, 5)
+			rec = append(rec, 1, 2)
+			return bytes.NewReader(rec)
+		}},
+		//: length varint missing entirely after the tag.
+		{"missing length varint", func() io.Reader {
+			return bytes.NewReader([]byte{byte(tagInt64)})
+		}},
+		//: declared length beyond maxTLVBytes — readOneRecord size cap.
+		{"oversize declared length", func() io.Reader {
+			return bytes.NewReader(appendTagLen(nil, tagBytes, craftedHugeLength))
+		}},
+		//: ten-byte varint whose final byte exceeds the legal MSB — overflow.
+		{"varint overflow terminal byte", func() io.Reader {
+			over := []byte{byte(tagBytes), 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02}
+			return bytes.NewReader(over)
+		}},
+		//: all-continuation varint exhausts the 10-byte budget.
+		{"varint exceeds budget", func() io.Reader {
+			over := append([]byte{byte(tagBytes)}, bytes.Repeat([]byte{0x80}, maxVarintBytes)...)
+			return bytes.NewReader(over)
+		}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		sc, ok := New().(codec.StreamingCodec)
+		//: the TLV codec must advertise streaming.
+		if !ok {
+			t.Fatal("codec does not implement StreamingCodec")
+		}
+		var out any
+		//: every malformed stream must surface a non-nil decode error.
+		if err := sc.NewDecoder(tc.reader()).Decode(&out); err == nil {
+			t.Errorf("%s: streaming Decode succeeded, want error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// craftInner is a small struct target used by the crafted-byte decode tests
+// (this file is white-box, so it cannot reach the tlv_test package types).
+type craftInner struct {
+	X int64
+	Y string
+}
+
+// TestDecodeStructuralLengthCaps drives the declared-length-DoS guards
+// (CWE-400): a record header advertising more children than maxTLVBytes
+// must surface SIZE_EXCEEDED before any pre-allocation, on BOTH the generic
+// (interface{}) and the typed fast paths. The crafted buffers carry only the
+// header so the structural cap — not the input-size cap — is the gate.
+func TestDecodeStructuralLengthCaps(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		data      []byte
+		newTarget func() any
+	}
+	tests := []tc{
+		//: generic map header with an absurd pair count.
+		{"huge map → any", appendTagLen(nil, tagMap, craftedHugeLength), func() any { return new(any) }},
+		//: typed map header — drives tryDecodeRootIntoMap's cap.
+		{"huge map → *map", appendTagLen(nil, tagMap, craftedHugeLength), func() any { return new(map[string]int64) }},
+		//: generic slice header with an absurd element count.
+		{"huge slice → any", appendTagLen(nil, tagSlice, craftedHugeLength), func() any { return new(any) }},
+		//: typed slice-of-scalar header — drives the scalar slice cap.
+		{"huge slice → *[]int64", appendTagLen(nil, tagSlice, craftedHugeLength), func() any { return new([]int64) }},
+		//: typed slice-of-struct header — drives the struct slice cap.
+		{"huge slice → *[]struct", appendTagLen(nil, tagSlice, craftedHugeLength), func() any { return new([]craftInner) }},
+		//: generic struct header with an absurd field count.
+		{"huge struct → any", appendTagLen(nil, tagStruct, craftedHugeLength), func() any { return new(any) }},
+		//: typed struct header — drives decodeStructFromHeader's cap.
+		{"huge struct → *struct", appendTagLen(nil, tagStruct, craftedHugeLength), func() any { return new(craftInner) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: the structural cap must reject the over-large declared length.
+		if err := New().Unmarshal(tc.data, tc.newTarget()); !errs.HasReason(err, "SIZE_EXCEEDED") {
+			t.Errorf("%s: err = %v, want SIZE_EXCEEDED", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// recSlice is self-referential through a slice field, so a crafted payload
+// can nest tagStruct→tagSlice records past maxTLVDepth and drive the typed
+// nested-recursion depth guards (decodeStructFromHeader /
+// decodeNestedSliceOfStruct / decodeSliceOfStructInto) into a single
+// concrete Go type — something the encoder (which shares the cap) cannot
+// produce on its own.
+type recSlice struct {
+	Children []recSlice
+}
+
+// recMap is self-referential through a map value, the map-flavoured
+// companion to recSlice for the decodeNestedMap / decodeMapInto depth guards.
+type recMap struct {
+	M map[string]recMap
+}
+
+// TestDecodeTypedNestedDepth drives the CWE-674 depth guards on the TYPED
+// nested-recursion paths. Crafted payloads nest a self-referential struct
+// past maxTLVDepth; because the typed recursion increments depth per level,
+// the decoder must surface DEPTH_EXCEEDED rather than recurse without bound.
+func TestDecodeTypedNestedDepth(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		build     func(levels int) []byte
+		newTarget func() any
+	}
+	//: levels well past maxTLVDepth (the typed recursion adds ~2 depth/level,
+	//: so 40 struct levels guarantees the guard fires).
+	const levels int = 40
+	tests := []tc{
+		{
+			name: "nested slice-of-struct depth",
+			build: func(levels int) []byte {
+				//: innermost empty struct, then wrap in struct{Children:[self]}.
+				node := appendTagLen(nil, tagStruct, 0)
+				for range levels {
+					inner := append(appendTagLen(nil, tagSlice, 1), node...)
+					node = append(appendTagLen(nil, tagStruct, 1), structField("Children", inner)...)
+				}
+				return node
+			},
+			newTarget: func() any { return new(recSlice) },
+		},
+		{
+			name: "nested map depth",
+			build: func(levels int) []byte {
+				//: innermost empty struct, then wrap in struct{M:{ "k": self }}.
+				node := appendTagLen(nil, tagStruct, 0)
+				for range levels {
+					key := append(appendTagLen(nil, tagString, 1), 'k')
+					mapRec := append(appendTagLen(nil, tagMap, 1), append(key, node...)...)
+					node = append(appendTagLen(nil, tagStruct, 1), structField("M", mapRec)...)
+				}
+				return node
+			},
+			newTarget: func() any { return new(recMap) },
+		},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: the over-deep crafted payload must trip the depth sentinel.
+		if err := New().Unmarshal(tc.build(levels), tc.newTarget()); !errs.HasReason(err, "DEPTH_EXCEEDED") {
+			t.Errorf("%s: err = %v, want DEPTH_EXCEEDED", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeMalformedScalarLengths drives the malformed-length arms of
+// decodeInt / decodeUint / decodeFloat: a fixed-width scalar tag whose
+// declared length disagrees with the tag's intrinsic width must be rejected
+// (distinct from a truncated payload, which carries the right length).
+func TestDecodeMalformedScalarLengths(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		tag  Tag
+		// badLen is a length that does not equal the tag's intrinsic width.
+		badLen uint64
+	}
+	tests := []tc{
+		{"int8 wrong length", tagInt8, 5},
+		{"int16 wrong length", tagInt16, 1},
+		{"int32 wrong length", tagInt32, 2},
+		{"int64 wrong length", tagInt64, 3},
+		{"uint8 wrong length", tagUint8, 2},
+		{"uint16 wrong length", tagUint16, 1},
+		{"uint32 wrong length", tagUint32, 2},
+		{"uint64 wrong length", tagUint64, 3},
+		{"float32 wrong length", tagFloat32, 2},
+		{"float64 wrong length", tagFloat64, 9},
+		//: zero-payload tags (nil/bool) must declare length 0 — a non-zero
+		//: length is malformed (decodeScalarByTag zero-payload arm).
+		{"nil non-zero length", tagNil, 1},
+		{"bool-true non-zero length", tagBoolTrue, 3},
+		{"bool-false non-zero length", tagBoolFalse, 2},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: craft a record whose declared length disagrees with the tag width,
+		//: padding the body so the length-mismatch (not truncation) is the gate.
+		data := appendTagLen(nil, tc.tag, tc.badLen)
+		data = append(data, make([]byte, tc.badLen)...)
+		var out any
+		//: the width/length disagreement must surface a decode error.
+		if err := New().Unmarshal(data, &out); err == nil {
+			t.Errorf("%s: malformed-length record decoded without error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// craftFields carries a map field and a slice-of-struct field so the
+// nested typed-recursion helpers (decodeNestedMap / decodeNestedSliceOfStruct)
+// can be driven with crafted malformed nested records.
+type craftFields struct {
+	M map[string]int64
+	L []craftInner
+}
+
+// structField builds one struct field record: a tagString name record
+// followed by the caller-supplied value bytes.
+func structField(name string, value []byte) []byte {
+	out := appendTagLen(nil, tagString, uint64(len(name)))
+	out = append(out, name...)
+	return append(out, value...)
+}
+
+// TestDecodeUnhashableMapKey drives the unhashable-key arm of decodeMap: a
+// wire map whose key is itself a composite (slice) cannot be a Go map key, so
+// the decoder must reject it rather than panic on the map insert.
+func TestDecodeUnhashableMapKey(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"slice key is not hashable"}}
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: a map with one pair whose KEY is an empty slice (tagSlice len 0)
+		//: and whose value is a nil record — the slice key is unhashable.
+		data := appendTagLen(nil, tagMap, 1)
+		data = append(data, appendTagLen(nil, tagSlice, 0)...) // key: []any{}
+		data = append(data, appendTagLen(nil, tagNil, 0)...)   // value: nil
+		var out any
+		//: the unhashable key must surface a decode error, not a panic.
+		if err := New().Unmarshal(data, &out); err == nil {
+			t.Error("unhashable map key decoded without error")
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeStructFieldValueErrors drives two field-value arms of the typed
+// struct decode: a KNOWN field whose wire value cannot convert to the field
+// type (assignFieldValue conversion error), and an UNKNOWN field whose value
+// record is truncated (decodeFieldValue skip-path decode error).
+func TestDecodeStructFieldValueErrors(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name  string
+		field []byte
+	}
+	tests := []tc{
+		//: known field X (int64) whose wire value is a string — convertValue
+		//: rejects string→int64, driving assignFieldValue's error arm.
+		{"X: unconvertible string", structField("X", append(appendTagLen(nil, tagString, 3), "bad"...))},
+		//: unknown field whose int64 value declares 8 bytes but delivers none —
+		//: the skip-path decodeValue fails on the truncated value.
+		{"unknown: truncated value", structField("Zzz", appendTagLen(nil, tagInt64, uint64(width64)))},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: wrap the crafted field in a one-field struct record.
+		data := appendTagLen(nil, tagStruct, 1)
+		data = append(data, tc.field...)
+		var out craftInner
+		//: both malformations must surface a decode error on the typed path.
+		if err := New().Unmarshal(data, &out); err == nil {
+			t.Errorf("%s: malformed field value decoded without error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeNestedFieldMalformed drives the size-cap and truncated-length
+// arms of decodeNestedMap and decodeNestedSliceOfStruct: a struct whose map
+// or slice-of-struct field carries a malformed nested header must surface a
+// decode error on the typed struct path.
+func TestDecodeNestedFieldMalformed(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name  string
+		value []byte // the field value record (after the field name).
+	}
+	tests := []tc{
+		//: map field declaring more pairs than maxTLVBytes — size cap.
+		{"M: huge map", appendTagLen(nil, tagMap, craftedHugeLength)},
+		//: map field whose length varint is missing — truncated.
+		{"M: map missing length", []byte{byte(tagMap)}},
+		//: slice-of-struct field declaring too many elements — size cap.
+		{"L: huge slice", appendTagLen(nil, tagSlice, craftedHugeLength)},
+		//: slice-of-struct field whose length varint is missing — truncated.
+		{"L: slice missing length", []byte{byte(tagSlice)}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: build a one-field struct record around the crafted field value.
+		fieldName := tc.name[:1]
+		data := appendTagLen(nil, tagStruct, 1)
+		data = append(data, structField(fieldName, tc.value)...)
+		var out craftFields
+		//: the malformed nested header must surface a decode error.
+		if err := New().Unmarshal(data, &out); err == nil {
+			t.Errorf("%s: malformed nested field decoded without error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeTrailingBytesTyped drives the trailing-bytes arms of the typed
+// fast path: a complete, valid record followed by junk bytes must be
+// rejected by tryDecodeRootIntoScalar / Map / SliceOfScalar / Struct (each
+// expects to consume the buffer exactly).
+func TestDecodeTrailingBytesTyped(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		in        any
+		newTarget func() any
+	}
+	tests := []tc{
+		{"scalar + junk into *int64", int64(7), func() any { return new(int64) }},
+		{"slice-of-scalar + junk into *[]int64", []int64{1, 2}, func() any { return new([]int64) }},
+		{"map + junk into *map", map[string]int64{"a": 1}, func() any { return new(map[string]int64) }},
+		{"struct + junk into *struct", craftInner{X: 1}, func() any { return new(craftInner) }},
+		{"slice-of-struct + junk into *[]struct", []craftInner{{X: 1}}, func() any { return new([]craftInner) }},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		encoded, merr := New().Marshal(tc.in)
+		//: the seed must encode cleanly before we append junk.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		//: a trailing byte makes the record over-long for the exact typed path.
+		withJunk := append(append([]byte{}, encoded...), 0x00)
+		//: the trailing-bytes guard must reject the over-long buffer.
+		if err := New().Unmarshal(withJunk, tc.newTarget()); err == nil {
+			t.Errorf("%s: trailing-bytes Unmarshal succeeded, want error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeNilSliceOfStructElement covers the nil-element arm of
+// decodeSliceElement: a nil record inside a []struct wire payload must decode
+// to the element's zero value rather than erroring.
+func TestDecodeNilSliceOfStructElement(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"nil element decodes to a zero struct"}}
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: a heterogeneous slice with a nil then a struct, decoded into a
+		//: typed []craftInner: element 0 (nil) → zero, element 1 → populated.
+		encoded, merr := New().Marshal([]any{nil, craftInner{X: 7, Y: "y"}})
+		if merr != nil {
+			t.Fatalf("Marshal err=%v", merr)
+		}
+		var out []craftInner
+		//: the nil element must not fail the typed slice-of-struct decode.
+		if uerr := New().Unmarshal(encoded, &out); uerr != nil {
+			t.Fatalf("Unmarshal err=%v", uerr)
+		}
+		//: element 0 is the zero struct, element 1 carries the decoded values.
+		if len(out) != 2 || out[0] != (craftInner{}) || out[1].X != 7 {
+			t.Errorf("decoded = %#v, want [{} {7 y}]", out)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeNilIntoTypedScalar covers the nil-source arm of
+// tryDecodeRootIntoScalar: a tagNil record decoded into a typed scalar must
+// zero the destination rather than error.
+func TestDecodeNilIntoTypedScalar(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"tagNil zeroes a typed int target"}}
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: Marshal(nil) emits a tagNil record.
+		encoded, merr := New().Marshal(nil)
+		if merr != nil {
+			t.Fatalf("Marshal(nil) err=%v", merr)
+		}
+		//: pre-seed a non-zero target so the zeroing is observable.
+		out := int64(99)
+		if uerr := New().Unmarshal(encoded, &out); uerr != nil {
+			t.Fatalf("Unmarshal err=%v", uerr)
+		}
+		//: the nil source must have zeroed the scalar.
+		if out != 0 {
+			t.Errorf("out = %d, want 0 (nil source zeroes the scalar)", out)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeLargeScalarSlice drives the over-budget (length > sliceHintCap)
+// growing path of walkScalarSlice: a slice declaring more than the 4096-entry
+// pre-alloc bucket must still round-trip via reflect.Append growth.
+func TestDecodeLargeScalarSlice(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		size int
+	}
+	tests := []tc{
+		{"five thousand elements exceed the slice hint", sliceHintCap + 904},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: build a slice past the pre-alloc hint so the growing walker runs.
+		in := make([]int64, tc.size)
+		for i := range in {
+			//: distinct values so a mis-indexed growth would be visible.
+			in[i] = int64(i)
+		}
+		encoded, merr := New().Marshal(in)
+		//: the large slice must encode cleanly.
+		if merr != nil {
+			t.Fatalf("%s: Marshal err=%v", tc.name, merr)
+		}
+		var out []int64
+		//: decode into the typed slice — drives walkScalarSliceGrowing.
+		if uerr := New().Unmarshal(encoded, &out); uerr != nil {
+			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
+		}
+		//: every element must survive the grow-as-we-go walk.
+		if len(out) != tc.size || out[tc.size-1] != int64(tc.size-1) {
+			t.Errorf("%s: len=%d last=%d, want len=%d last=%d",
+				tc.name, len(out), out[len(out)-1], tc.size, tc.size-1)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeFieldNameVarintError drives the field-name varint-failure arm of
+// decodeFieldName: a struct field whose name record carries a malformed
+// (continuation-only) length varint must be rejected.
+func TestDecodeFieldNameVarintError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"continuation-only name length varint"}}
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: struct with one field whose name record is [tagString, 0x80] — a
+		//: lone continuation byte that never terminates the varint.
+		data := appendTagLen(nil, tagStruct, 1)
+		data = append(data, byte(tagString), varintContinuationBit)
+		var out any
+		//: the malformed name varint must surface a decode error.
+		if err := New().Unmarshal(data, &out); err == nil {
+			t.Error("malformed field-name varint decoded without error")
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestDecodeOversizeFieldName drives the maxFieldNameBytes guard (255): a
+// struct record whose field-name string declares more than 255 bytes must be
+// rejected on both the generic and typed struct decode paths.
+func TestDecodeOversizeFieldName(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		newTarget func() any
+	}
+	tests := []tc{
+		{"generic struct target", func() any { return new(any) }},
+		{"typed struct target", func() any { return new(craftInner) }},
+	}
+	//: one struct field whose name record declares 256 bytes (> the 255 cap).
+	oversize := appendTagLen(nil, tagStruct, 1)
+	oversize = appendTagLen(oversize, tagString, uint64(maxFieldNameBytes+1))
+	//: pad the body so the cap check (not a truncation) is what rejects it.
+	oversize = append(oversize, make([]byte, maxFieldNameBytes+1)...)
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: the field-name cap must reject the over-long name.
+		err := New().Unmarshal(oversize, tc.newTarget())
+		//: any non-nil decode error is acceptable — the cap surfaces as a
+		//: decode failure on both the generic and typed struct paths.
+		if err == nil {
+			t.Errorf("%s: oversize field name decoded without error", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/service/codec/toml/decoder_internal_test.go
+++ b/internal/service/codec/toml/decoder_internal_test.go
@@ -2,6 +2,9 @@ package toml
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"testing"
 
 	gotoml "github.com/pelletier/go-toml/v2"
@@ -28,6 +31,96 @@ func Test_tomlDecoder_Decode(t *testing.T) {
 		//: treat EOF on the empty case as non-error.
 		if tc.wantErr && err == nil {
 			t.Errorf("%s: expected error on malformed input", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// eofWrapReader returns an error that WRAPS io.EOF (but is not the bare
+// sentinel) on its first Read. io.ReadAll — which pelletier's Decoder.Decode
+// calls — only swallows the exact io.EOF sentinel, so a wrapped EOF is
+// surfaced verbatim, then pelletier re-wraps it as "toml: …". This lets the
+// decoder's `errors.Is(derr, io.EOF)` arm fire through the real library path,
+// which neither empty nor garbage input can reach (pelletier maps both to a
+// nil-error empty document or a parse error, never io.EOF).
+type eofWrapReader struct{}
+
+// Read reports a wrapped-EOF failure so io.ReadAll propagates it.
+func (eofWrapReader) Read(_ []byte) (n int, err error) {
+	//: wrapped (not bare) io.EOF so io.ReadAll does not treat it as clean end.
+	return 0, fmt.Errorf("midstream truncation: %w", io.EOF)
+}
+
+// Test_tomlDecoder_Decode_DoneLatch asserts the sticky done latch: pelletier
+// consumes the entire input on the first Decode, so the codec marks the
+// stream drained and every subsequent Decode short-circuits to io.EOF via
+// `if d.done { return io.EOF }` — the arm single-call tests never reach.
+func Test_tomlDecoder_Decode_DoneLatch(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		data []byte
+	}
+	tests := []tc{
+		//: a one-key document: first Decode succeeds + latches, second hits it.
+		{"second decode after success hits latch", []byte("a = 1\n")},
+		//: empty document: first Decode succeeds (empty), second hits the latch.
+		{"second decode after empty doc hits latch", nil},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		dec := &tomlDecoder{inner: gotoml.NewDecoder(bytes.NewReader(tc.data))}
+		var out map[string]any
+		//: first Decode drains the single-document stream and sets done.
+		if err := dec.Decode(&out); err != nil {
+			t.Fatalf("%s: first Decode err=%v", tc.name, err)
+		}
+		//: the latched call MUST return io.EOF without re-reading.
+		if got := dec.Decode(&out); !errors.Is(got, io.EOF) {
+			t.Errorf("%s: latched Decode=%v want io.EOF", tc.name, got)
+		}
+		//: More MUST now report drained.
+		if dec.More() {
+			t.Errorf("%s: More=true after drain, want false", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// Test_tomlDecoder_Decode_EOFFromLibrary covers the `errors.Is(derr, io.EOF)`
+// arm of Decode using a reader whose Read surfaces a wrapped io.EOF. This is
+// the only way pelletier's Decode returns an io.EOF-matching error: it calls
+// io.ReadAll, which swallows the bare sentinel but propagates a wrapped one,
+// then re-wraps it as "toml: …". The arm must return io.EOF untouched and
+// set the done latch.
+func Test_tomlDecoder_Decode_EOFFromLibrary(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"wrapped EOF from reader maps to io.EOF"}}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		dec := &tomlDecoder{inner: gotoml.NewDecoder(eofWrapReader{})}
+		var out map[string]any
+		//: the library error wraps io.EOF, so Decode MUST surface io.EOF
+		//: untouched (not the UNMARSHAL_FAILED wrap) and latch done.
+		if got := dec.Decode(&out); !errors.Is(got, io.EOF) {
+			t.Errorf("%s: Decode=%v want io.EOF", tc.name, got)
+		}
+		//: the EOF arm sets done, so More now reports drained.
+		if dec.More() {
+			t.Errorf("%s: More=true after EOF, want false", tc.name)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/xml/decoder_internal_test.go
+++ b/internal/service/codec/xml/decoder_internal_test.go
@@ -2,6 +2,8 @@ package xml
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"testing"
 
 	stdxml "encoding/xml"
@@ -28,6 +30,61 @@ func Test_xmlDecoder_Decode(t *testing.T) {
 		//: treat EOF on the empty case as non-error.
 		if tc.wantErr && err == nil {
 			t.Errorf("%s: expected error on malformed input", tc.name)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// Test_xmlDecoder_Decode_DoneLatch asserts the sticky done latch: once a
+// Decode call drains the stream (surfacing io.EOF), every subsequent Decode
+// short-circuits to io.EOF WITHOUT touching the underlying reader. The first
+// Decode reaches EOF the slow way (delegating to the stdlib decoder); the
+// second exercises the `if d.done { return io.EOF }` fast-path that the
+// single-call tests never reach.
+func Test_xmlDecoder_Decode_DoneLatch(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		data []byte
+	}
+	tests := []tc{
+		//: one element then EOF — the second Decode must hit the latch.
+		{"second decode after drain hits latch", []byte(`<doc></doc>`)},
+		//: already-empty stream — first Decode drains, second hits the latch.
+		{"second decode on empty stream hits latch", nil},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		dec := &xmlDecoder{inner: stdxml.NewDecoder(bytes.NewReader(tc.data))}
+		//: encoding/xml cannot decode into a map, so the drain target is a
+		//: struct matching the <doc> element (zero value is fine for empty).
+		var out struct {
+			XMLName stdxml.Name `xml:"doc"`
+		}
+		//: drain the stream so the done latch is set; ignore the value, we
+		//: only need the decoder to reach io.EOF (directly or after one read).
+		for {
+			derr := dec.Decode(&out)
+			if errors.Is(derr, io.EOF) {
+				//: stream drained — latch is now set.
+				break
+			}
+			if derr != nil {
+				t.Fatalf("%s: unexpected drain err=%v", tc.name, derr)
+			}
+		}
+		//: the latched call MUST return io.EOF without consuming a token.
+		if got := dec.Decode(&out); !errors.Is(got, io.EOF) {
+			t.Errorf("%s: latched Decode=%v want io.EOF", tc.name, got)
+		}
+		//: More MUST now report drained.
+		if dec.More() {
+			t.Errorf("%s: More=true after drain, want false", tc.name)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/xml/encoder_internal_test.go
+++ b/internal/service/codec/xml/encoder_internal_test.go
@@ -3,6 +3,7 @@ package xml
 import (
 	"bytes"
 	stdxml "encoding/xml"
+	"errors"
 	"testing"
 )
 
@@ -59,6 +60,50 @@ func Test_xmlEncoder_Close(t *testing.T) {
 		err := enc.Close()
 		if (err != nil) != tc.wantErr {
 			t.Errorf("%s: Close err=%v wantErr=%v", tc.name, err, tc.wantErr)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// failingWriter always fails its Write so the stdlib encoder's Flush (driven
+// by Close) surfaces an error. Used to reach the Close wrap branch.
+type failingWriter struct{}
+
+// Write reports a synthetic failure for every byte the encoder flushes.
+func (failingWriter) Write(_ []byte) (n int, err error) {
+	//: deterministic failure so Flush propagates an error through Close.
+	return 0, errors.New("synthetic writer failure")
+}
+
+// Test_xmlEncoder_Close_FlushError covers the Close wrap branch
+// (encoder.go:34) which the success-only test never reaches. The trick is
+// to leave a token buffered without flushing it: EncodeToken does NOT flush
+// per call, so a StartElement stays pending until Close → Flush, which then
+// fails over a writer that errors on every byte. Calling Encode instead
+// would flush eagerly and leave nothing for Close to push, so the failing
+// writer must be paired with a buffered-token producer.
+func Test_xmlEncoder_Close_FlushError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{{"flush failure surfaces via Close wrap"}}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		enc := &xmlEncoder{inner: stdxml.NewEncoder(failingWriter{})}
+		//: a start-element token stays buffered (EncodeToken does not flush),
+		//: so the pending bytes are pushed only when Close calls Flush.
+		if terr := enc.inner.EncodeToken(stdxml.StartElement{Name: stdxml.Name{Local: "x"}}); terr != nil {
+			t.Fatalf("%s: EncodeToken setup err=%v", tc.name, terr)
+		}
+		//: Close → Flush fails over the failing writer, hitting the wrap.
+		if err := enc.Close(); err == nil {
+			t.Errorf("%s: Close=nil, want flush error wrapped as MARSHAL_FAILED", tc.name)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/yaml/codec_external_test.go
+++ b/internal/service/codec/yaml/codec_external_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/kitsunium/sdk/internal/core/codec"
@@ -15,6 +16,22 @@ type payload struct {
 	Name string `yaml:"name"`
 	Age  int    `yaml:"age"`
 }
+
+// badMarshaler implements yaml.v3's Marshaler contract returning an error so
+// Encode surfaces a clean error (no panic, no failing writer) — the only
+// public-API way to drive the Marshal/Append encode-error wrap branches,
+// since yaml.v3 panics on chan/func payloads instead of erroring.
+type badMarshaler struct{}
+
+// MarshalYAML returns a synthetic failure so yaml.v3's Encoder.Encode errors.
+func (badMarshaler) MarshalYAML() (any, error) {
+	//: deterministic failure surfaced by the codec as MARSHAL_FAILED.
+	return nil, errSyntheticMarshal
+}
+
+// errSyntheticMarshal is the sentinel badMarshaler hands back; kept package-
+// level so the failure is a stable, non-allocating value.
+var errSyntheticMarshal = errors.New("synthetic marshaler failure")
 
 // TestNew verifies the constructor returns a non-nil singleton with the
 // canonical name.
@@ -53,6 +70,8 @@ func TestMarshal(t *testing.T) {
 	}
 	tests := []tc{
 		{"round-trip success", payload{Name: "a", Age: 1}, ""},
+		//: a value whose MarshalYAML errors drives the encode-error wrap.
+		{"marshaler error surfaces MARSHAL_FAILED", badMarshaler{}, "MARSHAL_FAILED"},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
@@ -80,6 +99,11 @@ func TestUnmarshal(t *testing.T) {
 	if merr != nil {
 		t.Fatalf("Marshal setup err=%v", merr)
 	}
+	//: maxYAMLBytes is unexported but pinned at 10 MiB by the codec; one byte
+	//: past it must trip the size-cap rejection before any parse is attempted.
+	const maxYAMLBytes int = 10 << 20
+	//: a string scalar one byte over the cap — valid YAML, rejected on size.
+	oversize := []byte("a: " + strings.Repeat("x", maxYAMLBytes))
 	type tc struct {
 		name    string
 		data    []byte
@@ -88,9 +112,12 @@ func TestUnmarshal(t *testing.T) {
 	}
 	var good payload
 	var bad payload
+	var capped map[string]any
 	tests := []tc{
 		{"round-trip success", data, &good, ""},
 		{"malformed bytes surface UNMARSHAL_FAILED", []byte("[unclosed"), &bad, "UNMARSHAL_FAILED"},
+		//: input exceeding maxYAMLBytes is rejected before parsing (CWE-400).
+		{"over-cap input surfaces UNMARSHAL_FAILED", oversize, &capped, "UNMARSHAL_FAILED"},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()

--- a/internal/service/codec/yaml/codec_internal_test.go
+++ b/internal/service/codec/yaml/codec_internal_test.go
@@ -2,8 +2,20 @@ package yaml
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
+
+// appendBadMarshaler implements yaml.v3's Marshaler returning an error so the
+// Append encode-error branch is reachable without a chan/func payload (which
+// yaml.v3 panics on) or a failing writer (Append owns its buffer).
+type appendBadMarshaler struct{}
+
+// MarshalYAML returns a synthetic failure so the encoder surfaces an error.
+func (appendBadMarshaler) MarshalYAML() (any, error) {
+	//: deterministic failure → MARSHAL_FAILED, dst stays pristine.
+	return nil, errors.New("synthetic marshaler failure")
+}
 
 // Test_yamlCodec_Name covers the canonical identifier returned by the codec.
 func Test_yamlCodec_Name(t *testing.T) {
@@ -185,7 +197,9 @@ func Test_yamlCodec_Append(t *testing.T) {
 		{"happy-empty-dst", nil, map[string]int{"a": 1}, false},
 		{"happy-prefix-dst", []byte("PRE-"), "value", false},
 		//: yaml.v3 panics on chan/func types instead of returning an
-		//: error — out of our codec's control. Reject test omitted.
+		//: error, but a value whose MarshalYAML errors drives the encode-
+		//: error branch cleanly with dst left untouched.
+		{"reject-marshaler-error", []byte("PRE-"), appendBadMarshaler{}, true},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()

--- a/internal/service/codec/yaml/encoder_internal_test.go
+++ b/internal/service/codec/yaml/encoder_internal_test.go
@@ -60,26 +60,48 @@ func Test_yamlEncoder_Encode(t *testing.T) {
 	}
 }
 
-// Test_yamlEncoder_Close exercises the Close wrapper after a successful Encode.
+// Test_yamlEncoder_Close exercises the Close wrapper on both the success
+// path (buffer-backed encoder) and the failure path. yaml.v3 surfaces a
+// writer failure on both Encode and Close, so a writer that fails on every
+// Write makes Close return a wrapped error — the branch the success-only
+// case never reaches. The encode result is asserted per case (it must
+// succeed on the buffer path and fail on the writer path) so no error is
+// silently discarded.
 func Test_yamlEncoder_Close(t *testing.T) {
 	t.Parallel()
 	type tc struct {
-		name    string
-		wantErr bool
+		name          string
+		build         func() *yamlEncoder
+		wantEncodeErr bool
+		wantCloseErr  bool
 	}
 	tests := []tc{
-		{"close after encode succeeds", false},
+		{
+			"close after encode succeeds",
+			func() *yamlEncoder { return &yamlEncoder{inner: goyaml.NewEncoder(&bytes.Buffer{})} },
+			false,
+			false,
+		},
+		{
+			"close over failing writer surfaces wrap",
+			func() *yamlEncoder { return &yamlEncoder{inner: goyaml.NewEncoder(errWriter{})} },
+			true,
+			true,
+		},
 	}
 	runCase := func(t *testing.T, tc tc) {
 		t.Helper()
-		var buf bytes.Buffer
-		enc := &yamlEncoder{inner: goyaml.NewEncoder(&buf)}
-		if err := enc.Encode(map[string]int{"k": 1}); err != nil {
-			t.Fatalf("%s: Encode setup err=%v", tc.name, err)
+		enc := tc.build()
+		//: assert the encode outcome explicitly so the error is handled,
+		//: not discarded — yaml.v3 pushes to the writer eagerly enough that
+		//: the failing-writer case errors here too.
+		if eerr := enc.Encode(map[string]int{"k": 1}); (eerr != nil) != tc.wantEncodeErr {
+			t.Fatalf("%s: Encode err=%v wantErr=%v", tc.name, eerr, tc.wantEncodeErr)
 		}
-		err := enc.Close()
-		if (err != nil) != tc.wantErr {
-			t.Errorf("%s: Close err=%v wantErr=%v", tc.name, err, tc.wantErr)
+		//: Close flushes remaining buffered state; over the failing writer it
+		//: surfaces the wrapped MARSHAL_FAILED branch.
+		if cerr := enc.Close(); (cerr != nil) != tc.wantCloseErr {
+			t.Errorf("%s: Close err=%v wantErr=%v", tc.name, cerr, tc.wantCloseErr)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/logger/encoder/text_internal_test.go
+++ b/internal/service/logger/encoder/text_internal_test.go
@@ -118,6 +118,7 @@ func Test_appendValueOnly(t *testing.T) {
 	}{
 		{"string", corelogger.StringValue("v"), `"v"`},
 		{"int64", corelogger.Int64Value(7), "7"},
+		{"uint64", corelogger.Uint64Value(42), "42"},
 		{"bool", corelogger.BoolValue(true), "true"},
 		{"float", corelogger.Float64Value(0.5), "0.5"},
 		{"any degrades to ?", corelogger.AnyValue(struct{}{}), "?"},

--- a/internal/service/logger/logger_external_test.go
+++ b/internal/service/logger/logger_external_test.go
@@ -70,24 +70,47 @@ func TestBuild(t *testing.T) {
 func TestLogAttrs(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
+		name    string
+		nilLog  bool
+		message string
+		callLvl level.Level
+		minLvl  level.Level
+		want    bool
 	}{
-		{"LogAttrs on nil Logger silently drops without panicking"},
+		{"LogAttrs on nil Logger silently drops without panicking", true, "msg", level.Info, level.Info, false},
+		{"LogAttrs on real Logger above threshold emits the line", false, "emitted", level.Warn, level.Info, true},
+		{"LogAttrs on real Logger below threshold emits nothing", false, "quiet", level.Debug, level.Info, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			panicked := false
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						panicked = true
-					}
+			//: nil-logger arm asserts the silent-drop contract: no panic, no write.
+			if tc.nilLog {
+				panicked := false
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							panicked = true
+						}
+					}()
+					svclogger.LogAttrs(t.Context(), nil, tc.callLvl, tc.message, nil)
 				}()
-				svclogger.LogAttrs(t.Context(), nil, level.Info, "msg", nil)
-			}()
-			if panicked {
-				t.Error("LogAttrs panicked on nil Logger; contract requires silent drop")
+				if panicked {
+					t.Error("LogAttrs panicked on nil Logger; contract requires silent drop")
+				}
+				return
+			}
+			//: real-logger arm exercises the happy path that delegates to the
+			//: concrete loggerImpl and honours the handler's Enabled gate.
+			var buf bytes.Buffer
+			lg, err := svclogger.New(mustNewText(t, &buf, tc.minLvl))
+			if err != nil {
+				t.Fatalf("New returned err: %v", err)
+			}
+			attrs := []corelogger.AttrValue{{Key: "k", Value: corelogger.StringValue("v")}}
+			svclogger.LogAttrs(t.Context(), lg, tc.callLvl, tc.message, attrs)
+			if got := bytes.Contains(buf.Bytes(), []byte(tc.message)); got != tc.want {
+				t.Errorf("LogAttrs emitted=%v, want %v (buf=%q)", got, tc.want, buf.String())
 			}
 		})
 	}

--- a/internal/service/logger/middleware/async/async_sink_internal_test.go
+++ b/internal/service/logger/middleware/async/async_sink_internal_test.go
@@ -2,10 +2,12 @@ package async
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	corelogger "github.com/kitsunium/sdk/internal/core/logger"
 	"github.com/kitsunium/sdk/internal/core/logger/level"
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
@@ -108,16 +110,48 @@ func Test_asyncSink_Flush(t *testing.T) {
 	tests := []struct {
 		name      string
 		ctxCancel bool
-		wantErr   bool
+		//: prime enqueues entries before Flush so the loop sees a non-empty
+		//: ring and falls through to the cancellation arm instead of the
+		//: empty-queue fast path. freshSink has no live drainer so the
+		//: primed entries are never consumed.
+		prime bool
+		//: closeSignal pre-closes flushSignal so waitForDrainerProgress
+		//: returns false on the first non-empty iteration — driving Flush's
+		//: documented Stopped arm ("flushSignal observed closed").
+		closeSignal bool
+		wantErr     bool
+		wantCode    bool
+		//: wantStopped asserts the Stopped sentinel (drainer-exited path).
+		wantStopped bool
 	}{
-		{"empty queue + live ctx returns nil", false, false},
-		{"empty queue + cancelled ctx still flushes downstream", true, false},
-		{"explicit nil context is permitted by the contract", false, false},
+		{"empty queue + live ctx returns nil", false, false, false, false, false, false},
+		{"empty queue + cancelled ctx still flushes downstream", true, false, false, false, false, false},
+		{"explicit nil context is permitted by the contract", false, false, false, false, false, false},
+		{"non-empty queue + cancelled ctx surfaces the typed cancellation", true, true, false, true, true, false},
+		{"non-empty queue + closed flushSignal surfaces Stopped", false, true, true, true, false, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			s := freshSink(t, DropNewest)
+			//: prime the ring so Flush observes remaining > 0 and reaches the
+			//: ctx-cancellation arm rather than returning on the empty path.
+			if tc.prime {
+				if werr := s.queue.TryWrite(newRecordEntry()); werr != nil {
+					t.Fatalf("priming TryWrite err = %v", werr)
+				}
+			}
+			//: pre-close flushSignal to reproduce the documented drainer-exited
+			//: state so Flush's waitForDrainerProgress returns false and the
+			//: Stopped arm runs. freshSink leaves flushSignal nil, so equip a
+			//: dedicated channel first (mirroring Test_waitForDrainerProgress),
+			//: then close it. The drainer never closes this channel in
+			//: production (only Close terminates it indirectly), so this
+			//: white-box setup is the only way to exercise the defensive arm.
+			if tc.closeSignal {
+				s.flushSignal = make(chan struct{}, 1)
+				close(s.flushSignal)
+			}
 			ctx := t.Context()
 			if tc.ctxCancel {
 				cancelled, cancel := context.WithCancel(ctx)
@@ -127,6 +161,20 @@ func Test_asyncSink_Flush(t *testing.T) {
 			err := s.Flush(ctx)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Flush err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			//: the cancellation arm wraps ctx.Err() with the typed sentinel —
+			//: assert both the dotted-quad code and stdlib Is() chaining.
+			if tc.wantCode {
+				if !errs.HasCode(err, CodeAsyncCtxCancelled) {
+					t.Errorf("Flush err = %v, want CodeAsyncCtxCancelled", err)
+				}
+				if !errors.Is(err, context.Canceled) {
+					t.Errorf("Flush err = %v, want errors.Is(context.Canceled)", err)
+				}
+			}
+			//: the Stopped arm returns the drainer-exited sentinel verbatim.
+			if tc.wantStopped && !errs.HasCode(err, CodeAsyncStopped) {
+				t.Errorf("Flush err = %v, want Stopped", err)
 			}
 		})
 	}
@@ -226,12 +274,37 @@ func Test_mustNewRing(t *testing.T) {
 	tests := []struct {
 		name string
 		size int
+		//: wantPanic asserts the documented contract-violation arm: a
+		//: non-positive size makes ring.New fail, which mustNewRing converts
+		//: into a panic. New never reaches this path (it substitutes the
+		//: default for size <= 0); the helper is probed directly so the
+		//: defensive arm has explicit coverage.
+		wantPanic bool
 	}{
-		{"valid size returns a non-nil queue", 4},
+		{"valid size returns a non-nil queue", 4, false},
+		{"zero size violates the ring contract and panics", 0, true},
+		{"negative size violates the ring contract and panics", -1, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			//: panic arm — capture the recover so the helper's contract-breach
+			//: path is exercised without escaping the test goroutine.
+			if tc.wantPanic {
+				panicked := false
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							panicked = true
+						}
+					}()
+					mustNewRing(tc.size)
+				}()
+				if !panicked {
+					t.Errorf("mustNewRing(%d) did not panic; contract requires a panic on bad capacity", tc.size)
+				}
+				return
+			}
 			q := mustNewRing(tc.size)
 			if q == nil {
 				t.Error("mustNewRing returned nil")

--- a/internal/service/logger/middleware/failover/failover_sink_external_test.go
+++ b/internal/service/logger/middleware/failover/failover_sink_external_test.go
@@ -68,6 +68,43 @@ func TestNew(t *testing.T) {
 	}
 }
 
+// TestNew_SkipsNilBranches covers the nil-skip arm of New: nil entries are
+// silently dropped from the chain (documented contract), so a slate mixing
+// nils with one real sink still yields a usable failover Sink.
+func TestNew_SkipsNilBranches(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		real    int
+		wantErr bool
+	}{
+		{"nils plus one real branch succeeds", 1, false},
+		{"only nils collapses to Empty", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: interleave two nil branches with tc.real concrete sinks.
+			branches := []corelogger.Sink{nil, nil}
+			for range tc.real {
+				branches = append(branches, &controlledSink{})
+			}
+			s, err := failover.New(branches...)
+			//: an all-nil slate must collapse to the Empty sentinel.
+			if tc.wantErr {
+				if !errs.HasCode(err, failover.CodeFailoverEmpty) {
+					t.Errorf("New err = %v, want Empty", err)
+				}
+				return
+			}
+			//: a surviving real branch must yield a usable sink.
+			if err != nil || s == nil {
+				t.Errorf("New = (%v, %v), want a non-nil sink", s, err)
+			}
+		})
+	}
+}
+
 func TestFailover_Write(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -115,22 +152,36 @@ func TestFailover_Write(t *testing.T) {
 func TestFailover_Flush(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
+		name    string
+		bFails  bool
+		wantErr bool
 	}{
-		{"Flush hits every branch"},
+		{"clean flush hits every branch", false, false},
+		{"a failing branch is aggregated, others still flush", true, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a := &controlledSink{}
 			b := &controlledSink{}
+			//: a failing downstream Flush must be collected, not short-circuited.
+			if tc.bFails {
+				b.ferr = errors.New("flush boom")
+			}
 			s, err := failover.New(a, b)
 			if err != nil {
 				t.Fatalf("New err = %v", err)
 			}
-			if ferr := s.Flush(t.Context()); ferr != nil {
-				t.Errorf("Flush err = %v", ferr)
+			ferr := s.Flush(t.Context())
+			//: the failure case must surface the joined branch error.
+			if tc.wantErr {
+				if !errors.Is(ferr, b.ferr) {
+					t.Errorf("Flush err = %v, want it to wrap %v", ferr, b.ferr)
+				}
+			} else if ferr != nil {
+				t.Errorf("Flush err = %v, want nil", ferr)
 			}
+			//: every branch is flushed unconditionally regardless of failures.
 			if a.flush.Load() != 1 || b.flush.Load() != 1 {
 				t.Errorf("flush counts: a=%d b=%d, want both 1", a.flush.Load(), b.flush.Load())
 			}
@@ -141,22 +192,36 @@ func TestFailover_Flush(t *testing.T) {
 func TestFailover_Close(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
+		name    string
+		aFails  bool
+		wantErr bool
 	}{
-		{"Close hits every branch"},
+		{"clean close hits every branch", false, false},
+		{"a failing branch is aggregated, others still close", true, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a := &controlledSink{}
 			b := &controlledSink{}
+			//: a failing downstream Close must be collected, not short-circuited.
+			if tc.aFails {
+				a.cerr = errors.New("close boom")
+			}
 			s, err := failover.New(a, b)
 			if err != nil {
 				t.Fatalf("New err = %v", err)
 			}
-			if cerr := s.Close(); cerr != nil {
-				t.Errorf("Close err = %v", cerr)
+			cerr := s.Close()
+			//: the failure case must surface the joined branch error.
+			if tc.wantErr {
+				if !errors.Is(cerr, a.cerr) {
+					t.Errorf("Close err = %v, want it to wrap %v", cerr, a.cerr)
+				}
+			} else if cerr != nil {
+				t.Errorf("Close err = %v, want nil", cerr)
 			}
+			//: every branch is closed unconditionally regardless of failures.
 			if a.closed.Load() != 1 || b.closed.Load() != 1 {
 				t.Errorf("close counts: a=%d b=%d, want both 1", a.closed.Load(), b.closed.Load())
 			}

--- a/internal/service/logger/middleware/recover/panic_value_internal_test.go
+++ b/internal/service/logger/middleware/recover/panic_value_internal_test.go
@@ -101,6 +101,29 @@ func (evilStringer) String() (s string) {
 	panic("evil: String() panic")
 }
 
+// nestedPanicPayload is a panic value whose own String() panics. fmt's
+// internal Stringer-panic guard catches the OUTER panic, then tries to
+// render this payload, panics AGAIN, and re-raises rather than producing a
+// "%!v(PANIC=...)" marker — the only path that drives safeString's inner
+// recover (panic_value.go:37) instead of letting fmt absorb the panic.
+type nestedPanicPayload struct{}
+
+// String panics so fmt cannot format the payload during its own panic guard.
+func (nestedPanicPayload) String() string {
+	//: panic during payload formatting forces fmt to re-raise.
+	panic("nested: payload String() panic")
+}
+
+// doublePanicStringer panics with a value that ITSELF panics on String().
+// This re-raises out of fmt.Sprintf, exercising safeString's inner recover.
+type doublePanicStringer struct{}
+
+// String panics with a nestedPanicPayload so fmt re-raises the meta-panic.
+func (doublePanicStringer) String() string {
+	//: panic payload is itself unformattable, defeating fmt's panic guard.
+	panic(nestedPanicPayload{})
+}
+
 // Test_safeString_GuardsAgainstPanickingStringer asserts the meta-panic
 // invariant: even when v.String() panics, safeString returns gracefully.
 //
@@ -140,6 +163,38 @@ func Test_safeString_GuardsAgainstPanickingStringer(t *testing.T) {
 			gotDegraded := okFmt || okInner
 			if gotDegraded != tc.degradedMarker {
 				t.Errorf("safeString(%v) = %q, gotDegraded=%v want %v", tc.val, got, gotDegraded, tc.degradedMarker)
+			}
+		})
+	}
+}
+
+// Test_safeString_InnerRecoverMarker drives the meta-panic arm that fmt
+// cannot absorb: a Stringer whose panic payload is itself unformattable
+// forces fmt.Sprintf to re-raise, so safeString's own deferred recover
+// (panic_value.go:37) substitutes the "<panic in String(): T>" marker.
+// The plain evilStringer case is absorbed by fmt and therefore exercises a
+// different arm — this test pins the genuine inner-recover path.
+func Test_safeString_InnerRecoverMarker(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  any
+	}{
+		{"double-panic stringer triggers safeString's inner recover", doublePanicStringer{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				//: the inner recover must absorb the re-raised meta-panic.
+				if r := recover(); r != nil {
+					t.Fatalf("safeString allowed a meta-panic to escape: %v", r)
+				}
+			}()
+			got := safeString(tc.val)
+			//: the substituted marker proves line 37 ran (not fmt's own guard).
+			if !strings.Contains(got, "panic in String()") {
+				t.Errorf("safeString(%v) = %q, want inner-recover marker %q", tc.val, got, "<panic in String(): T>")
 			}
 		})
 	}

--- a/internal/service/logger/middleware/route/router_sink_external_test.go
+++ b/internal/service/logger/middleware/route/router_sink_external_test.go
@@ -2,6 +2,7 @@ package route_test
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -22,6 +23,20 @@ func (r *recordingSink) Write(_ context.Context, _ corelogger.RecordEvent, p []b
 
 func (r *recordingSink) Flush(_ context.Context) error { return nil }
 func (r *recordingSink) Close() error                  { return nil }
+
+// erroringSink is a Sink whose Flush and Close always fail with a fixed
+// error so the router's error-aggregation arms (errors.Join over per-sink
+// failures) are exercised on both the entry and the fallback path.
+type erroringSink struct {
+	err error
+}
+
+func (e *erroringSink) Write(_ context.Context, _ corelogger.RecordEvent, p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (e *erroringSink) Flush(_ context.Context) error { return e.err }
+func (e *erroringSink) Close() error                  { return e.err }
 
 func TestNew(t *testing.T) {
 	t.Parallel()
@@ -112,6 +127,37 @@ func TestRouter_FlushAndClose(t *testing.T) {
 			}
 			if err := r.Close(); err != nil {
 				t.Errorf("Close err = %v", err)
+			}
+		})
+	}
+}
+
+func TestRouter_FlushAndClose_AggregatesErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+	}{
+		{"Flush + Close join the entry and fallback failures"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: distinct sentinels prove the join captured BOTH the entry and the
+			//: fallback failure rather than short-circuiting on the first.
+			entryErr := errors.New("entry sink failed")
+			fallbackErr := errors.New("fallback sink failed")
+			entrySink := &erroringSink{err: entryErr}
+			fallbackSink := &erroringSink{err: fallbackErr}
+			r := route.New(fallbackSink, route.Params{When: route.LevelAtLeast(level.Error), Sink: entrySink})
+			//: Flush walks the entry then the fallback, joining both failures.
+			ferr := r.Flush(t.Context())
+			if !errors.Is(ferr, entryErr) || !errors.Is(ferr, fallbackErr) {
+				t.Errorf("Flush err = %v, want join of entry + fallback failures", ferr)
+			}
+			//: Close mirrors Flush — both downstream Close failures are joined.
+			cerr := r.Close()
+			if !errors.Is(cerr, entryErr) || !errors.Is(cerr, fallbackErr) {
+				t.Errorf("Close err = %v, want join of entry + fallback failures", cerr)
 			}
 		})
 	}

--- a/pkg/v1/codec/codec_bench_test.go
+++ b/pkg/v1/codec/codec_bench_test.go
@@ -935,14 +935,30 @@ func seedStream(stream corecodec.StreamingCodec, records []any) ([]byte, error) 
 // `-test.bench=^$` overrides the BUILD args' `-test.bench=.`, which would
 // otherwise re-run all ten top-level Benchmark* funcs on top of this
 // generator (the matrix is already driven internally here).
+//
+// It must stay in this *_bench_test.go file (a dedicated `manual`-tagged
+// go_test target, gazelle:excluded, gated by -test.run=^$) so the matrix
+// never runs under `bazel test //...`. Moving it to a regular
+// _external_test.go would either run the whole benchmark suite on every CI
+// test run (codec_test target) or trip KTN-TEST-FILES (no matching source).
+// KTN-TEST-SUFFIX is excluded for this file for that reason (see .ktn-linter.yaml).
 func TestGenerateBenchMD(t *testing.T) {
-	t.Helper()
+	//: drive the whole matrix programmatically via testing.Benchmark — this
+	//: direct call is the driver edge KTN-TEST-SUFFIX's IsBenchOrchestrator
+	//: (kodflow/ktn-linter#377) traces to exempt the Test from the bench-file
+	//: rule (and from TABLE / PARALLEL / ASSERT, which skip orchestrators).
 	rows := runAllBenches()
+	//: stamp the host envelope (CPU / RAM / OS / toolchain / git SHA).
 	env := collectMachineEnvelope()
+	//: render the Markdown report from the envelope + measured rows.
 	md := renderBenchMarkdown(env, rows)
+	//: resolve the source-tree path (BUILD_WORKSPACE_DIRECTORY under bazel run).
 	outPath := resolveBenchOutputPath()
+	//: write the regenerated report next to the sources. A benchmark
+	//: orchestrator must NOT assert via t.* (IsBenchOrchestrator, #377), so a
+	//: write failure panics — loud and non-assertion — instead of t.Fatalf.
 	if werr := os.WriteFile(outPath, []byte(md), 0o644); werr != nil {
-		t.Fatalf("write %s: %v", outPath, werr)
+		panic(fmt.Sprintf("codec bench: write %s: %v", outPath, werr))
 	}
 	t.Logf("wrote %s (%d rows)", outPath, len(rows))
 }

--- a/pkg/v1/codec/codec_external_test.go
+++ b/pkg/v1/codec/codec_external_test.go
@@ -1630,6 +1630,92 @@ func TestMarshalMany(t *testing.T) {
 	}
 }
 
+// marshalManyPromoteUser is the ordinary Go struct MarshalMany's
+// promotion-path cases broadcast. It is NOT a [][]string, so a
+// constrained codec (csv) rejects its native shape and forces
+// MarshalMany down the encodeWithPromotion → promoteMarshal fallback
+// that the JSON/CBOR/MsgPack happy-path cases never touch.
+type marshalManyPromoteUser struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}
+
+// TestMarshalMany_PromotionPath drives the encodeWithPromotion fallback
+// inside MarshalMany: a constrained Format (csv) plus an ordinary struct
+// makes the codec reject the native shape, so MarshalMany must promote
+// via the JSON bridge and still record the bytes. The chan case proves
+// the symmetric failure arm — promotion's json.Marshal step fails, the
+// per-format error is joined, and no map entry is recorded for that
+// Format. Kept separate from TestMarshalMany because that table fixes a
+// single shared value across all formats, whereas the promotion arms
+// need a value the constrained codec rejects natively.
+func TestMarshalMany_PromotionPath(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name        string
+		value       any
+		formats     []codec.Format
+		wantKeys    []codec.Format
+		wantMissing []codec.Format
+		wantErr     bool
+	}
+	tests := []tc{
+		{
+			//: csv rejects the struct natively → promotion encodes it →
+			//: bytes recorded under csv. json is the native control.
+			name:     "csv_promotion_succeeds",
+			value:    marshalManyPromoteUser{Name: "Ada", Age: 36},
+			formats:  []codec.Format{codec.JSON, codec.CSV},
+			wantKeys: []codec.Format{codec.JSON, codec.CSV},
+			wantErr:  false,
+		},
+		{
+			//: a chan never serialises to the JSON intermediate, so csv
+			//: promotion fails; the joined error carries it and csv gets
+			//: no map entry, while json still fails the same way (chan is
+			//: not json-marshalable for either codec) — both missing.
+			name:        "csv_promotion_json_error",
+			value:       make(chan int),
+			formats:     []codec.Format{codec.CSV},
+			wantMissing: []codec.Format{codec.CSV},
+			wantErr:     true,
+		},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		out, err := codec.MarshalMany(tc.value, tc.formats...)
+		//: error expectation gate.
+		if tc.wantErr && err == nil {
+			t.Fatalf("%s: expected joined error, got nil", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("%s: MarshalMany err=%v want nil", tc.name, err)
+		}
+		//: every expected key must carry bytes.
+		for _, f := range tc.wantKeys {
+			if _, ok := out[f]; !ok {
+				t.Errorf("%s: missing entry for %s", tc.name, f)
+			}
+		}
+		//: every failed Format must be absent from the map.
+		for _, f := range tc.wantMissing {
+			if _, ok := out[f]; ok {
+				t.Errorf("%s: unexpected entry for %s", tc.name, f)
+			}
+		}
+		//: the map cardinality matches exactly the successful keys.
+		if len(out) != len(tc.wantKeys) {
+			t.Errorf("%s: len(out)=%d want %d", tc.name, len(out), len(tc.wantKeys))
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
 // universalRoundtripUser is the canonical value used by
 // TestUniversalRoundtripAllCodecs to prove the post-promotion contract:
 // every Format accepts the SAME ordinary Go struct in Marshal and

--- a/pkg/v1/codec/promote_internal_test.go
+++ b/pkg/v1/codec/promote_internal_test.go
@@ -8,9 +8,26 @@ import (
 	"strings"
 	"testing"
 
+	corecodec "github.com/kitsunium/sdk/internal/core/codec"
 	kerrs "github.com/kitsunium/sdk/internal/kernel/errs"
 	fbcodec "github.com/kitsunium/sdk/internal/service/codec/flatbuffers"
 )
+
+// lookupCodec resolves a registered codec from the core registry for the
+// promotion-path tests that need a real codec to drive the inner
+// Marshal / Unmarshal failure arms (the blank imports in codec.go have
+// already registered every Format by the time the test runs).
+func lookupCodec(t *testing.T, f Format) corecodec.Codec {
+	t.Helper()
+	//: registry lookup mirrors what the public facade does.
+	c, ok := corecodec.Lookup(f)
+	//: a missing registration is a build-wiring bug, not a test input.
+	if !ok {
+		t.Fatalf("codec %q not registered", f)
+	}
+	//: caller drives the promotion path with the concrete codec.
+	return c
+}
 
 // promoteCanaryUser is the canonical fixture every promote-side test
 // runs against — small enough that all binary codecs fit the JSON
@@ -642,6 +659,140 @@ func TestPromoteUnmarshal_UnknownFormat(t *testing.T) {
 		err := promoteUnmarshal(tc.format, nil, []byte("ignored"), &back)
 		if reason, ok := kerrs.ReasonOf(err); !ok || reason != "PROMOTE_FAILED" {
 			t.Errorf("%s: reason=%q want PROMOTE_FAILED (err=%v)", tc.name, reason, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestPromoteMarshal_JSONError asserts promoteMarshal forwards the
+// encoding/json failure verbatim when the value cannot be serialised to
+// the JSON intermediate. A chan can never round-trip through json, so a
+// CSV-routed chan reaches the codec's VALUE_INVALID shape-rejection but
+// fails one step earlier at the json.Marshal bridge — exercising the
+// "surface json failure verbatim" arm that no roundtrip fixture hits.
+func TestPromoteMarshal_JSONError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name   string
+		format Format
+		value  any
+	}
+	tests := []tc{
+		//: chan is the canonical json-unsupported type.
+		{name: "csv-chan", format: CSV, value: make(chan int)},
+		//: func is the second json-unsupported scalar; ndjson is another
+		//: constrained codec so the arm holds across promotion targets.
+		{name: "ndjson-func", format: NDJSON, value: func() {}},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := lookupCodec(t, tc.format)
+		_, err := promoteMarshal(tc.format, c, tc.value)
+		//: the json bridge fails before any wrap step.
+		if err == nil {
+			t.Fatalf("%s: want json marshal error, got nil", tc.name)
+		}
+		//: the failure is the raw encoding/json error, NOT a typed
+		//: PromoteFailed sentinel — promoteMarshal forwards it as-is.
+		if _, ok := kerrs.ReasonOf(err); ok {
+			t.Errorf("%s: err=%v unexpectedly carries a typed reason; want raw json error", tc.name, err)
+		}
+		//: the json package names itself in the message.
+		if !strings.Contains(err.Error(), "json") {
+			t.Errorf("%s: err=%q does not look like an encoding/json failure", tc.name, err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestPromoteUnmarshal_ContainerUnmarshalError asserts promoteUnmarshal
+// surfaces the codec's own decode failure when the wire bytes are
+// malformed for the codec's native container. The CSV reader rejects a
+// row whose field count disagrees with the header, so feeding ragged CSV
+// drives the "codec failed to decode the wire bytes" arm — distinct from
+// the extract-shape arm below.
+func TestPromoteUnmarshal_ContainerUnmarshalError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name   string
+		format Format
+		data   []byte
+		reason string
+	}
+	tests := []tc{
+		//: ragged CSV (header has 3 cols, body has 2) fails ReadAll.
+		{name: "csv-ragged", format: CSV, data: []byte("a,b,c\n1,2\n"), reason: "UNMARSHAL_FAILED"},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := lookupCodec(t, tc.format)
+		var back promoteCanaryUser
+		err := promoteUnmarshal(tc.format, c, tc.data, &back)
+		//: the codec rejected the wire bytes before extract could run.
+		if err == nil {
+			t.Fatalf("%s: want codec decode error, got nil", tc.name)
+		}
+		//: the surfaced reason is the codec's own UNMARSHAL_FAILED, not
+		//: the promotion container sentinel.
+		if reason, ok := kerrs.ReasonOf(err); !ok || reason != tc.reason {
+			t.Errorf("%s: reason=%q ok=%v want %q", tc.name, reason, ok, tc.reason)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestPromoteUnmarshal_ExtractError asserts promoteUnmarshal surfaces the
+// typed PromoteFailed container sentinel when the codec decodes the wire
+// bytes cleanly but into a shape the extract closure rejects. A single-
+// row CSV parses fine yet lacks the header+body pair the csv extract
+// requires, so this drives the "container shape mismatch" arm that sits
+// after a SUCCESSFUL inner Unmarshal.
+func TestPromoteUnmarshal_ExtractError(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name    string
+		format  Format
+		data    []byte
+		private string
+	}
+	tests := []tc{
+		//: a lone header row parses to a 1-row table; extractCSV needs 2.
+		{name: "csv-single-row", format: CSV, data: []byte("onlyheader\n"), private: "malformed csv"},
+		//: an empty ndjson stream parses to a 0-row slice; extractNDJSON
+		//: needs at least one record.
+		{name: "ndjson-empty", format: NDJSON, data: []byte(""), private: "empty ndjson"},
+	}
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		c := lookupCodec(t, tc.format)
+		var back promoteCanaryUser
+		err := promoteUnmarshal(tc.format, c, tc.data, &back)
+		//: extract rejected the populated container shape.
+		if err == nil {
+			t.Fatalf("%s: want container-shape error, got nil", tc.name)
+		}
+		//: the typed sentinel keeps PROMOTE_FAILED routing intact.
+		if reason, ok := kerrs.ReasonOf(err); !ok || reason != "PROMOTE_FAILED" {
+			t.Fatalf("%s: reason=%q want PROMOTE_FAILED (err=%v)", tc.name, reason, err)
+		}
+		//: Private names the malformed container so triage is precise.
+		if priv := kerrs.PrivateOf(err); !strings.Contains(priv, tc.private) {
+			t.Errorf("%s: Private=%q missing %q", tc.name, priv, tc.private)
 		}
 	}
 	for _, tc := range tests {

--- a/pkg/v1/logger/logger_external_test.go
+++ b/pkg/v1/logger/logger_external_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"math"
 	"strings"
 	"testing"
+	"time"
 
 	corelogger "github.com/kitsunium/sdk/internal/core/logger"
 	errs "github.com/kitsunium/sdk/pkg/v1/errs"
@@ -98,6 +101,67 @@ func TestNewTextInjectsFrameworkVersion(t *testing.T) {
 			line := buf.String()
 			if !strings.Contains(line, `framework_version="`+logger.FrameworkVersion()+`"`) {
 				t.Errorf("missing framework_version attr: %q", line)
+			}
+		})
+	}
+}
+
+// TestNewTextWriters exercises the Writers fan-out branch of NewText: a
+// non-empty Writers slice broadcasts each record to every writer, while a
+// nil entry surfaces WriterRequired so a typo in the slice fails fast.
+func TestNewTextWriters(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		writers   func() []*bytes.Buffer
+		withNil   bool
+		wantErr   bool
+		wantEvery bool
+	}{
+		{
+			name:      "fan-out broadcasts to every writer",
+			writers:   func() []*bytes.Buffer { return []*bytes.Buffer{{}, {}} },
+			wantEvery: true,
+		},
+		{
+			name:    "a nil writer in the slice yields WriterRequired",
+			writers: func() []*bytes.Buffer { return []*bytes.Buffer{{}} },
+			withNil: true,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bufs := tc.writers()
+			//: assemble the io.Writer slice; the nil case prepends an untyped nil.
+			ws := make([]io.Writer, 0, len(bufs)+1)
+			//: the nil-entry case must put the nil first so it is hit before any buffer.
+			if tc.withNil {
+				ws = append(ws, nil)
+			}
+			for _, b := range bufs {
+				ws = append(ws, b)
+			}
+			lg, err := logger.NewText(logger.Config{Writers: ws, MinLevel: logger.LevelDebug})
+			//: error case — a nil writer must abort construction with WriterRequired.
+			if tc.wantErr {
+				if !errors.Is(err, logger.WriterRequired) {
+					t.Errorf("errors.Is(err, WriterRequired) = false: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewText(Writers) failed: %v", err)
+			}
+			logger.Info(t.Context(), lg, "fanned")
+			//: every writer in the fan-out must observe the same record.
+			if tc.wantEvery {
+				for i, b := range bufs {
+					if !strings.Contains(b.String(), "fanned") {
+						t.Errorf("writer %d missing record: %q", i, b.String())
+					}
+				}
 			}
 		})
 	}
@@ -232,7 +296,10 @@ func TestInt(t *testing.T) {
 		val  int
 	}{
 		{"positive", 42},
+		{"negative", -42},
 		{"zero", 0},
+		{"max int", math.MaxInt},
+		{"min int", math.MinInt},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -241,6 +308,185 @@ func TestInt(t *testing.T) {
 			if attr.Value.Kind() != corelogger.KindInt64 || attr.Value.Int64() != int64(tc.val) {
 				t.Errorf("Value = %v (kind=%s), want %d (KindInt64)",
 					attr.Value, attr.Value.Kind(), tc.val)
+			}
+		})
+	}
+}
+
+func TestBool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  bool
+	}{
+		{"true", true},
+		{"false", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Bool("k", tc.val)
+			if attr.Value.Kind() != corelogger.KindBool || attr.Value.Bool() != tc.val {
+				t.Errorf("Value = %v (kind=%s), want %t (KindBool)",
+					attr.Value, attr.Value.Kind(), tc.val)
+			}
+		})
+	}
+}
+
+func TestFloat64(t *testing.T) {
+	t.Parallel()
+	//: zero is a runtime variable so the division-by-zero rows compute real
+	//: IEEE-754 ±Inf / NaN payloads rather than tripping the constant-division
+	//: compile error.
+	zero := 0.0
+	tests := []struct {
+		name  string
+		val   float64
+		isNaN bool
+	}{
+		{name: "positive", val: 3.14},
+		{name: "negative", val: -2.5},
+		{name: "zero", val: 0},
+		{name: "positive infinity (1/0)", val: 1.0 / zero},
+		{name: "negative infinity (-1/0)", val: -1.0 / zero},
+		{name: "NaN (0/0)", val: zero / zero, isNaN: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Float64("k", tc.val)
+			//: every float row must keep the KindFloat64 discriminant.
+			if attr.Value.Kind() != corelogger.KindFloat64 {
+				t.Fatalf("Kind = %s, want KindFloat64", attr.Value.Kind())
+			}
+			got := attr.Value.Float64()
+			//: NaN never equals itself, so the NaN row asserts via IsNaN.
+			if tc.isNaN {
+				if !math.IsNaN(got) {
+					t.Errorf("Float64() = %g, want NaN", got)
+				}
+				return
+			}
+			//: finite and ±Inf rows round-trip under plain equality.
+			if got != tc.val {
+				t.Errorf("Float64() = %g, want %g", got, tc.val)
+			}
+		})
+	}
+}
+
+func TestInt64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  int64
+	}{
+		{"positive", 9_000_000_000},
+		{"negative", -1},
+		{"zero", 0},
+		{"max int64", math.MaxInt64},
+		{"min int64", math.MinInt64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Int64("k", tc.val)
+			if attr.Value.Kind() != corelogger.KindInt64 || attr.Value.Int64() != tc.val {
+				t.Errorf("Value = %v (kind=%s), want %d (KindInt64)",
+					attr.Value, attr.Value.Kind(), tc.val)
+			}
+		})
+	}
+}
+
+func TestUint64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  uint64
+	}{
+		{"zero", 0},
+		{"large", 18_000_000_000_000_000_000},
+		//: high-bit-set value would read as negative if mistaken for int64 —
+		//: pins the unsigned round-trip.
+		{"max uint64", math.MaxUint64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Uint64("k", tc.val)
+			if attr.Value.Kind() != corelogger.KindUint64 || attr.Value.Uint64() != tc.val {
+				t.Errorf("Value = %v (kind=%s), want %d (KindUint64)",
+					attr.Value, attr.Value.Kind(), tc.val)
+			}
+		})
+	}
+}
+
+func TestDuration(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  time.Duration
+	}{
+		{"positive seconds", 5 * time.Second},
+		{"negative (clock skew)", -3 * time.Hour},
+		{"zero", 0},
+		{"max duration", math.MaxInt64},
+		{"min duration", math.MinInt64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Duration("k", tc.val)
+			if attr.Value.Kind() != corelogger.KindDuration || attr.Value.Duration() != tc.val {
+				t.Errorf("Value = %v (kind=%s), want %s (KindDuration)",
+					attr.Value, attr.Value.Kind(), tc.val)
+			}
+		})
+	}
+}
+
+func TestTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  time.Time
+	}{
+		{"fixed instant", time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)},
+		{"zero time", time.Time{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Time("k", tc.val)
+			if attr.Value.Kind() != corelogger.KindTime || !attr.Value.Time().Equal(tc.val) {
+				t.Errorf("Value = %v (kind=%s), want %s (KindTime)",
+					attr.Value, attr.Value.Kind(), tc.val)
+			}
+		})
+	}
+}
+
+func TestAny(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		val  any
+	}{
+		{"struct payload", struct{ X int }{X: 1}},
+		{"nil payload", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			attr := logger.Any("k", tc.val)
+			if attr.Value.Kind() != corelogger.KindAny {
+				t.Errorf("Kind = %s, want KindAny", attr.Value.Kind())
+			}
+			if attr.Value.Any() != tc.val {
+				t.Errorf("Any() = %v, want %v", attr.Value.Any(), tc.val)
 			}
 		})
 	}

--- a/pkg/v1/logger/sink_external_test.go
+++ b/pkg/v1/logger/sink_external_test.go
@@ -264,3 +264,50 @@ func TestTextEncoderIsNonNil(t *testing.T) {
 		})
 	}
 }
+
+// TestNewWriterSink covers both arms of the io.Writer adapter: a nil writer
+// surfaces WriterRequired (the same sentinel NewText uses), and a real
+// writer yields a Sink that ships records through NewWithSink.
+func TestNewWriterSink(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		nilW bool
+	}{
+		{"nil writer yields WriterRequired", true},
+		{"real writer ships records", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			//: nil-writer arm — construction must abort with the typed sentinel.
+			if tc.nilW {
+				sink, err := logger.NewWriterSink(nil)
+				if sink != nil {
+					t.Errorf("expected nil sink, got %v", sink)
+				}
+				if !errors.Is(err, logger.WriterRequired) {
+					t.Errorf("errors.Is(err, WriterRequired) = false: %v", err)
+				}
+				if code, _ := errs.CodeOf(err); code != logger.CodeWriterRequired {
+					t.Errorf("CodeOf = %v, want %v", code, logger.CodeWriterRequired)
+				}
+				return
+			}
+			//: real-writer arm — the adapter must produce a record-shipping sink.
+			var buf bytes.Buffer
+			sink, err := logger.NewWriterSink(&buf)
+			if err != nil {
+				t.Fatalf("NewWriterSink err = %v", err)
+			}
+			lg, err := logger.NewWithSink(logger.SinkConfig{Sink: sink})
+			if err != nil {
+				t.Fatalf("NewWithSink err = %v", err)
+			}
+			logger.Info(t.Context(), lg, "wrote")
+			if !strings.Contains(buf.String(), "wrote") {
+				t.Errorf("writer sink missing payload: %q", buf.String())
+			}
+		})
+	}
+}

--- a/pkg/v1/logger/version_external_test.go
+++ b/pkg/v1/logger/version_external_test.go
@@ -6,6 +6,42 @@ import (
 	"github.com/kitsunium/sdk/pkg/v1/logger"
 )
 
+// TestFrameworkVersionInjected covers the link-time-set arm of
+// FrameworkVersion: when Version is non-empty (as the ldflags / Bazel
+// --stamp pipeline leaves it in a real build) the function returns it
+// verbatim instead of the "dev" sentinel. The package global is mutated
+// here, so this test is intentionally NOT parallel — it runs to completion
+// (set → assert → restore) while every t.Parallel() test in the package is
+// still paused, keeping the shared Version free of races.
+func TestFrameworkVersionInjected(t *testing.T) {
+	//: snapshot the link-time value so the mutation is fully reversible.
+	saved := logger.Version
+	//: restore on exit regardless of assertion outcome.
+	t.Cleanup(func() { logger.Version = saved })
+	tests := []struct {
+		name string
+		set  string
+	}{
+		{"semver", "v1.2.3"},
+		{"arbitrary", "build-42-abcdef"},
+	}
+	runCase := func(t *testing.T, set string) {
+		t.Helper()
+		//: stamp the global as the build pipeline would.
+		logger.Version = set
+		//: the injected value must come back unchanged, not "dev".
+		if got := logger.FrameworkVersion(); got != set {
+			t.Errorf("FrameworkVersion()=%q want %q", got, set)
+		}
+	}
+	for _, tc := range tests {
+		//: subtests stay serial — they share the package global Version.
+		t.Run(tc.name, func(t *testing.T) {
+			runCase(t, tc.set)
+		})
+	}
+}
+
 func TestFrameworkVersionFallback(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Rename `snapshot.New` → `NewValue` (fixes `KTN-STRUCT-CTOR`; internal-only, no consumer impact).
- Drive every package toward 100% statement coverage with credible black-box + white-box fixtures.
- Per-module totals: core **100%**, kernel **99.7%**, service **97.6%**, pkg/v1 **97.4%** (2926 go tests + 37 bazel race targets green).
- Numeric edge cases covered: NaN, ±Inf (division by zero), signed/unsigned bounds, negatives.
- TLV reflection codec **86.6% → 95.9%** (typed round-trip, generic↔typed projection, recursive-type depth guards, streaming/encode errors, truncation + crafted-byte matrices).
- Scoped `KTN-TEST-PARALLEL` exclude in `.ktn-linter.yaml` for the serial Version-injection test (it mutates a package global; parallel would race).

Remaining sub-100% lines are **genuinely unreachable test-only** defensive code, each justified in the commit body: switch defaults the dispatcher prevents, pool/cache invariant panics, root-only depth guards, infallible in-memory buffers in non-streaming Marshal/Append, defer-close-on-error bodies with no err-setting seam, cbor `must*` over fixed library options, and public wrappers that pre-validate the only failing input.

## Test plan

- [ ] `make build` (gazelle + gofumpt + bazel build) passes
- [ ] `make test` (`bazel test --config=race //...`) — all targets green
- [ ] `make lint` (mod-tidy + gazelle drift + gofumpt -l + ktn-linter) clean
- [ ] `bazel coverage --combined_report=lcov //...` reflects the new per-module totals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Large expansion of test coverage across codecs, logging, snapshot behavior, and edge/error paths (streaming, truncation, marshaling, promotion, depth/size limits).
  * New regression and integration tests to exercise error handling, nil-safety, and round-trip correctness.

* **Documentation**
  * Updated release metadata and whats-new entry timestamp.

* **Chores**
  * Linting configuration cleaned up to retire several scoped rule exclusions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->