### PR TITLE
test(sdk): address CodeRabbit follow-up on PR #37

### DIFF
--- a/internal/core/codec/registry_external_test.go
+++ b/internal/core/codec/registry_external_test.go
@@ -204,11 +204,12 @@ func TestRegistryHitPaths(t *testing.T) {
 		ext:  []string{".cov"},
 	}
 	codec.Register(mc)
-	tests := []struct {
+	type tc struct {
 		name   string
 		lookup func() (codec.Codec, bool)
 		wantOK bool
-	}{
+	}
+	tests := []tc{
 		{"Lookup resolves the registered Format", func() (codec.Codec, bool) {
 			return codec.Lookup(codec.Format("cov-hit"))
 		}, true},
@@ -236,13 +237,16 @@ func TestRegistryHitPaths(t *testing.T) {
 			return codec.LookupExt(".absent")
 		}, false},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; sequential — shares the process-wide registry seeded above.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		if _, ok := tc.lookup(); ok != tc.wantOK {
+			t.Errorf("%s: ok=%v want %v", tc.name, ok, tc.wantOK)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			//: sequential — shares the process-wide registry seeded above.
-			if _, ok := tc.lookup(); ok != tc.wantOK {
-				t.Errorf("%s: ok=%v want %v", tc.name, ok, tc.wantOK)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { runCase(t, tc) })
 	}
 	//: Available must now surface the freshly registered Format.
 	found := false
@@ -265,10 +269,11 @@ func TestRegistryHitPaths(t *testing.T) {
 func TestRegistryEmptyMisses(t *testing.T) {
 	//: drive all three snapshots back to nil to hit the absence branches.
 	codec.ResetForTest()
-	tests := []struct {
+	type tc struct {
 		name   string
 		lookup func() (codec.Codec, bool)
-	}{
+	}
+	tests := []tc{
 		{"Lookup misses on empty registry", func() (codec.Codec, bool) {
 			return codec.Lookup(codec.Format("cov-hit"))
 		}},
@@ -279,13 +284,16 @@ func TestRegistryEmptyMisses(t *testing.T) {
 			return codec.LookupExt(".cov")
 		}},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; every reader must report a miss against the nil snapshot.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		if _, ok := tc.lookup(); ok {
+			t.Errorf("%s: ok=true, want false on empty registry", tc.name)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			//: every reader must report a miss against the nil snapshot.
-			if _, ok := tc.lookup(); ok {
-				t.Errorf("%s: ok=true, want false on empty registry", tc.name)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { runCase(t, tc) })
 	}
 	//: Available must return the documented nil slice when nothing is registered.
 	if got := codec.Available(); got != nil {

--- a/internal/core/codec/scratch/scratch_external_test.go
+++ b/internal/core/codec/scratch/scratch_external_test.go
@@ -85,26 +85,30 @@ func TestReleaseBuffer(t *testing.T) {
 // rather than a panic.
 func TestReleaseNilIsNoOp(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name    string
 		release func()
-	}{
+	}
+	tests := []tc{
 		{"ReleaseBuffer(nil)", func() { scratch.ReleaseBuffer(nil) }},
 		{"ReleaseReader(nil)", func() { scratch.ReleaseReader(nil) }},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; a nil release must complete cleanly, so any panic here fails.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: a recovered panic is the failure signal — a nil release must
+		//: complete cleanly, so any panic here fails the assertion.
+		defer func() {
+			//: recover surfaces a panic as an explicit test failure.
+			if rec := recover(); rec != nil {
+				t.Errorf("%s panicked: %v", tc.name, rec)
+			}
+		}()
+		tc.release()
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: a recovered panic is the failure signal — a nil release must
-			//: complete cleanly, so any panic here fails the assertion.
-			defer func() {
-				//: recover surfaces a panic as an explicit test failure.
-				if rec := recover(); rec != nil {
-					t.Errorf("%s panicked: %v", tc.name, rec)
-				}
-			}()
-			tc.release()
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 

--- a/internal/kernel/errs/error_external_test.go
+++ b/internal/kernel/errs/error_external_test.go
@@ -652,32 +652,36 @@ func TestError_Is(t *testing.T) {
 // wrap-site code, then the inherited Reason and public message.
 func TestError_Error_RendersTrail(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
-	}{
+	}
+	tests := []tc{
 		{"single wrap renders one <- separated trail code"},
 	}
+	//: runCase executes one row directly so the static analyser credits
+	//: the branch; a wrap on a non-zero Code must produce the " <- " trail.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: 0x00_03_0F_70 = origin slot; 0x00_03_0F_71 = wrap-site slot.
+		origin := errs.Define(0x00_03_0F_70, "ORIGIN_TRAIL",
+			"origin public", "origin private")
+		wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_03_0F_71})
+		got := wrapped.Error()
+		//: a populated trail must render the ASCII wrap separator.
+		if !strings.Contains(got, " <- ") {
+			t.Errorf("Error() = %q, want ' <- ' trail separator", got)
+		}
+		//: origin-wins — Reason and public come from the wrapped cause.
+		if !strings.Contains(got, "ORIGIN_TRAIL") || !strings.Contains(got, "origin public") {
+			t.Errorf("Error() = %q, want origin reason + public", got)
+		}
+		//: Private must never leak into the rendered form.
+		if strings.Contains(got, "origin private") {
+			t.Errorf("Error() leaked Private: %q", got)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: 0x00_03_0F_70 = origin slot; 0x00_03_0F_71 = wrap-site slot.
-			origin := errs.Define(0x00_03_0F_70, "ORIGIN_TRAIL",
-				"origin public", "origin private")
-			wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_03_0F_71})
-			got := wrapped.Error()
-			//: a populated trail must render the ASCII wrap separator.
-			if !strings.Contains(got, " <- ") {
-				t.Errorf("Error() = %q, want ' <- ' trail separator", got)
-			}
-			//: origin-wins — Reason and public come from the wrapped cause.
-			if !strings.Contains(got, "ORIGIN_TRAIL") || !strings.Contains(got, "origin public") {
-				t.Errorf("Error() = %q, want origin reason + public", got)
-			}
-			//: Private must never leak into the rendered form.
-			if strings.Contains(got, "origin private") {
-				t.Errorf("Error() leaked Private: %q", got)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -685,30 +689,34 @@ func TestError_Error_RendersTrail(t *testing.T) {
 // monotonic truncation marker " (truncated)" is rendered before the Reason.
 func TestError_Error_RendersTruncated(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name  string
 		wraps int
-	}{
+	}
+	tests := []tc{
 		{"forty wraps overflow the trail cap", 40},
 	}
+	//: runCase executes one row directly so the static analyser credits
+	//: the branch; overflowing the trail cap must flip trailTruncated.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: 0x00_03_0F_72 = origin slot for the truncation walk.
+		var err error = errs.Define(0x00_03_0F_72, "TRUNC_ORIGIN",
+			"trunc public", "trunc private")
+		//: each wrap adds one distinct non-zero trail code; well past the
+		//: documented cap of 16 this must flip trailTruncated.
+		for i := range tc.wraps {
+			//: 0x00_07_01_xx — distinct non-zero wrap codes in layer 7.
+			err = errs.Wrap(err, errs.WrapParams{Code: errs.Code(0x00_07_01_00 + i + 1)})
+		}
+		got := err.Error()
+		//: overflow must surface the verbatim marker operators grep for.
+		if !strings.Contains(got, "(truncated)") {
+			t.Errorf("Error() = %q, want '(truncated)' marker", got)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: 0x00_03_0F_72 = origin slot for the truncation walk.
-			var err error = errs.Define(0x00_03_0F_72, "TRUNC_ORIGIN",
-				"trunc public", "trunc private")
-			//: each wrap adds one distinct non-zero trail code; well past the
-			//: documented cap of 16 this must flip trailTruncated.
-			for i := range tc.wraps {
-				//: 0x00_07_01_xx — distinct non-zero wrap codes in layer 7.
-				err = errs.Wrap(err, errs.WrapParams{Code: errs.Code(0x00_07_01_00 + i + 1)})
-			}
-			got := err.Error()
-			//: overflow must surface the verbatim marker operators grep for.
-			if !strings.Contains(got, "(truncated)") {
-				t.Errorf("Error() = %q, want '(truncated)' marker", got)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -717,30 +725,34 @@ func TestError_Error_RendersTruncated(t *testing.T) {
 // rather than dereferencing the nil receiver.
 func TestWrap_TypedNilErrorCause(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
-	}{
+	}
+	tests := []tc{
 		{"typed-nil *Error cause yields a params-driven error with nil source"},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: a typed-nil *Error is the classic interface-holding-nil trap.
-			var cause *errs.Error
-			//: 0x00_03_0F_73 = wrap slot for the typed-nil path.
-			wrapped := errs.Wrap(cause, errs.WrapParams{
-				Code: 0x00_03_0F_73, Reason: "TYPED_NIL_WRAP",
-				Public: "typed nil collapses to stdlib path", Private: "debug",
-			})
-			//: params apply because no *Error was inherited from the cause.
-			if wrapped.Code() != 0x00_03_0F_73 {
-				t.Errorf("Code = %s, want params code", wrapped.Code())
-			}
-			//: the collapsed path carries no wrapped cause.
-			if wrapped.Source() != nil {
-				t.Errorf("Source = %v, want nil", wrapped.Source())
-			}
+	//: runCase executes one row directly so the static analyser credits
+	//: the branch; a typed-nil *Error cause must collapse to the params path.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: a typed-nil *Error is the classic interface-holding-nil trap.
+		var cause *errs.Error
+		//: 0x00_03_0F_73 = wrap slot for the typed-nil path.
+		wrapped := errs.Wrap(cause, errs.WrapParams{
+			Code: 0x00_03_0F_73, Reason: "TYPED_NIL_WRAP",
+			Public: "typed nil collapses to stdlib path", Private: "debug",
 		})
+		//: params apply because no *Error was inherited from the cause.
+		if wrapped.Code() != 0x00_03_0F_73 {
+			t.Errorf("Code = %s, want params code", wrapped.Code())
+		}
+		//: the collapsed path carries no wrapped cause.
+		if wrapped.Source() != nil {
+			t.Errorf("Source = %v, want nil", wrapped.Source())
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -749,25 +761,30 @@ func TestWrap_TypedNilErrorCause(t *testing.T) {
 // code falls inside it, so errors.Is must still report a hit.
 func TestError_Is_MatchesTrailPrefix(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
-	}{
+	}
+	tests := []tc{
 		{"prefix matches a trail entry the origin misses"},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the trail-walk arm of matchesPrefix must catch a wrap-site
+	//: code whose subnet the origin misses.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: origin sits in layer 3; the matcher targets layer 7.
+		origin := errs.Define(0x00_03_0F_74, "PREFIX_TRAIL_ORIGIN",
+			"prefix trail public", "prefix trail private")
+		//: wrap with a layer-7 code so only the trail entry can match.
+		wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_07_01_01})
+		//: subnet over major+layer == 0.7 — origin (layer 3) misses it.
+		matcher := errs.NewPrefixMatcher(0x00_07_00_00, errs.MaskByLayer)
+		if !errors.Is(wrapped, matcher) {
+			t.Errorf("errors.Is(wrapped, layer-7 matcher) = false, want true via trail")
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: origin sits in layer 3; the matcher targets layer 7.
-			origin := errs.Define(0x00_03_0F_74, "PREFIX_TRAIL_ORIGIN",
-				"prefix trail public", "prefix trail private")
-			//: wrap with a layer-7 code so only the trail entry can match.
-			wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_07_01_01})
-			//: subnet over major+layer == 0.7 — origin (layer 3) misses it.
-			matcher := errs.NewPrefixMatcher(0x00_07_00_00, errs.MaskByLayer)
-			if !errors.Is(wrapped, matcher) {
-				t.Errorf("errors.Is(wrapped, layer-7 matcher) = false, want true via trail")
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -776,25 +793,29 @@ func TestError_Is_MatchesTrailPrefix(t *testing.T) {
 // through every branch to find a matching *Error code.
 func TestHasCode_MultiUnwrap(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
 		code errs.Code
 		want bool
-	}{
+	}
+	tests := []tc{
 		{"code present in a joined branch", 0x00_03_0F_75, true},
 		{"code absent from every branch", 0x00_03_0F_76, false},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; HasCode must recurse through every Unwrap() []error branch.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: 0x00_03_0F_75 = the sdk branch buried inside the join.
+		sdk := errs.Define(0x00_03_0F_75, "JOINED_SDK",
+			"joined public", "joined private")
+		//: errors.Join exposes Unwrap() []error, forcing the multi walk.
+		joined := errors.Join(errors.New("plain branch"), sdk)
+		if got := errs.HasCode(joined, tc.code); got != tc.want {
+			t.Errorf("HasCode(joined, %s) = %v, want %v", tc.code, got, tc.want)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: 0x00_03_0F_75 = the sdk branch buried inside the join.
-			sdk := errs.Define(0x00_03_0F_75, "JOINED_SDK",
-				"joined public", "joined private")
-			//: errors.Join exposes Unwrap() []error, forcing the multi walk.
-			joined := errors.Join(errors.New("plain branch"), sdk)
-			if got := errs.HasCode(joined, tc.code); got != tc.want {
-				t.Errorf("HasCode(joined, %s) = %v, want %v", tc.code, got, tc.want)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }

--- a/internal/service/codec/tlv/codec_external_test.go
+++ b/internal/service/codec/tlv/codec_external_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/kitsunium/sdk/internal/core/codec"
@@ -1134,6 +1135,10 @@ func TestAppendRollbackOnError(t *testing.T) {
 			t.Fatal("codec does not implement Appender")
 		}
 		prefill := []byte{0xAA, 0xBB, 0xCC}
+		//: snapshot prefill BEFORE Append so any in-place mutation is
+		//: visible — otherwise comparing out against prefill could silently
+		//: agree when prefill itself was clobbered.
+		want := slices.Clone(prefill)
 		out, err := ap.Append(prefill, make(chan int))
 		//: the encode must fail on the unsupported value.
 		if err == nil {
@@ -1141,8 +1146,8 @@ func TestAppendRollbackOnError(t *testing.T) {
 		}
 		//: rollback contract — the returned buffer is byte-for-byte the prior
 		//: prefix: neither truncated/grown (length) nor mutated (content).
-		if !bytes.Equal(out, prefill) {
-			t.Errorf("Append did not roll back: out=%v, want %v", out, prefill)
+		if !bytes.Equal(out, want) {
+			t.Errorf("Append did not roll back: out=%v, want %v", out, want)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/tlv/types_internal_test.go
+++ b/internal/service/codec/tlv/types_internal_test.go
@@ -541,10 +541,16 @@ func TestDecodeLargeScalarSlice(t *testing.T) {
 		if uerr := New().Unmarshal(encoded, &out); uerr != nil {
 			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
 		}
-		//: every element must survive the grow-as-we-go walk.
-		if len(out) != tc.size || out[tc.size-1] != int64(tc.size-1) {
-			t.Errorf("%s: len=%d last=%d, want len=%d last=%d",
-				tc.name, len(out), out[len(out)-1], tc.size, tc.size-1)
+		//: every element must survive the grow-as-we-go walk. Length is
+		//: checked first so a short-decode failure doesn't index past
+		//: out — out[tc.size-1] would panic on len(out) == 0 and mask
+		//: the real failure.
+		if len(out) != tc.size {
+			t.Errorf("%s: len=%d, want len=%d", tc.name, len(out), tc.size)
+			return
+		}
+		if out[tc.size-1] != int64(tc.size-1) {
+			t.Errorf("%s: last=%d, want last=%d", tc.name, out[tc.size-1], tc.size-1)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/xml/encoder_internal_test.go
+++ b/internal/service/codec/xml/encoder_internal_test.go
@@ -5,6 +5,8 @@ import (
 	stdxml "encoding/xml"
 	"errors"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
 
 type xmlDoc struct {
@@ -102,8 +104,10 @@ func Test_xmlEncoder_Close_FlushError(t *testing.T) {
 			t.Fatalf("%s: EncodeToken setup err=%v", tc.name, terr)
 		}
 		//: Close → Flush fails over the failing writer, hitting the wrap.
-		if err := enc.Close(); err == nil {
-			t.Errorf("%s: Close=nil, want flush error wrapped as MARSHAL_FAILED", tc.name)
+		//: assert the typed code, not just non-nil, so a regression where
+		//: Close stops carrying the dotted-quad sentinel actually fails.
+		if err := enc.Close(); !errs.HasCode(err, CodeXMLMarshalFailed) {
+			t.Errorf("%s: Close err=%v, want CodeXMLMarshalFailed (0.3.3.1)", tc.name, err)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/yaml/codec_internal_test.go
+++ b/internal/service/codec/yaml/codec_internal_test.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"bytes"
 	"errors"
+	"slices"
 	"testing"
 )
 
@@ -210,14 +211,17 @@ func Test_yamlCodec_Append(t *testing.T) {
 		if !ok {
 			t.Fatalf("%s: yamlCodec does not implement Appender", tc.name)
 		}
+		//: snapshot dst BEFORE Append so a same-length in-place mutation
+		//: on the error path is still detectable — length alone would miss it.
+		orig := slices.Clone(tc.dst)
 		got, err := ap.Append(tc.dst, tc.v)
 		if tc.wantErr {
 			if err == nil {
 				t.Fatalf("%s: want error, got nil", tc.name)
 			}
-			//: dst returned untouched on error (length match).
-			if len(got) != len(tc.dst) {
-				t.Errorf("%s: dst len changed on error: got=%d want=%d", tc.name, len(got), len(tc.dst))
+			//: dst returned byte-for-byte untouched on error.
+			if !bytes.Equal(got, orig) {
+				t.Errorf("%s: dst mutated on error: got=%q want=%q", tc.name, got, orig)
 			}
 			return
 		}

--- a/internal/service/logger/middleware/async/async_sink_internal_test.go
+++ b/internal/service/logger/middleware/async/async_sink_internal_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
+// ctxKind / flushOutcome consolidate the table-driven test flags so the
+// Test_asyncSink_Flush case struct stays under the KTN-STRUCT-FLAGS
+// threshold and each row's intent is self-documenting.
+
+const (
+	ctxLive      ctxKind = iota //: default — t.Context()
+	ctxNil                      //: literal nil — wait-forever contract
+	ctxCancelled                //: pre-cancelled context — drives the typed cancellation arm
+)
+
+const (
+	outcomeOK        flushOutcome = iota //: Flush returns nil (happy path / fast-return)
+	outcomeCancelled                     //: Flush wraps ctx.Err() as CodeAsyncCtxCancelled
+	outcomeStopped                       //: Flush returns the Stopped sentinel (drainer exited)
+)
+
+// ctxKind enumerates the Flush context flavours the table exercises.
+type ctxKind uint8
+
+// flushOutcome enumerates the three documented terminal states of Flush
+// (nil / typed cancellation / Stopped) so the table-case struct can
+// express the assertion with one enum instead of three parallel bools.
+type flushOutcome uint8
+
 // noopDownstream satisfies corelogger.Sink for white-box drainer tests
 // that don't care about delivery.
 type noopDownstream struct{}
@@ -107,14 +131,10 @@ func Test_asyncSink_handleFull(t *testing.T) {
 
 func Test_asyncSink_Flush(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name      string
-		ctxCancel bool
-		//: nilCtx swaps t.Context() for a literal nil so the
-		//: "nil-context permitted by the contract" row actually exercises
-		//: the nil-ctx path (the empty-queue fast return) instead of the
-		//: live-ctx path the previous all-zero row tested by accident.
-		nilCtx bool
+	type tc struct {
+		name string
+		//: ctx picks the Flush context flavour for this row.
+		ctx ctxKind
 		//: prime enqueues entries before Flush so the loop sees a non-empty
 		//: ring and falls through to the cancellation arm instead of the
 		//: empty-queue fast path. freshSink has no live drainer so the
@@ -124,71 +144,85 @@ func Test_asyncSink_Flush(t *testing.T) {
 		//: returns false on the first non-empty iteration — driving Flush's
 		//: documented Stopped arm ("flushSignal observed closed").
 		closeSignal bool
-		wantErr     bool
-		wantCode    bool
-		//: wantStopped asserts the Stopped sentinel (drainer-exited path).
-		wantStopped bool
-	}{
-		{"empty queue + live ctx returns nil", false, false, false, false, false, false, false},
-		{"empty queue + cancelled ctx still flushes downstream", true, false, false, false, false, false, false},
-		{"explicit nil context is permitted by the contract", false, true, false, false, false, false, false},
-		{"non-empty queue + cancelled ctx surfaces the typed cancellation", true, false, true, false, true, true, false},
-		{"non-empty queue + closed flushSignal surfaces Stopped", false, false, true, true, true, false, true},
+		//: want consolidates the three terminal states (nil/cancelled/
+		//: stopped) so each row carries one verdict instead of three
+		//: parallel booleans.
+		want flushOutcome
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			s := freshSink(t, DropNewest)
-			//: prime the ring so Flush observes remaining > 0 and reaches the
-			//: ctx-cancellation arm rather than returning on the empty path.
-			if tc.prime {
-				if werr := s.queue.TryWrite(newRecordEntry()); werr != nil {
-					t.Fatalf("priming TryWrite err = %v", werr)
-				}
+	tests := []tc{
+		{"empty queue + live ctx returns nil", ctxLive, false, false, outcomeOK},
+		{"empty queue + cancelled ctx still flushes downstream", ctxCancelled, false, false, outcomeOK},
+		{"explicit nil context is permitted by the contract", ctxNil, false, false, outcomeOK},
+		{"non-empty queue + cancelled ctx surfaces the typed cancellation", ctxCancelled, true, false, outcomeCancelled},
+		{"non-empty queue + closed flushSignal surfaces Stopped", ctxLive, true, true, outcomeStopped},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; Flush's documented contract spans the empty-queue fast path,
+	//: nil-ctx wait-forever, cancellation arm, and Stopped sentinel — every
+	//: row drives one of those branches under a freshSink (no live drainer).
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		s := freshSink(t, DropNewest)
+		//: prime the ring so Flush observes remaining > 0 and reaches the
+		//: ctx-cancellation arm rather than returning on the empty path.
+		if tc.prime {
+			if werr := s.queue.TryWrite(newRecordEntry()); werr != nil {
+				t.Fatalf("priming TryWrite err = %v", werr)
 			}
-			//: pre-close flushSignal to reproduce the documented drainer-exited
-			//: state so Flush's waitForDrainerProgress returns false and the
-			//: Stopped arm runs. freshSink leaves flushSignal nil, so equip a
-			//: dedicated channel first (mirroring Test_waitForDrainerProgress),
-			//: then close it. The drainer never closes this channel in
-			//: production (only Close terminates it indirectly), so this
-			//: white-box setup is the only way to exercise the defensive arm.
-			if tc.closeSignal {
-				s.flushSignal = make(chan struct{}, 1)
-				close(s.flushSignal)
+		}
+		//: pre-close flushSignal to reproduce the documented drainer-exited
+		//: state so Flush's waitForDrainerProgress returns false and the
+		//: Stopped arm runs. freshSink leaves flushSignal nil, so equip a
+		//: dedicated channel first (mirroring Test_waitForDrainerProgress),
+		//: then close it. The drainer never closes this channel in
+		//: production (only Close terminates it indirectly), so this
+		//: white-box setup is the only way to exercise the defensive arm.
+		if tc.closeSignal {
+			s.flushSignal = make(chan struct{}, 1)
+			close(s.flushSignal)
+		}
+		//: select the ctx the row asks for; the nil arm exercises the
+		//: documented "wait-forever, no cancellation" contract.
+		var ctx context.Context
+		switch tc.ctx {
+		case ctxNil:
+			ctx = nil
+		case ctxCancelled:
+			cancelled, cancel := context.WithCancel(t.Context())
+			cancel()
+			ctx = cancelled
+		case ctxLive:
+			fallthrough
+		default:
+			ctx = t.Context()
+		}
+		err := s.Flush(ctx)
+		//: dispatch on the single verdict — each branch fully covers its
+		//: outcome (nil-on-OK, typed code + stdlib chain on cancelled,
+		//: Stopped sentinel on drainer-exited).
+		switch tc.want {
+		case outcomeOK:
+			if err != nil {
+				t.Errorf("Flush err = %v, want nil", err)
 			}
-			//: select the ctx the row asks for; the nil arm exercises the
-			//: documented "wait-forever, no cancellation" contract.
-			var ctx context.Context
-			switch {
-			case tc.nilCtx:
-				ctx = nil
-			case tc.ctxCancel:
-				cancelled, cancel := context.WithCancel(t.Context())
-				cancel()
-				ctx = cancelled
-			default:
-				ctx = t.Context()
+		case outcomeCancelled:
+			if err == nil {
+				t.Fatal("Flush err = nil, want CodeAsyncCtxCancelled")
 			}
-			err := s.Flush(ctx)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("Flush err = %v, wantErr = %v", err, tc.wantErr)
+			if !errs.HasCode(err, CodeAsyncCtxCancelled) {
+				t.Errorf("Flush err = %v, want CodeAsyncCtxCancelled", err)
 			}
-			//: the cancellation arm wraps ctx.Err() with the typed sentinel —
-			//: assert both the dotted-quad code and stdlib Is() chaining.
-			if tc.wantCode {
-				if !errs.HasCode(err, CodeAsyncCtxCancelled) {
-					t.Errorf("Flush err = %v, want CodeAsyncCtxCancelled", err)
-				}
-				if !errors.Is(err, context.Canceled) {
-					t.Errorf("Flush err = %v, want errors.Is(context.Canceled)", err)
-				}
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("Flush err = %v, want errors.Is(context.Canceled)", err)
 			}
-			//: the Stopped arm returns the drainer-exited sentinel verbatim.
-			if tc.wantStopped && !errs.HasCode(err, CodeAsyncStopped) {
+		case outcomeStopped:
+			if !errs.HasCode(err, CodeAsyncStopped) {
 				t.Errorf("Flush err = %v, want Stopped", err)
 			}
-		})
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 

--- a/internal/service/logger/middleware/async/async_sink_internal_test.go
+++ b/internal/service/logger/middleware/async/async_sink_internal_test.go
@@ -110,6 +110,11 @@ func Test_asyncSink_Flush(t *testing.T) {
 	tests := []struct {
 		name      string
 		ctxCancel bool
+		//: nilCtx swaps t.Context() for a literal nil so the
+		//: "nil-context permitted by the contract" row actually exercises
+		//: the nil-ctx path (the empty-queue fast return) instead of the
+		//: live-ctx path the previous all-zero row tested by accident.
+		nilCtx bool
 		//: prime enqueues entries before Flush so the loop sees a non-empty
 		//: ring and falls through to the cancellation arm instead of the
 		//: empty-queue fast path. freshSink has no live drainer so the
@@ -124,11 +129,11 @@ func Test_asyncSink_Flush(t *testing.T) {
 		//: wantStopped asserts the Stopped sentinel (drainer-exited path).
 		wantStopped bool
 	}{
-		{"empty queue + live ctx returns nil", false, false, false, false, false, false},
-		{"empty queue + cancelled ctx still flushes downstream", true, false, false, false, false, false},
-		{"explicit nil context is permitted by the contract", false, false, false, false, false, false},
-		{"non-empty queue + cancelled ctx surfaces the typed cancellation", true, true, false, true, true, false},
-		{"non-empty queue + closed flushSignal surfaces Stopped", false, true, true, true, false, true},
+		{"empty queue + live ctx returns nil", false, false, false, false, false, false, false},
+		{"empty queue + cancelled ctx still flushes downstream", true, false, false, false, false, false, false},
+		{"explicit nil context is permitted by the contract", false, true, false, false, false, false, false},
+		{"non-empty queue + cancelled ctx surfaces the typed cancellation", true, false, true, false, true, true, false},
+		{"non-empty queue + closed flushSignal surfaces Stopped", false, false, true, true, true, false, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -152,11 +157,18 @@ func Test_asyncSink_Flush(t *testing.T) {
 				s.flushSignal = make(chan struct{}, 1)
 				close(s.flushSignal)
 			}
-			ctx := t.Context()
-			if tc.ctxCancel {
-				cancelled, cancel := context.WithCancel(ctx)
+			//: select the ctx the row asks for; the nil arm exercises the
+			//: documented "wait-forever, no cancellation" contract.
+			var ctx context.Context
+			switch {
+			case tc.nilCtx:
+				ctx = nil
+			case tc.ctxCancel:
+				cancelled, cancel := context.WithCancel(t.Context())
 				cancel()
 				ctx = cancelled
+			default:
+				ctx = t.Context()
 			}
 			err := s.Flush(ctx)
 			if (err != nil) != tc.wantErr {


### PR DESCRIPTION
## Summary

Apply the 9 advisory CodeRabbit findings raised on the merged coverage PR #37.

ktn-linter v1.34.5 does **not** enforce any of these (per the active session
note), but each one closes a real test-quality gap or aligns with the
established `runCase` convention used throughout the kernel test suites.

## Findings addressed

### Group A — extract `runCase(t, tc)` for new tables (4)

| File | Change |
|---|---|
| `internal/core/codec/registry_external_test.go` | Both `tests :=` tables (TestRegistryHits + TestRegistryEmptyMisses) now route through a local `runCase`. |
| `internal/core/codec/scratch/scratch_external_test.go` | `TestReleaseNilIsNoOp` aligned with the rest of the file. |
| `internal/kernel/errs/error_external_test.go` | 5 new tests added in #37: `TestError_Error_RendersTrail`, `…_RendersTruncated`, `TestWrap_TypedNilErrorCause`, `TestError_Is_MatchesTrailPrefix`, `TestHasCode_MultiUnwrap`. |

### Group B — close real test gaps (5)

| File | Bug closed |
|---|---|
| `tlv/codec_external_test.go` | Snapshot `prefill` via `slices.Clone` before `Append` — an in-place mutation that preserved the length was previously invisible. |
| `tlv/types_internal_test.go` | Split length-then-index assertions so a `len(out)==0` failure no longer panics in the format string and masks the real cause. |
| `xml/encoder_internal_test.go` | Assert `CodeXMLMarshalFailed` via `errs.HasCode` (SDK Rule 3) instead of accepting any non-nil error. |
| `yaml/codec_internal_test.go` | Snapshot `dst` via `slices.Clone` and assert `bytes.Equal` — a same-length in-place mutation on the error path was previously invisible. |
| `async/async_sink_internal_test.go` | Add `nilCtx bool` on `tc`; the `"explicit nil context is permitted by the contract"` row now actually exercises the nil-ctx path instead of `t.Context()` by accident. |

## Notes

- CodeRabbit suggested `append([]byte(nil), s...)` for the two snapshots; ktn-linter's `KTN-VAR-SLICECLONE` prefers `slices.Clone` — used here.
- No production code touched; this is strictly a test-quality refinement.
- No ADR impact, no `.ktn-linter.yaml` change.

## Test plan

- [x] `bazel build //...` — green
- [x] `make test` (race-on) — 37/37 targets pass
- [x] `make lint` (mod tidy + gazelle diff + gofumpt + ktn-linter all phases) — clean
- [ ] CodeRabbit re-review on the new diff to confirm the 9 findings are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test robustness and clarity by refactoring table-driven cases into reusable runners.
  * Hardened assertions to avoid panics and false positives (safer slice/length checks, buffer snapshot comparisons).
  * Added explicit checks for expected error codes and tightened expectations for failure paths.
  * Expanded coverage of edge scenarios (nil releases/contexts, rollback-on-error, flush outcomes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->