### PR TITLE
feat(kernel): add sdkwarn + ADR 0012 writer subsystem (PR 1/10)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,6 +26,7 @@ filegroup(
         "//internal/kernel/clock:audit_srcs",
         "//internal/kernel/errs:audit_srcs",
         "//internal/kernel/recycler:audit_srcs",
+        "//internal/kernel/sdkwarn:audit_srcs",
         "//internal/kernel/snapshot:audit_srcs",
         "//internal/service/codec/asn1:audit_srcs",
         "//internal/service/codec/baseenc:audit_srcs",

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -20,6 +20,7 @@ Long-form SDK documentation. ADRs here are the source of truth for cross-cutting
 | `adr/0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible (no local `replace`) | Accepted (requirement); impl Deferred |
 | `adr/0010-kernel-recycler-primitive.md` | Generic kernel `Pool[T]` + `CappedPool[T]`; `buffer` + `core/codec/scratch` become consumers | Accepted |
 | `adr/0011-kernel-snapshot-primitive.md` | Generic kernel `Value[T]` copy-on-write container; codec registry consolidates onto it | Accepted |
+| `adr/0012-sdk-writer-subsystem-architecture.md` | Writer subsystem v2: `Sink` identity methods + factory registry + 5 new middlewares + `composevalidate` + public facade + reserved PP block 0.3.25-79 + 1.1.1.* | Accepted (amends ADR 0006) |
 
 ## ADR conventions
 

--- a/docs/adr/0006-sdk-error-code-registry-extension.md
+++ b/docs/adr/0006-sdk-error-code-registry-extension.md
@@ -109,6 +109,11 @@ assigning it by analogy without checking.
   authoritative list — this extension table becomes part of it after
   merge.
 
+- **Amended by ADR 0012** (writer subsystem v2) for the logger sub-tree
+  — see ADR 0012 §11 for the new block reservations 0.3.25-79 plus the
+  Layer-1 1.1.1.* facade range. The "PP slot 22+" guidance above stays
+  valid for non-logger sub-trees.
+
 ## Deferred (not addressed here)
 
 - **`KTN-ERRS-DOTTEDQUAD` linter rule** (ADR 0005 §Deferred): an

--- a/docs/adr/0012-sdk-writer-subsystem-architecture.md
+++ b/docs/adr/0012-sdk-writer-subsystem-architecture.md
@@ -1,0 +1,337 @@
+# ADR 0012 — Writer Subsystem v2: universal-pattern alignment
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-29
+
+## Deciders
+
+kodflow (with 25-agent synthesis — see `.claude/contexts/logger-writers-architecture.md` §5)
+
+## Amends
+
+ADR 0006 §"Future allocations" — the "next logger sub-package gets PP slot 22+"
+guidance is retired for the logger sub-tree; the new block reservations in §11
+supersede it.
+
+## Related
+
+- ADR 0001 — multi-module layout
+- ADR 0003 — universal codec package (registry shape model)
+- ADR 0005 — dotted-quad error codes
+- ADR 0010 — kernel object-recycling primitive (concrete-struct precedent)
+- ADR 0011 — kernel copy-on-write snapshot primitive (storage choice for registry)
+- `.claude/contexts/logger-writers-architecture.md` — research context (industry survey + 25-agent universal-pattern synthesis)
+
+## Context
+
+The SDK logger writer subsystem (`internal/service/logger/sink/*` + `…/middleware/*`)
+shipped with a 3-method `Sink` interface (`Write` / `Flush` / `Close`),
+three transports (`console`, `file`, `syslog`), six middlewares (`multi`, `async`,
+`route`, `failover`, `sample`, `recover`), and ADR 0006 PP slots 13–21. The
+universal-pattern audit (`.claude/contexts/logger-writers-architecture.md`)
+ran a 25-agent synthesis against the codec subsystem (ADR 0003 — 10+ formats
+behind one registry) and the kernel pool primitives (ADR 0010 — concrete
+generic types, no interface) and concluded that the logger subsystem needs:
+
+1. **Three new identity methods on `Sink`** (`Name` / `Class` / `Schemes`) so a
+   construction-time registry can dispatch URL → factory and middlewares can
+   choose defaults from class. The codec interface already carries
+   `Name`/`MIMETypes`/`Extensions` for exactly this reason.
+2. **A registry of factories** (not instances — sinks own resources) keyed on
+   `Name` + `Schemes`, storage backed by `snapshot.Value[map[K]V]` (ADR 0011 +
+   the codec 9.1 ns vs 12.8 ns measurement justifying COW over `sync.Map`).
+3. **Five new reliability middlewares** (`timeout`, `retry`, `circuit_breaker`,
+   `dlq`, `rate_limit`) so the upcoming remote sinks (OTLP, Loki, CloudWatch,
+   S3 — each lands as its own follow-up PR) ride a battle-tested compose stack.
+4. **A composition validator** (`composevalidate`) that catches the 10
+   anti-patterns the compiler cannot (cycles, empty Multi, sample rate ≤ 0,
+   redundant async-over-async, etc.) at construction time.
+5. **A public facade `pkg/v1/logger/sink/` + `pkg/v1/logger/sinkmw/`** so the
+   extension surface is `go get`-resolvable (ADR 0009).
+6. **One construction-time warning primitive** so a middleware can hint
+   "you're wrapping a Local sink with a CircuitBreaker — this will never trip"
+   without throwing an error. The hint sink is `os.Stderr` by default and an
+   installable hook in tests.
+7. **A reserved PP-block allocation** so the 10+ upcoming sinks claim slots
+   alphabetically without per-PR contention.
+
+The locked architectural answers are in `.claude/contexts/logger-writers-architecture.md`
+§5. This ADR is the authoritative record cited by the migration's commit
+messages.
+
+## Decision
+
+The 15 numbered choices below are the architectural decisions the migration
+carries. Each is binary — accept or reject the whole — to keep follow-up PRs
+focused on implementation, not re-litigation.
+
+### 1. `Sink` stays the name; `Encoder` stays the format port; `Handler` stays composition
+
+Disambiguates from `io.Writer` (zerolog), `slog.Handler` (fused format+transport),
+`zapcore.Core` (owns level checking). "Writer" is reserved for the underlying
+`io.Writer` that a console-class sink wraps.
+
+### 2. `Sink` interface gains `Name() string` + `Class() SinkClass` + `Schemes() []string`
+
+```go
+type Sink interface {
+    Name() string             // unique registry key, kebab-case, frozen post-v1
+    Class() SinkClass         // middleware compose-time hint, NEVER on hot path
+    Schemes() []string        // URL schemes this sink handles, defensive-cloned on each call
+    Write(ctx context.Context, r RecordEvent, p []byte) (n int, err error)
+    Flush(ctx context.Context) error
+    Close() error
+}
+```
+
+`SinkClass uint8` is a bounded enum: `UnknownClass` (zero value) / `LocalClass` /
+`AsyncLocalClass` / `RemoteBatchedClass` / `RemoteStreamingClass`. The
+zero-value-as-Unknown design is the wave-2 review's safety footgun fix —
+forgetting to set a class fails closed rather than silently falling back to
+`LocalClass`.
+
+### 3. Optional capability sub-interfaces detected by type assertion
+
+```go
+type BatchSink interface { Sink; WriteBatch(ctx, []RecordEvent, [][]byte) (int, error) }
+type SyncSink  interface { Sink; Sync(ctx) error }   // durability (fsync), not Flush
+```
+
+Convergent with zap (`zapcore.Core` + the unexported buffered wrappers) and
+phuslu/log (`Writer` + the `Sync()`-conformant variants). Decorators fall back
+to N×`Write` when absent — zero breaking change for sinks that don't implement
+the capability.
+
+### 4. `*BaseSink` embed (pointer embed, 1 word) — zero-breaking migration
+
+```go
+type BaseSink struct { name string; class SinkClass; schemes []string }
+
+func NewBaseSink(name string, class SinkClass, schemes []string) *BaseSink {
+    // validates: empty name → panic; class > max → panic; duplicate scheme → panic
+    return &BaseSink{name: name, class: class, schemes: slices.Clone(schemes)}
+}
+
+func (b *BaseSink) Name() string      { return b.name }
+func (b *BaseSink) Class() SinkClass  { return b.class }
+func (b *BaseSink) Schemes() []string { return slices.Clone(b.schemes) }
+```
+
+`*BaseSink` embed (1 word) — not value embed (5 words). Migration patch per
+existing sink ≤ 5 lines. Public constructors stay byte-for-byte identical.
+
+### 5. Sink registry = registry of factories, NOT instances
+
+```go
+type Factory interface {
+    Name() string
+    Schemes() []string
+    FromURL(u *url.URL) (logger.Sink, error)
+    FromConfig(cfg any) (logger.Sink, error)
+}
+```
+
+Codec singletons are stateless; sinks own resources (endpoints, creds,
+goroutines). Sticking instances in the registry would either force a singleton
+or leak. The factory shape is the canonical answer (`database/sql.Register`
+precedent).
+
+### 6. Registry storage = `snapshot.Value[map[K]V]` (ADR 0011)
+
+Two snapshots: `byName snapshot.Value[map[string]Factory]` for lookup, `byScheme
+snapshot.Value[map[string]string]` for URL dispatch. Lock-free `Load` on every
+`FromURL` call; mutex-serialised `Update` on every `Register` (package init only).
+Same shape as the codec registry consolidated under ADR 0011.
+
+### 7. Named-singleton registration — NO `init()`
+
+```go
+var Factory sinkreg.Factory = sinkreg.Register(&consoleFactory{})
+```
+
+Convergent with the codec convention (`internal/core/codec/registry.go` —
+`var Codec = codec.Register(&fooCodec{})`). `KTN-FUNC-NOINIT` stays globally
+enforced; sinks must use the package-level var idiom, not `init()`.
+
+### 8. Multi/fanout is NOT a registered sink — it's a middleware
+
+No URL shape can describe "fan out to N sinks"; pretending otherwise pollutes
+the URL dispatch table. `multi` stays in `…/middleware/multi/`.
+
+### 9. Driver sub-registry (`dbsink`) is the ONLY 2-level nest
+
+`internal/service/logger/sink/db/` is a shell (batching + retry + CB + DSN
+dispatch) over backend-specific drivers (`clickhouse/`, `loki-db/`,
+`victorialogs/`). Mirrors `database/sql.Register`. Anti-coupling: the shell
+MUST NOT import any concrete driver; drivers import the shell.
+
+### 10. Folder layout — flat under `sink/` (revisit at 12 entries)
+
+Alphabetical, one PP slot per entry. Beyond 12 top-level entries we revisit
+`local/cloud/wire/` grouping. The post-v1 plan reaches 11 entries; ample
+headroom.
+
+### 11. PP-block reservation (amends ADR 0006)
+
+| Range | Owner |
+|---|---|
+| 0.3.1.\* — 0.3.21.\* | existing logger sub-tree (no change) |
+| 0.3.22.\* — 0.3.24.\* | codec extensions (existing, ADR 0006 — no change) |
+| **0.3.25.\*** | encoder/null (new — PR-05) |
+| **0.3.26.\*** | middleware/timeout (new — PR-07) |
+| **0.3.27.\*** | middleware/retry (new — PR-07) |
+| **0.3.28.\*** | middleware/circuit_breaker (new — PR-07) |
+| **0.3.29.\*** | middleware/dlq (new — PR-07) |
+| **0.3.30.\*** | middleware/rate_limit (new — PR-07) |
+| **0.3.31.\*** | sink registry (new — PR-03) |
+| **0.3.32.\*** | encoder/codec adapter (new — PR-05) |
+| **0.3.33.\* — 0.3.63.\*** | sink expansion (alphabetical from 33: azure, cloudwatch, datadog, db, db/clickhouse, db/loki, db/victorialogs, gcp, loki, otlp, s3, splunk) |
+| **0.3.64.\* — 0.3.79.\*** | middleware overflow (composevalidate claims 64-65) |
+| **1.1.1.\*** | sinkmw facade (`pkg/v1/logger/sinkmw`) — tombstone code for invalid BackoffPolicy |
+
+Within-package serial layout (recorded as documentary convention):
+`.1` config / construction failure · `.10` ctx cancel · `.20` write failure ·
+`.30` flush failure · `.40` close failure · `.50+` package-specific.
+
+### 12. Public facade: `pkg/v1/logger/sink/` + `pkg/v1/logger/sinkmw/`
+
+```
+pkg/v1/logger/sink/      type aliases (Sink, Record, BatchSink, SyncSink, SinkClass, BaseSink, Factory)
+                         forwarders (Lookup, LookupScheme, FromURL, Available)
+                         blank_imports.go — tier-1 (console, file, syslog) only
+                         codes.go — 0.3.31.* re-exports + 1.1.1.* facade codes
+                         {console,file,syslog,mock}/
+pkg/v1/logger/sinkmw/    re-exports for the 11 middlewares + shared option types
+```
+
+Tier-2 sinks (CloudWatch, S3, GCP, Azure, Datadog, Splunk) land in their own
+`pkg/v1/logger/sink/<vendor>/` modules with separate `go.mod` (ADR 0001
+multi-module precedent) — keeps AWS-SDK weight (~10 MB compiled) opt-in.
+
+### 13. Class-aware middleware behavior — warnings via `sdkwarn`
+
+Each middleware reads `downstream.Class()` at construction time (zero hot-path
+cost) and emits at most one warning per call site:
+
+| Middleware ↓ / Class → | Local | AsyncLocal | RemoteBatched | RemoteStreaming |
+|---|---|---|---|---|
+| async | warn (redundant) | warn (redundant) | recommended | warn (stream has its own buffer) |
+| timeout | 100 ms | 100 ms | 1 s | 1 s |
+| retry | n=1 (rare) | n=1 | n=3 exp+jitter | per-stream |
+| circuit_breaker | warn (n/a) | warn (n/a) | on (5/30s) | on (5/30s) |
+| dlq | warn (rarely useful) | warn | required for at-least-once | opt-in |
+| rate_limit | OFF | OFF | OFF | opt-in |
+| recover | always on | always on | always on | always on |
+
+A `Force()` Option silences the warning per call site (avoids paternalism).
+Warnings go to `internal/kernel/sdkwarn.Emit`, which writes to `os.Stderr` by
+default and routes to an installable hook in tests.
+
+### 14. Composition validation (`composevalidate`) — 10 anti-patterns, 3-tier policy
+
+| # | Pattern | Verdict |
+|---|---|---|
+| 1 | Cyclical Multi (`Multi(a, Multi(a, b))`) | Error (`Validate` returns) |
+| 2 | Async over Async | Warning |
+| 3 | DLQ over DLQ | Warning |
+| 4 | Sample rate ≤ 0 | Panic (always broken) |
+| 5 | Retry over Sample | Warning (retry budget wasted) |
+| 6 | CircuitBreaker over Local sink | Warning (will never trip) |
+| 7 | Inner Timeout > Outer Timeout | Warning (inner ctx dead on arrival) |
+| 8 | `Multi()` with 0 children | Panic (promote current silent no-op) |
+| 9 | Failover primary == secondary | Error (returned from `Failover.New`) |
+| 10 | Route with empty table + no fallback | Error (returned from `Route.New`) |
+
+Each middleware adds a 5-line `Describe() string` + `Children() []Sink`
+implementation; `composevalidate.Validate(root)` walks via pointer identity.
+DoS protection: `MaxDepth = 1024` and `MaxDescribeBytes = 64 KiB` guards
+prevent stack overflow / allocation explosion on adversarial deep chains.
+
+### 15. URL-scheme convention
+
+Schemes drive `FromURL` dispatch. RFC 3986 §3.1 alphabet (`ALPHA *( ALPHA / DIGIT
+/ "+" / "-" / "." )`):
+
+| Sink | Schemes |
+|---|---|
+| console | `stdout`, `stderr` |
+| file | `file://` |
+| syslog | `udp+syslog://`, `tcp+syslog://`, `tls+syslog://` |
+| otlp | `otlp+http://`, `otlp+grpc://` |
+| loki | `loki://` |
+| s3 | `s3://` |
+| cloudwatch | `cloudwatch://group/stream` |
+| dbsink/clickhouse | `clickhouse://` |
+| dbsink/loki-db | `loki+db://` |
+| dbsink/victorialogs | `victorialogs://` |
+
+## Consequences
+
+- **Documentary**: ADR 0006 §"Future allocations" is amended (see PR-01 amendment paragraph). The dotted-quad table in `internal/kernel/errs/registry_external_test.go` gains the 0.3.25-79 block (PR-10) plus Layer-1 1.1.1.* coverage.
+- **Source**: existing public constructors `console.New / NewStderr / NewStdout`, `file.New`, `syslog.New / NewWithConfig` keep byte-for-byte identical signatures. The `*BaseSink` embed is the migration vehicle.
+- **Layering**: `core/logger` MUST NOT import `core/codec` (encoder/codec adapter lives at service layer). Enforced by Bazel visibility — `bazel query 'rdeps(//internal/core/logger/..., //internal/core/codec/...)'` stays empty.
+- **Kernel**: one new primitive (`sdkwarn`) admitted by this ADR (PR-01). Stdlib-only + generic (one-shot warnings + audit hook) — passes the kernel gate.
+- **Tests**: every new package ships `_internal_test.go` + `_external_test.go`; AllocsPerRun gates on the `Emit`-with-hook-installed path (PR-01) + the `sinkreg.Load` path (PR-03).
+- **Hot path**: zero new allocations on `Write` / `Flush` / `Close`. All new behavior is construction-time.
+
+## Breaking changes
+
+None to the public API. The 3 new `Sink` methods are added in PR-04 via the
+`*BaseSink` embed; existing in-tree implementations adopt the embed in the same
+atomic PR without changing their public constructors. Out-of-tree
+implementations (currently none — `pkg/v1/logger/sink/` does not yet exist)
+will need to embed `*BaseSink` after PR-08, but the public surface is created
+in that PR — no "break" exists because no consumer ships yet.
+
+## Alternatives considered
+
+- **A. Mega-PR (all 22+ commits, ~15000 LOC).** Rejected: bisect-hostile,
+  un-reviewable, one failing CI lane stalls everything. The parent plan
+  documents the rejection in §2.
+- **B. Builder DSL at the core layer.** Rejected: community sinks would have
+  to learn it; plain function composition (matching `samber/slog-multi`) is
+  the converged industry idiom (zap, zerolog, phuslu, slog).
+- **C. `sync.Map` for the registry.** Rejected: not generic, dirty-map write
+  path adds machinery for write-mostly workloads the registry never triggers,
+  measured 12.8 ns vs 9.1 ns against the codec snapshot — same loss the ADR
+  0011 chose against.
+- **D. `Reloadable` / `HealthChecker` capability sub-interfaces.** Deferred:
+  `Reloadable` is achievable via atomic-swap with `snapshot.Value` outside
+  the sink; `HealthChecker` waits until the circuit breaker MW lands and
+  needs it concretely.
+- **E. Slog-handler bridge in this PR.** Deferred to its own ADR; the slog
+  interop story has design implications that deserve dedicated review.
+- **F. `slog.Handler` shim for `sdkwarn`.** Rejected: `slog` is a log
+  destination; `sdkwarn` is a construction-time hint channel. Wiring `sdkwarn`
+  to `slog` would couple every test's audit captor to the logger under test
+  — the exact dependency `sdkwarn` exists to break. `slog` callers wanting
+  composition warnings in their structured stream can register a hook that
+  forwards to `slog.Warn` themselves; the primitive stays minimal.
+
+## Deferred
+
+- New transports (otlp, loki, dbsink + drivers, cloudwatch, s3, gcp, azure,
+  datadog, splunk) — each its own PR after PR-10 lands.
+- `console` v2 PIPE_BUF fast path — perf PR with BENCH.md regression evidence.
+- `file` v2 `O_APPEND` + `fdatasync` periodic + rotator goroutine + zstd async
+  — perf PR after BENCH.md baseline is captured.
+- LMAX Disruptor MPSC ring inside `async` middleware — deferred until profiling
+  at >5M msg/s justifies it.
+- TLS path validation for `syslog` (RFC 5425) — separate hardening PR.
+- `KTN-LOGGER-SINK-REGISTERED` ktn-linter rule — separate ktn-linter PR.
+
+## References
+
+- ADR 0001 — multi-module layout — `docs/adr/0001-sdk-go-multimodule-layout.md`
+- ADR 0003 — universal codec package — `docs/adr/0003-sdk-codec-package.md`
+- ADR 0005 — dotted-quad error codes — `docs/adr/0005-sdk-error-codes-dotted-quad.md`
+- ADR 0006 — error code registry extension — `docs/adr/0006-sdk-error-code-registry-extension.md` (amended by this ADR)
+- ADR 0010 — kernel object-recycling primitive — `docs/adr/0010-kernel-recycler-primitive.md`
+- ADR 0011 — kernel copy-on-write snapshot primitive — `docs/adr/0011-kernel-snapshot-primitive.md`
+- Architecture research context — `.claude/contexts/logger-writers-architecture.md`
+- Parent migration plan — `.claude/plans/logger-writer-universal-pattern.md`

--- a/docs/adr/CLAUDE.md
+++ b/docs/adr/CLAUDE.md
@@ -20,6 +20,7 @@ Architecture Decision Records. Each ADR captures one cross-cutting decision (lay
 | `0009-pkg-public-module-resolvability.md` | Published `pkg/<major>` must be `go get`-resolvable + accessible; release tags the whole module chain | Accepted; mechanism implemented |
 | `0010-kernel-recycler-primitive.md` | Generic `recycler.Pool[T]` + `CappedPool[T]` object pools; `buffer`/`scratch` become consumers | Accepted |
 | `0011-kernel-snapshot-primitive.md` | Generic `snapshot.Value[T]` copy-on-write container; codec registry consolidates onto it | Accepted |
+| `0012-sdk-writer-subsystem-architecture.md` | Writer subsystem v2: identity methods on `Sink`, factory registry, 5 new reliability middlewares, composition validator, public facade, PP-block reservation 0.3.25-79 + 1.1.1.* | Accepted (amends ADR 0006) |
 
 ## Conventions
 

--- a/internal/kernel/CLAUDE.md
+++ b/internal/kernel/CLAUDE.md
@@ -15,6 +15,7 @@ The SDK's lowest layer: **stdlib-only AND generic** primitives. A package qualif
 | `buffer/` | `sync.Pool` of `[]byte` — a `recycler.CappedPool[*[]byte]` specialisation | 1200-1299 (reserved) |
 | `clock/` | `Clock` interface (`Now` + `Since`) for testable time | 1300-1399 (reserved) |
 | `ring/` | SPSC lock-free bounded queue (ADR 0006) | 1400-1499 (RING_FULL / RING_EMPTY / RING_CAP_ZERO emit today) |
+| `sdkwarn/` | construction-time warning channel + installable audit hook (ADR 0012) | (none — never returns errors) |
 
 Each package owns a sibling `CLAUDE.md` documenting its surface and contract.
 
@@ -38,6 +39,7 @@ As of the 2026-04-19 audit (extended by ADR 0006 to admit `ring`):
 - `buffer` stays — the `[]byte` pool is generic even though `service/logger` is the heaviest consumer today. Since ADR 0010 it is a thin specialisation over `recycler.CappedPool[*[]byte]` (the generic `Pool[T]` moved to `recycler`).
 - `ring` admitted by ADR 0006 — SPSC bounded queue is a textbook generic primitive. Logger's async middleware is the only consumer today; metrics batchers and codec stream pipelines are obvious future users.
 - `snapshot` admitted by ADR 0011 — `Value[T]` is a textbook generic copy-on-write container (lock-free `Load` + mutex-serialised writers). The codec registry consolidated its three hand-rolled `atomic.Pointer[map]` + CAS loops onto it; routing tables, feature-flag maps, and hot-reloaded config are obvious future consumers.
+- `sdkwarn` admitted by ADR 0012 — one-shot construction-time warning channel (`Emit` + `SetHook`) over `atomic.Pointer[func(string)]`. Stdlib-only AND domain-neutral (any future kernel/core/service package needing a "this composition is dubious but not wrong" channel can use it). Never on the hot path. Tests install a hook to capture warnings without piping `os.Stderr`.
 
 ## Conventions unique to kernel
 
@@ -72,3 +74,4 @@ GOWORK=off go test -race -cover ./...
 - `buffer/` — see `internal/kernel/buffer/CLAUDE.md`
 - `clock/` — see `internal/kernel/clock/CLAUDE.md`
 - `ring/` — see `internal/kernel/ring/CLAUDE.md`
+- `sdkwarn/` — see `internal/kernel/sdkwarn/CLAUDE.md`

--- a/internal/kernel/sdkwarn/BUILD.bazel
+++ b/internal/kernel/sdkwarn/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//internal/kernel:kernel_consumers"])
+
+go_library(
+    name = "sdkwarn",
+    srcs = ["sdkwarn.go"],
+    importpath = "github.com/kitsunium/sdk/internal/kernel/sdkwarn",
+    visibility = ["//internal/kernel:kernel_consumers"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":sdkwarn",
+    visibility = ["//internal/kernel:kernel_consumers"],
+)
+
+go_test(
+    name = "sdkwarn_test",
+    size = "small",
+    srcs = [
+        "sdkwarn_external_test.go",
+        "sdkwarn_integration_test.go",
+        "sdkwarn_internal_test.go",
+    ],
+    embed = [":sdkwarn"],
+)
+
+filegroup(
+    name = "audit_srcs",
+    srcs = glob(["*.go"]),
+    visibility = ["//:__pkg__"],
+)

--- a/internal/kernel/sdkwarn/CLAUDE.md
+++ b/internal/kernel/sdkwarn/CLAUDE.md
@@ -1,0 +1,63 @@
+# internal/kernel/sdkwarn/
+
+## Purpose
+
+The SDK's construction-time warning primitive. Stdlib-only, domain-neutral.
+`Emit(format, args...)` formats a message and routes it to the installed
+audit hook, or to `os.Stderr` when no hook is set. `SetHook(fn)` installs an
+audit captor used by tests to assert that sinks/middlewares surfaced the
+right composition warnings at `New` time — without piping `os.Stderr`.
+
+`sdkwarn` is the channel a middleware uses when it wants to say
+"this composition is dubious but not wrong" — e.g. `async` wrapping a
+`LocalClass` sink, `CircuitBreaker` wrapping a sink that can't be down,
+`Retry` wrapping a `Sample` whose drop is permanent.
+
+## Contents
+
+| Symbol | Surface | Use case |
+|---|---|---|
+| `HookFn` | `type HookFn = func(string)` | shared name for the hook signature |
+| `Emit` | `func Emit(format string, args ...any)` | one-shot construction-time warning |
+| `SetHook` | `func SetHook(fn HookFn) (previous HookFn)` | install / restore audit captor |
+
+## Conventions
+
+- **Construction time only.** `Emit` MUST NOT be called on the hot path
+  (`Write` / `Flush` / `Close`). There is no rate limit, no buffering, no
+  batching — a per-record caller will saturate `stderr` and starve the GC.
+  The convention is "once per anomaly per process".
+- **Hot-path budget is zero.** `Emit` is never invoked on the `Write` path.
+  Sinks/middlewares evaluate `downstream.Class()` at `New` time and call
+  `Emit` once; the resulting decoration sink writes Records without re-checking.
+- **Hook deadlock contract.** The hook runs in the caller goroutine. A
+  blocking hook deadlocks the caller. Hooks MUST return promptly. `sdkwarn`
+  does NOT `recover` from a panicking hook — a panic propagates as documented
+  Go semantics.
+- **Stderr-path allocation budget is NOT gated.** When no hook is installed,
+  `Emit` allocates 3+ times (Sprintf result + concat + stderr buffering). The
+  hook-installed path allocates only the Sprintf result (1 alloc/op). Tests
+  gate the hook-installed path at `<= 1.0 allocs/op` (`AllocsPerRun(1000)`);
+  the stderr path is exercised but not measured.
+- **No `init()`.** The zero value of `atomic.Pointer[HookFn]` is "no hook"
+  — exactly the documented default. `KTN-FUNC-NOINIT` enforced globally.
+- **Concurrent-safe.** `atomic.Pointer.Load` on `Emit`, `atomic.Pointer.Swap`
+  on `SetHook`. No mutex. Race tests verified under `bazel test --config=race`.
+
+## Do NOT
+
+- Call `Emit` on the hot path. The warning channel has no rate limit.
+- Install a blocking hook in production. Hooks are a test-time captor;
+  production hooks (for log forwarding) should be non-blocking channel sends.
+- Use `sdkwarn` for error reporting — errors go through `errs.Define` /
+  `errs.Wrap`. `Emit` carries a string, not a typed `*errs.Error`.
+- Replace the package-level slot in tests — call `SetHook` instead. The slot
+  is `atomic.Pointer[HookFn]` and `SetHook` is the only sanctioned mutator.
+
+## Verification
+
+```sh
+bazel test --config=race //internal/kernel/sdkwarn:sdkwarn_test
+# allocation gate runs without race instrumentation:
+bazel test //internal/kernel/sdkwarn:sdkwarn_test
+```

--- a/internal/kernel/sdkwarn/sdkwarn.go
+++ b/internal/kernel/sdkwarn/sdkwarn.go
@@ -1,0 +1,123 @@
+// Package sdkwarn emits one-shot construction-time warnings to stderr with an
+// installable audit hook for tests. Stdlib-only (fmt + log + os + sync/atomic),
+// zero domain vocabulary. Callers use Emit to surface "this composition is
+// dubious but not wrong" — sinks/middlewares spot redundant decoration
+// (CircuitBreaker over a Local sink, async-over-async, etc.) at construction
+// time; tests install SetHook to capture the warning string without piping
+// os.Stderr.
+//
+// sdkwarn is construction-time ONLY. It MUST NOT appear on the hot path of
+// Write/Flush/Close — there is no rate limit, no buffering, no batching. A
+// caller invoking Emit per record will saturate stderr and starve the GC.
+//
+// # Hook deadlock contract
+//
+// The installed hook runs in the caller goroutine of Emit. A hook that blocks
+// indefinitely (waits on a channel, takes a lock the caller holds) will
+// deadlock the construction path. Hook implementations MUST return promptly;
+// tests typically use a simple append-to-slice closure or a non-blocking
+// channel send. sdkwarn does NOT recover() from a panicking hook — a panic
+// propagates to the caller as documented Go semantics. Test hooks that
+// intentionally panic for fault-injection MUST be paired with a recover() in
+// the test goroutine.
+//
+// # Stderr-path allocation budget
+//
+// When no hook is installed, Emit writes to os.Stderr via the stdlib log
+// package (log.Logger.Println, which discards write errors internally — same
+// policy as log.Default()). This path allocates 2+ times (fmt.Sprintf result,
+// log.Logger.Output internal buffering). The hook-installed path allocates
+// only the fmt.Sprintf result (1 alloc/op). Tests gate the hook-installed
+// path at <= 1.0 allocs/op (testing.AllocsPerRun); the stderr path is NOT
+// gated.
+//
+// # Thread safety
+//
+// Emit and SetHook are concurrent-safe via atomic.Pointer. SetHook is process-
+// global; tests using t.Parallel that mutate the hook MUST use a captor
+// pattern (one hook captures all parallel events) rather than per-test
+// install/restore.
+package sdkwarn
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync/atomic"
+)
+
+// HookFn is the audit-hook signature. Aliased so consumers and tests share the
+// type name; func(string) anywhere in the SDK refers to the same shape.
+type HookFn = func(string)
+
+// Package-private state. Grouped per KTN-VAR-GROUP — a single var() block
+// captures every mutable shared slot the primitive owns.
+var (
+	// hookSlot stores the currently installed *HookFn — nil means "no hook;
+	// route to stderr". Read on every Emit (no lock), written on SetHook
+	// (atomic). The double-pointer indirection is unavoidable: atomic.Pointer
+	// needs a typed pointee, and a function value is not addressable.
+	hookSlot atomic.Pointer[HookFn]
+
+	// stderrLogger is the default writer used when no hook is installed. We
+	// use log.Logger so the stderr-write error (rare: closed stderr, /dev/null
+	// swap) is handled by the stdlib log package — log.Logger.Println discards
+	// the underlying io.Writer.Write error internally, matching log.Default()
+	// behaviour.
+	stderrLogger = log.New(os.Stderr, "", 0)
+)
+
+// Emit formats msg via fmt.Sprintf and routes the resulting string to the
+// installed hook, or — when no hook is installed — to os.Stderr with the
+// "sdk: " prefix via the stdlib log package. Emit is concurrent-safe. It is
+// NOT designed for the hot path: callers MUST limit invocations to
+// construction time (sink/middleware New) or to "once per anomaly per
+// process" patterns. There is no rate limit.
+func Emit(format string, args ...any) {
+	//: build the formatted message once; both the hook path and stderr path
+	//: receive the same string so callers see a stable observation.
+	msg := fmt.Sprintf(format, args...)
+	//: hook-installed path: forward the formatted message to the audit captor.
+	if hookPtr := hookSlot.Load(); hookPtr != nil {
+		//: invoke the hook in the caller's goroutine — see the deadlock contract
+		//: in the package doc.
+		(*hookPtr)(msg)
+		//: short-circuit so the stderr fallback below does not also fire.
+		return
+	}
+	//: default path: stdlib log handles the io.Writer.Write error internally
+	//: (same policy as log.Default()), so this call returns no error to
+	//: propagate or discard at our level.
+	stderrLogger.Println("sdk:", msg)
+}
+
+// SetHook installs fn as the warning sink. Passing nil restores the default
+// (stderr). The previous hook (or nil) is returned so tests can stack
+// install/restore without leaking state across t.Parallel boundaries.
+//
+// SetHook is process-global. Tests that mutate the hook MUST defer-restore the
+// returned previous value; running such tests with t.Parallel is unsafe
+// because concurrent SetHook calls race for the slot. This is documented
+// intentionally — a per-goroutine hook would require context plumbing on a
+// non-hot-path primitive, which is over-engineering.
+func SetHook(fn HookFn) HookFn {
+	//: encode "no hook" as a nil *HookFn so Emit's nil-check sees the same
+	//: shape as an unwritten zero-value slot.
+	var newPtr *HookFn
+	//: non-nil installs need a heap-allocated copy so the atomic pointer can
+	//: address it across concurrent reads.
+	if fn != nil {
+		//: pin the function value to a local before taking its address.
+		captured := fn
+		newPtr = &captured
+	}
+	//: atomic swap publishes the new slot and returns the previous *HookFn.
+	prev := hookSlot.Swap(newPtr)
+	//: empty-slot path: nothing to hand back.
+	if prev == nil {
+		//: explicit nil signals "no previous hook" to the caller's restore stack.
+		return nil
+	}
+	//: hand back the previous HookFn value so the caller can stack-restore it.
+	return *prev
+}

--- a/internal/kernel/sdkwarn/sdkwarn_external_test.go
+++ b/internal/kernel/sdkwarn/sdkwarn_external_test.go
@@ -1,0 +1,222 @@
+package sdkwarn_test
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/sdkwarn"
+)
+
+// installCaptor installs a captor hook that buffers every message and
+// returns a snapshot accessor + a restore func. Callers Cleanup the restore
+// to keep the process-global hookSlot pristine.
+func installCaptor(t *testing.T) (snap func() []string, restore func()) {
+	t.Helper()
+	var mu sync.Mutex
+	var buf []string
+	prev := sdkwarn.SetHook(func(s string) {
+		mu.Lock()
+		buf = append(buf, s)
+		mu.Unlock()
+	})
+	snap = func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(buf)
+	}
+	restore = func() { sdkwarn.SetHook(prev) }
+	return snap, restore
+}
+
+// TestEmit verifies that an installed hook receives the formatted message
+// verbatim — the core contract every middleware relies on at construction
+// time. Covers literal, single arg, multi arg, and empty format.
+func TestEmit(t *testing.T) {
+	type tc struct {
+		name   string
+		format string
+		args   []any
+		want   string
+	}
+	tests := []tc{
+		{"plain literal", "warning", nil, "warning"},
+		{"single arg", "warn %d", []any{42}, "warn 42"},
+		{"multi arg", "warn %d %s", []any{1, "two"}, "warn 1 two"},
+		{"empty format", "", nil, ""},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; each row formats its own message and asserts the hook saw the
+	//: exact expected string. Tests share the process-global hookSlot and
+	//: cannot run in parallel — they call installCaptor sequentially.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		snap, restore := installCaptor(t)
+		t.Cleanup(restore)
+		sdkwarn.Emit(tc.format, tc.args...)
+		got := snap()
+		//: hook must have been invoked exactly once for the single Emit call.
+		if len(got) != 1 {
+			t.Fatalf("hook invocations = %d, want 1", len(got))
+		}
+		//: captured message must equal the expected Sprintf result.
+		if got[0] != tc.want {
+			t.Fatalf("hook saw %q, want %q", got[0], tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestSetHook verifies install/uninstall stack semantics callers depend on
+// for nested test setup. The single test exercises every state transition:
+// clear → install A → install B → uninstall → uninstall again.
+func TestSetHook(t *testing.T) {
+	type tc struct {
+		name string
+	}
+	tests := []tc{
+		{"install A install B uninstall returns B then A"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the test mutates the process-global hookSlot and runs
+	//: sequentially with respect to other slot-mutating tests.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		hookA := func(string) {}
+		hookB := func(string) {}
+		//: clear the slot to a known state; previous may be nil or stale.
+		saved := sdkwarn.SetHook(nil)
+		t.Cleanup(func() { sdkwarn.SetHook(saved) })
+		//: install A from the cleared state; previous must be nil.
+		if prev := sdkwarn.SetHook(hookA); prev != nil {
+			t.Fatalf("SetHook(A) prev = %v, want nil", prev)
+		}
+		//: install B; previous must be the hookA captor — we only check
+		//: non-nil because function-pointer equality on closures isn't
+		//: meaningful, but the captor's identity is the contract.
+		if prev := sdkwarn.SetHook(hookB); prev == nil {
+			t.Fatalf("SetHook(B) prev = nil, want non-nil")
+		}
+		//: uninstall (nil); previous must be the hookB captor.
+		if prev := sdkwarn.SetHook(nil); prev == nil {
+			t.Fatalf("SetHook(nil) prev = nil, want non-nil")
+		}
+		//: uninstall a second time; previous must be nil (no hook to restore).
+		if prev := sdkwarn.SetHook(nil); prev != nil {
+			t.Fatalf("SetHook(nil) x2 prev = %v, want nil", prev)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestEmitConcurrentSafeUnderRace fans goroutines × Emit calls through a
+// counting hook. The -race-built test verifies no race on the atomic-pointer
+// slot.
+func TestEmitConcurrentSafeUnderRace(t *testing.T) {
+	const goroutines int = 32
+	const perGoroutine int = 256
+	type tc struct {
+		name         string
+		goroutines   int
+		perGoroutine int
+	}
+	tests := []tc{
+		{"32 goroutines x 256 Emit each", goroutines, perGoroutine},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the captor counts every hook invocation and the test asserts
+	//: the total matches the expected fan-out.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		var count atomic.Int64
+		prev := sdkwarn.SetHook(func(string) { count.Add(1) })
+		t.Cleanup(func() { sdkwarn.SetHook(prev) })
+		var wg sync.WaitGroup
+		//: spawn N goroutines that each Emit perGoroutine messages.
+		for range tc.goroutines {
+			wg.Go(func() {
+				for range tc.perGoroutine {
+					sdkwarn.Emit("race")
+				}
+			})
+		}
+		wg.Wait()
+		//: every Emit must have produced exactly one hook invocation.
+		want := int64(tc.goroutines * tc.perGoroutine)
+		if got := count.Load(); got != want {
+			t.Fatalf("hook invocations = %d, want %d", got, want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestSetHookEmitRaceUnderRace specifically targets the install-during-emit
+// race lane: an installer goroutine flips hooks while an emitter calls Emit.
+// -race must report clean.
+func TestSetHookEmitRaceUnderRace(t *testing.T) {
+	type tc struct {
+		name       string
+		iterations int
+	}
+	tests := []tc{
+		{"10000 emits with concurrent installer", 10000},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the test verifies the atomic.Pointer publish/load contract via
+	//: a count assertion: every Emit must invoke whatever hook was current.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		var emitCount atomic.Int64
+		saved := sdkwarn.SetHook(func(string) { emitCount.Add(1) })
+		t.Cleanup(func() { sdkwarn.SetHook(saved) })
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		//: installer goroutine flips the hook to identical no-op captors so
+		//: even when its SetHook wins the race, Emit still produces a count.
+		wg.Go(func() {
+			for {
+				//: stop signal: emitter goroutine closes the channel.
+				select {
+				case <-stop:
+					return
+				default:
+					//: install a fresh captor that also bumps the counter so
+					//: the count assertion stays meaningful regardless of which
+					//: hook a given Emit observed.
+					sdkwarn.SetHook(func(string) { emitCount.Add(1) })
+				}
+			}
+		})
+		//: emitter goroutine drives the Emit count.
+		wg.Go(func() {
+			for range tc.iterations {
+				sdkwarn.Emit("race")
+			}
+			close(stop)
+		})
+		wg.Wait()
+		//: every Emit produced at least one counter bump (the installer races
+		//: do not lose Emits because the hookSlot publish is atomic).
+		if got := emitCount.Load(); got < int64(tc.iterations) {
+			t.Fatalf("emit count = %d, want >= %d", got, tc.iterations)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/kernel/sdkwarn/sdkwarn_integration_test.go
+++ b/internal/kernel/sdkwarn/sdkwarn_integration_test.go
@@ -1,0 +1,55 @@
+//go:build !race
+
+package sdkwarn_test
+
+import (
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/sdkwarn"
+)
+
+// allocSink defeats dead-code elimination in the AllocsPerRun probe.
+var allocSink string
+
+// TestAllocBudget pins the documented hook-dispatch allocation budget. Emit
+// with a hook installed allocates exactly 1 per op (the fmt.Sprintf result
+// string). The gate catches accidental extra allocations from future
+// refactors (incidental string concat, slice copy, boxing).
+//
+// The gate is <= 1.0, not == 0: building the formatted string is the caller's
+// intent and must allocate. The gate's value is rejecting regressions that
+// introduce a *second* allocation (e.g. an internal []byte slab built
+// incidentally by a future Emit body).
+func TestAllocBudget(t *testing.T) {
+	type tc struct {
+		name   string
+		format string
+		args   []any
+		want   float64
+	}
+	tests := []tc{
+		{"single format arg", "budget %d", []any{42}, 1.0},
+		{"no args", "plain warning", nil, 1.0},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; AllocsPerRun measures the hook-installed path which must
+	//: allocate only the fmt.Sprintf result.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		prev := sdkwarn.SetHook(func(s string) { allocSink = s })
+		t.Cleanup(func() { sdkwarn.SetHook(prev) })
+		fn := func() { sdkwarn.Emit(tc.format, tc.args...) }
+		//: warm-up call to amortise per-process init costs of the underlying
+		//: log.Logger; the gate measures steady-state.
+		fn()
+		got := testing.AllocsPerRun(1000, fn)
+		if got > tc.want {
+			t.Errorf("Emit allocs = %.1f, want <= %.1f", got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/kernel/sdkwarn/sdkwarn_internal_test.go
+++ b/internal/kernel/sdkwarn/sdkwarn_internal_test.go
@@ -1,0 +1,79 @@
+package sdkwarn
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// TestHookSlotZeroValue pins the documented contract that the hookSlot is nil
+// before any SetHook call — Emit's nil-check branch depends on it.
+func TestHookSlotZeroValue(t *testing.T) {
+	t.Parallel()
+	type tc struct{ name string }
+	tests := []tc{
+		{"zero-value hookSlot loads nil"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the test verifies a local Pointer mirrors the documented
+	//: zero-value behaviour of the package-global hookSlot.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: assert via a local clone of the same type — the package-global slot
+		//: is process-state and unsafe to mutate from a parallel test.
+		var localSlot atomic.Pointer[HookFn]
+		//: a zero-value atomic.Pointer must Load nil; this is the same shape
+		//: the production Emit relies on.
+		if got := localSlot.Load(); got != nil {
+			t.Fatalf("zero-value Pointer Load() = %v, want nil", got)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestSetHookSwapInternalContract verifies the unexported Swap semantics that
+// SetHook delegates to: the atomic.Pointer correctly hands back the previous
+// pointee.
+func TestSetHookSwapInternalContract(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{
+		{"local atomic.Pointer Swap returns prior pointee"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the test exercises the same atomic.Pointer[HookFn] shape SetHook
+	//: uses, against a local instance to stay parallel-safe.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		hookA := func(string) {}
+		hookB := func(string) {}
+		var localSlot atomic.Pointer[HookFn]
+		//: install A; the previous pointer must be nil because the slot is
+		//: zero-valued.
+		if prev := localSlot.Swap(&hookA); prev != nil {
+			t.Fatalf("Swap(A) prev = %v, want nil", prev)
+		}
+		//: install B; the previous pointer must be &hookA.
+		prev := localSlot.Swap(&hookB)
+		if prev != &hookA {
+			t.Fatalf("Swap(B) prev = %p, want %p", prev, &hookA)
+		}
+		//: uninstall (nil); the previous pointer must be &hookB.
+		final := localSlot.Swap(nil)
+		if final != &hookB {
+			t.Fatalf("Swap(nil) prev = %p, want %p", final, &hookB)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Foundation PR (1 of 10) for the **Writer Subsystem v2** universal-pattern alignment. Adds the ADR documenting the migration's 15 architectural decisions plus a tiny stdlib-only kernel primitive (\`sdkwarn\`) used by sinks and middlewares at construction time to surface dubious-but-not-wrong compositions.

## Scope

| Change | Notes |
|---|---|
| NEW \`docs/adr/0012-sdk-writer-subsystem-architecture.md\` | 15 numbered decisions + Alternatives + Deferred + amends ADR 0006 |
| MODIFY \`docs/adr/0006-…\` | 3-line amendment paragraph pointing forward to ADR 0012 §11 |
| NEW \`internal/kernel/sdkwarn/\` | \`Emit\` + \`SetHook\` over \`atomic.Pointer[HookFn]\` |
| MODIFY \`internal/kernel/CLAUDE.md\` | Contents + Subtree + Audit subsections |
| MODIFY \`docs/CLAUDE.md\` + \`docs/adr/CLAUDE.md\` | ADR index row |
| MODIFY root \`BUILD.bazel\` | \`audit_sources\` filegroup gains \`//internal/kernel/sdkwarn:audit_srcs\` |

12 files, 923 LOC added.

## Design

\`sdkwarn\` is admitted to \`internal/kernel/\` per ADR 0012 because it passes the kernel gate:
- **stdlib-only**: \`fmt\` + \`log\` + \`os\` + \`sync/atomic\`
- **domain-neutral**: any future SDK domain (codec, http, metrics) can reuse the warning channel

The hook-installed path allocates exactly 1/op (the \`fmt.Sprintf\` result); the stderr fallback uses the stdlib \`log.Logger\` which discards write errors internally.

## Constraints honoured

- No \`init()\` (KTN-FUNC-NOINIT)
- No \`fmt.Errorf\` / \`errors.New\` (kernel package has no error surface — returns nothing)
- Kernel gate (stdlib-only + generic)
- Existing tests in \`internal/kernel/...\` all pass (38/38 green)
- \`make lint\` green (ktn-linter all phases)
- No new external Go module deps

## Test plan

- [x] \`bazel build //...\` green
- [x] \`bazel test --config=race //...\` 38/38 pass
- [x] \`bazel test //internal/kernel/sdkwarn:sdkwarn_test\` (alloc gate, \`!race\`) — \`<= 1.0 allocs/op\`
- [x] \`make lint\` green
- [x] Concurrent Emit + SetHook race lane covered explicitly

## Dependencies

- **Blocks** PR-02 (core sink types), PR-06 (composevalidate uses sdkwarn for class-aware warnings), PR-07 (5 new middlewares use sdkwarn).
- **No regression risk** to current production code — sdkwarn has zero consumers at merge time.

## Plan files

- Master: \`.claude/plans/logger-writer-universal-pattern.md\`
- This PR: \`.claude/plans/pr-01-adr-sdkwarn.md\` + \`pr-01-adr-sdkwarn-review.md\`
- Synthesis: \`.claude/plans/SYNTHESIS-resolutions.md\` §3 PR-01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SDK construction-time warning system with hook-based observability for composition warnings.

* **Documentation**
  * Added ADR 0012 documenting SDK writer subsystem architecture v2, including updated Sink interface patterns and composition validation.
  * Updated architecture documentation index and references.

* **Tests**
  * Added comprehensive test suite covering warning system behavior, concurrency safety, and allocation performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->