### PR TITLE
feat(logger): add composevalidate + Describer on 6 middlewares (PR 6/10)

### DIFF
--- a/internal/core/codec/registry_external_test.go
+++ b/internal/core/codec/registry_external_test.go
@@ -204,11 +204,12 @@ func TestRegistryHitPaths(t *testing.T) {
 		ext:  []string{".cov"},
 	}
 	codec.Register(mc)
-	tests := []struct {
+	type tc struct {
 		name   string
 		lookup func() (codec.Codec, bool)
 		wantOK bool
-	}{
+	}
+	tests := []tc{
 		{"Lookup resolves the registered Format", func() (codec.Codec, bool) {
 			return codec.Lookup(codec.Format("cov-hit"))
 		}, true},
@@ -236,13 +237,16 @@ func TestRegistryHitPaths(t *testing.T) {
 			return codec.LookupExt(".absent")
 		}, false},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; sequential — shares the process-wide registry seeded above.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		if _, ok := tc.lookup(); ok != tc.wantOK {
+			t.Errorf("%s: ok=%v want %v", tc.name, ok, tc.wantOK)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			//: sequential — shares the process-wide registry seeded above.
-			if _, ok := tc.lookup(); ok != tc.wantOK {
-				t.Errorf("%s: ok=%v want %v", tc.name, ok, tc.wantOK)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { runCase(t, tc) })
 	}
 	//: Available must now surface the freshly registered Format.
 	found := false
@@ -265,10 +269,11 @@ func TestRegistryHitPaths(t *testing.T) {
 func TestRegistryEmptyMisses(t *testing.T) {
 	//: drive all three snapshots back to nil to hit the absence branches.
 	codec.ResetForTest()
-	tests := []struct {
+	type tc struct {
 		name   string
 		lookup func() (codec.Codec, bool)
-	}{
+	}
+	tests := []tc{
 		{"Lookup misses on empty registry", func() (codec.Codec, bool) {
 			return codec.Lookup(codec.Format("cov-hit"))
 		}},
@@ -279,13 +284,16 @@ func TestRegistryEmptyMisses(t *testing.T) {
 			return codec.LookupExt(".cov")
 		}},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; every reader must report a miss against the nil snapshot.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		if _, ok := tc.lookup(); ok {
+			t.Errorf("%s: ok=true, want false on empty registry", tc.name)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			//: every reader must report a miss against the nil snapshot.
-			if _, ok := tc.lookup(); ok {
-				t.Errorf("%s: ok=true, want false on empty registry", tc.name)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { runCase(t, tc) })
 	}
 	//: Available must return the documented nil slice when nothing is registered.
 	if got := codec.Available(); got != nil {

--- a/internal/core/codec/scratch/scratch_external_test.go
+++ b/internal/core/codec/scratch/scratch_external_test.go
@@ -85,26 +85,30 @@ func TestReleaseBuffer(t *testing.T) {
 // rather than a panic.
 func TestReleaseNilIsNoOp(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name    string
 		release func()
-	}{
+	}
+	tests := []tc{
 		{"ReleaseBuffer(nil)", func() { scratch.ReleaseBuffer(nil) }},
 		{"ReleaseReader(nil)", func() { scratch.ReleaseReader(nil) }},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; a nil release must complete cleanly, so any panic here fails.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: a recovered panic is the failure signal — a nil release must
+		//: complete cleanly, so any panic here fails the assertion.
+		defer func() {
+			//: recover surfaces a panic as an explicit test failure.
+			if rec := recover(); rec != nil {
+				t.Errorf("%s panicked: %v", tc.name, rec)
+			}
+		}()
+		tc.release()
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: a recovered panic is the failure signal — a nil release must
-			//: complete cleanly, so any panic here fails the assertion.
-			defer func() {
-				//: recover surfaces a panic as an explicit test failure.
-				if rec := recover(); rec != nil {
-					t.Errorf("%s panicked: %v", tc.name, rec)
-				}
-			}()
-			tc.release()
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 

--- a/internal/core/logger/BUILD.bazel
+++ b/internal/core/logger/BUILD.bazel
@@ -6,12 +6,15 @@ go_library(
     name = "logger",
     srcs = [
         "attr.go",
+        "base_sink.go",
         "encoder.go",
         "handler.go",
         "kind.go",
         "logger.go",
         "record.go",
         "sink.go",
+        "sink_caps.go",
+        "sink_class.go",
         "value.go",
     ],
     importpath = "github.com/kitsunium/sdk/internal/core/logger",
@@ -34,8 +37,12 @@ filegroup(
 go_test(
     name = "logger_test",
     srcs = [
+        "base_sink_external_test.go",
+        "base_sink_internal_test.go",
         "kind_external_test.go",
         "kind_internal_test.go",
+        "sink_caps_external_test.go",
+        "sink_class_external_test.go",
         "value_external_test.go",
         "value_internal_test.go",
     ],

--- a/internal/core/logger/base_sink.go
+++ b/internal/core/logger/base_sink.go
@@ -1,0 +1,101 @@
+// Package logger — BaseSink embeddable identity holder. Concrete sinks
+// embed *BaseSink to inherit the upcoming Name/Class/Schemes accessors
+// without per-impl boilerplate; the struct is constructed once and never
+// mutated.
+package logger
+
+import "slices"
+
+// minDuplicateLen is the smallest slice length that can contain a duplicate.
+// A slice with 0 or 1 element trivially cannot duplicate.
+const minDuplicateLen int = 2
+
+// BaseSink carries the immutable identity triple (name, class, schemes) that
+// every Sink reports. Concrete sinks embed *BaseSink so they automatically
+// satisfy the upcoming sink identity methods (Name / Class / Schemes — added
+// to the Sink interface in PR-04) without per-impl boilerplate.
+//
+// Pointer-embed only (1 word vs 5-word value embed). The struct is
+// constructed once at sink construction and never copied.
+type BaseSink struct {
+	name    string
+	class   SinkClass
+	schemes []string
+}
+
+// NewBaseSink builds a frozen identity triple. The schemes slice is cloned
+// so a caller-side mutation never bleeds into Schemes(). The constructor
+// panics on three documented programmer errors:
+//
+//   - empty name (the registry's primary key cannot be empty)
+//   - SinkClass strictly greater than maxKnownSinkClass
+//     (a stale binary using a class value the current build does not know)
+//   - duplicate scheme strings (would create an ambiguous registry index)
+//
+// These are construction-time panics, never returned errors — a sink that
+// misdeclares its identity is a programmer mistake the test suite must
+// catch, not a runtime condition the caller should handle.
+func NewBaseSink(name string, class SinkClass, schemes []string) *BaseSink {
+	//: empty name fails closed — the registry's primary key cannot be empty.
+	if name == "" {
+		panic("logger.NewBaseSink: empty name")
+	}
+	//: out-of-range class fails closed — UnknownClass is allowed (it is the
+	//: zero value documenting "missing metadata"), but any value above the
+	//: top-defined class is an error.
+	if class > maxKnownSinkClass {
+		panic("logger.NewBaseSink: SinkClass out of range")
+	}
+	//: duplicate schemes would split the registry's scheme→Name index so we
+	//: refuse construction with a deterministic panic message.
+	if hasDuplicate(schemes) {
+		panic("logger.NewBaseSink: duplicate scheme string")
+	}
+	//: defensive clone so a caller-side mutation never bleeds into Schemes().
+	return &BaseSink{name: name, class: class, schemes: slices.Clone(schemes)}
+}
+
+// Name returns the identity string the sink registers under.
+func (b *BaseSink) Name() string {
+	//: package-level identifier — frozen at construction.
+	return b.name
+}
+
+// Class returns the operational profile the sink declared.
+func (b *BaseSink) Class() SinkClass {
+	//: immutable triple member — no clone needed for a uint8.
+	return b.class
+}
+
+// Schemes returns the URL schemes this sink handles. The returned slice is
+// a defensive clone — caller-side mutation does not affect the sink's
+// identity.
+func (b *BaseSink) Schemes() []string {
+	//: clone every call so the registry slice stays pristine. The cost is a
+	//: small allocation per call; Schemes is construction-time and accepts it.
+	return slices.Clone(b.schemes)
+}
+
+// hasDuplicate reports whether s contains the same string twice. Linear scan
+// with a map probe — schemes lists are tiny (usually 1-3 entries), so the
+// allocation cost of the map is paid once at construction.
+func hasDuplicate(s []string) bool {
+	//: empty / single-element slices cannot contain duplicates.
+	if len(s) < minDuplicateLen {
+		//: trivial false: no second slot to compare against.
+		return false
+	}
+	//: build a set keyed by scheme to detect a second occurrence.
+	seen := make(map[string]struct{}, len(s))
+	//: iterate once; the first repeated key terminates the scan.
+	for _, v := range s {
+		//: probe + insert in a single pass.
+		if _, ok := seen[v]; ok {
+			//: second occurrence: report duplicate immediately.
+			return true
+		}
+		seen[v] = struct{}{}
+	}
+	//: no duplicates observed across the linear scan.
+	return false
+}

--- a/internal/core/logger/base_sink_external_test.go
+++ b/internal/core/logger/base_sink_external_test.go
@@ -1,0 +1,221 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/core/logger"
+)
+
+// TestNewBaseSink verifies the constructor accepts valid identity triples
+// and panics on the three documented programmer errors.
+func TestNewBaseSink(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name      string
+		sinkName  string
+		class     logger.SinkClass
+		schemes   []string
+		wantPanic bool
+	}
+	tests := []tc{
+		{"valid local sink", "console", logger.LocalClass, []string{"stderr", "stdout"}, false},
+		{"valid unknown class is allowed at construction", "x", logger.UnknownClass, nil, false},
+		{"empty schemes is allowed", "x", logger.LocalClass, nil, false},
+		{"empty name panics", "", logger.LocalClass, []string{"stdout"}, true},
+		{"out-of-range class panics", "x", logger.SinkClass(99), nil, true},
+		{"duplicate scheme panics", "x", logger.LocalClass, []string{"stdout", "stdout"}, true},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the constructor must build a frozen identity OR panic with a
+	//: deterministic programmer-error message.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: recover into a sentinel so the test can assert the panic shape
+		//: without crashing the test process.
+		defer func() {
+			r := recover()
+			//: panic-expected row: recover must observe a non-nil value.
+			if tc.wantPanic && r == nil {
+				t.Fatalf("NewBaseSink(%q, %v, %v) expected panic; got none", tc.sinkName, tc.class, tc.schemes)
+			}
+			//: non-panic row: a recover value here signals an unexpected crash.
+			if !tc.wantPanic && r != nil {
+				t.Fatalf("NewBaseSink(%q, %v, %v) panicked: %v", tc.sinkName, tc.class, tc.schemes, r)
+			}
+		}()
+		b := logger.NewBaseSink(tc.sinkName, tc.class, tc.schemes)
+		//: panic-expected row should never reach here — the recover above
+		//: handles the assertion.
+		if tc.wantPanic {
+			return
+		}
+		//: identity accessors must round-trip the constructor arguments.
+		if got := b.Name(); got != tc.sinkName {
+			t.Errorf("Name() = %q, want %q", got, tc.sinkName)
+		}
+		if got := b.Class(); got != tc.class {
+			t.Errorf("Class() = %v, want %v", got, tc.class)
+		}
+		gotSchemes := b.Schemes()
+		if len(gotSchemes) != len(tc.schemes) {
+			t.Errorf("Schemes() length = %d, want %d", len(gotSchemes), len(tc.schemes))
+		}
+		for i := range gotSchemes {
+			if gotSchemes[i] != tc.schemes[i] {
+				t.Errorf("Schemes()[%d] = %q, want %q", i, gotSchemes[i], tc.schemes[i])
+			}
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestBaseSink_Name covers BaseSink.Name() — the identity accessor
+// returns the constructor argument verbatim.
+func TestBaseSink_Name(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		want string
+	}
+	tests := []tc{
+		{"console name", "console"},
+		{"long kebab", "my-sink-v2"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; Name() must hand back the constructor argument.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		b := logger.NewBaseSink(tc.want, logger.LocalClass, nil)
+		//: the identity getter must equal the constructor name.
+		if got := b.Name(); got != tc.want {
+			t.Fatalf("Name() = %q, want %q", got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestBaseSink_Class covers BaseSink.Class() — the accessor returns the
+// SinkClass declared at construction.
+func TestBaseSink_Class(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		want logger.SinkClass
+	}
+	tests := []tc{
+		{"local", logger.LocalClass},
+		{"remote-batched", logger.RemoteBatchedClass},
+		{"unknown is preserved", logger.UnknownClass},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; Class() must hand back the constructor value.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		b := logger.NewBaseSink("x", tc.want, nil)
+		//: the identity getter must equal the constructor class.
+		if got := b.Class(); got != tc.want {
+			t.Fatalf("Class() = %v, want %v", got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestBaseSink_Schemes covers BaseSink.Schemes() — the accessor returns a
+// defensive clone of the constructor argument; caller-side mutation never
+// bleeds.
+func TestBaseSink_Schemes(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   []string
+	}
+	tests := []tc{
+		{"empty", nil},
+		{"single", []string{"stdout"}},
+		{"multi", []string{"stderr", "stdout"}},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; Schemes() must defensively clone on every call.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		b := logger.NewBaseSink("x", logger.LocalClass, tc.in)
+		got := b.Schemes()
+		//: lengths must match.
+		if len(got) != len(tc.in) {
+			t.Fatalf("Schemes() len = %d, want %d", len(got), len(tc.in))
+		}
+		//: element-wise equality with the constructor argument.
+		for i := range got {
+			if got[i] != tc.in[i] {
+				t.Errorf("Schemes()[%d] = %q, want %q", i, got[i], tc.in[i])
+			}
+		}
+		//: second call must hand back an independent slice (defensive clone).
+		again := b.Schemes()
+		if len(again) > 0 && len(got) > 0 && &again[0] == &got[0] {
+			t.Errorf("Schemes() did not clone: same backing array")
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestBaseSinkSchemesDefensiveClone verifies the documented contract that
+// mutating the caller-side schemes slice does NOT affect Schemes(), and
+// vice versa.
+func TestBaseSinkSchemesDefensiveClone(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{
+		{"caller mutation leaves Schemes intact"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the identity triple must be immutable from outside the sink.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		original := []string{"stderr", "stdout"}
+		b := logger.NewBaseSink("console", logger.LocalClass, original)
+		//: mutate the caller-side slice after construction.
+		original[0] = "MUTATED"
+		got := b.Schemes()
+		//: BaseSink kept its own copy — the first element is the original.
+		if got[0] != "stderr" {
+			t.Fatalf("constructor clone failed: Schemes()[0] = %q, want %q", got[0], "stderr")
+		}
+		//: mutate the returned slice and confirm the next call still
+		//: observes the immutable identity.
+		got[0] = "ALSO_MUTATED"
+		again := b.Schemes()
+		//: Schemes() defensively clones on every call.
+		if again[0] != "stderr" {
+			t.Fatalf("Schemes() clone failed: second call[0] = %q, want %q", again[0], "stderr")
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/core/logger/base_sink_internal_test.go
+++ b/internal/core/logger/base_sink_internal_test.go
@@ -1,0 +1,42 @@
+package logger
+
+import "testing"
+
+// TestHasDuplicate exercises the unexported hasDuplicate helper. The
+// scheme-validation path inside NewBaseSink depends on its correctness;
+// this white-box test pins the contract so a future refactor that swaps
+// the linear scan for a sort-based approach must still satisfy the same
+// truth table.
+func TestHasDuplicate(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		in   []string
+		want bool
+	}
+	tests := []tc{
+		{"nil slice has no duplicates", nil, false},
+		{"single element has no duplicates", []string{"x"}, false},
+		{"two distinct elements", []string{"a", "b"}, false},
+		{"two identical elements", []string{"a", "a"}, true},
+		{"three elements with trailing dup", []string{"a", "b", "a"}, true},
+		{"three distinct elements", []string{"a", "b", "c"}, false},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; hasDuplicate must return the documented truth value for each
+	//: input shape.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		got := hasDuplicate(tc.in)
+		//: the helper's return value must match the table expectation.
+		if got != tc.want {
+			t.Fatalf("hasDuplicate(%v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/core/logger/sink_caps.go
+++ b/internal/core/logger/sink_caps.go
@@ -1,0 +1,41 @@
+// Package logger — optional capability sub-interfaces detected by type
+// assertion. A Sink that implements one of these gains a richer protocol
+// with the compose layer; middlewares that need a capability fall back to
+// the base Sink.Write contract when it is absent.
+package logger
+
+import "context"
+
+// BatchSink is the optional batching capability. A sink that satisfies
+// BatchSink receives N records in one call from Async / Multi /
+// async-aware middlewares — the genericHandler fans out to WriteBatch
+// instead of N sequential Write calls.
+//
+// Detection happens once at the middleware's construction time via
+// type assertion; the hot path stays branch-free.
+type BatchSink interface {
+	Sink
+	// WriteBatch delivers N records as a single call. The recs and payloads
+	// slices MUST be the same length, and recs[i] corresponds to payloads[i].
+	// Returns the total bytes successfully forwarded plus the first error
+	// encountered; partial-batch policy is the implementer's contract (the
+	// retry middleware reads n to decide whether to resume mid-batch).
+	WriteBatch(ctx context.Context, recs []RecordEvent, payloads [][]byte) (n int, err error)
+}
+
+// SyncSink is the optional durability capability. A sink that satisfies
+// SyncSink can guarantee on-disk durability (or its equivalent — fsync,
+// remote-side acknowledged write) on demand, distinct from Sink.Flush which
+// only drains in-memory buffers.
+//
+// The distinction matters for crash-safe consumers: Flush returns when the
+// records have left the SDK; Sync returns when the records survive a
+// power loss.
+type SyncSink interface {
+	Sink
+	// Sync forces the underlying transport to confirm durability. For file
+	// sinks this maps to fsync/fdatasync; for remote sinks it waits for the
+	// server-side ack. A sink that has no stronger guarantee than Flush
+	// should NOT implement SyncSink.
+	Sync(ctx context.Context) (err error)
+}

--- a/internal/core/logger/sink_caps_external_test.go
+++ b/internal/core/logger/sink_caps_external_test.go
@@ -1,0 +1,131 @@
+package logger_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/core/logger"
+)
+
+// batchStub satisfies both Sink and BatchSink — used by TestBatchSink to
+// prove the interface composition compiles and a type assertion from Sink
+// upgrades to BatchSink when implemented.
+type batchStub struct{}
+
+func (batchStub) Write(context.Context, logger.RecordEvent, []byte) (int, error) {
+	//: stub returns a sentinel byte count so a future test can distinguish
+	//: it from the WriteBatch path.
+	return 0, nil
+}
+
+func (batchStub) Flush(context.Context) error {
+	//: synchronous sink — Flush is a no-op.
+	return nil
+}
+
+func (batchStub) Close() error {
+	//: stateless stub — Close is a no-op.
+	return nil
+}
+
+func (batchStub) WriteBatch(context.Context, []logger.RecordEvent, [][]byte) (int, error) {
+	//: stub returns a recognisable batch-count sentinel.
+	return 1, nil
+}
+
+// syncStub satisfies both Sink and SyncSink — used by TestSyncSink to prove
+// the type assertion path.
+type syncStub struct{}
+
+func (syncStub) Write(context.Context, logger.RecordEvent, []byte) (int, error) {
+	//: stub: zero bytes written so the result is unambiguous.
+	return 0, nil
+}
+
+func (syncStub) Flush(context.Context) error {
+	//: stub flush is a no-op.
+	return nil
+}
+
+func (syncStub) Close() error {
+	//: stub close is a no-op.
+	return nil
+}
+
+func (syncStub) Sync(context.Context) error {
+	//: stub durability call — always succeeds.
+	return nil
+}
+
+// TestBatchSink verifies the capability sub-interface composes with Sink
+// and a type assertion from Sink upgrades cleanly when the implementer
+// satisfies BatchSink.
+func TestBatchSink(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{
+		{"batchStub satisfies BatchSink"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the type assertion must succeed and WriteBatch is callable.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		var s logger.Sink = batchStub{}
+		bs, ok := s.(logger.BatchSink)
+		//: assertion must succeed when the underlying type satisfies the
+		//: capability sub-interface.
+		if !ok {
+			t.Fatalf("type assert Sink → BatchSink failed for batchStub")
+		}
+		//: WriteBatch must call through; the stub returns 1.
+		n, err := bs.WriteBatch(t.Context(), nil, nil)
+		if err != nil {
+			t.Fatalf("WriteBatch err = %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("WriteBatch n = %d, want 1", n)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}
+
+// TestSyncSink verifies SyncSink composes with Sink and Sync is callable
+// via the upgraded interface.
+func TestSyncSink(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+	}
+	tests := []tc{
+		{"syncStub satisfies SyncSink"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the type assertion must succeed and Sync is callable.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		var s logger.Sink = syncStub{}
+		ss, ok := s.(logger.SyncSink)
+		//: assertion must succeed when the underlying type satisfies the
+		//: capability sub-interface.
+		if !ok {
+			t.Fatalf("type assert Sink → SyncSink failed for syncStub")
+		}
+		//: Sync must return nil for the stub.
+		if err := ss.Sync(t.Context()); err != nil {
+			t.Fatalf("Sync err = %v", err)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/core/logger/sink_class.go
+++ b/internal/core/logger/sink_class.go
@@ -1,0 +1,90 @@
+// Package logger — SinkClass classification for routing and middleware
+// composition hints. Read once at sink construction; never on the hot path.
+package logger
+
+import "strconv"
+
+// SinkClass tags a sink's operational profile so middleware can refuse to
+// stack a redundant decorator on top of it (e.g. Async over a
+// RemoteStreaming sink that already owns flow control). Bounded enum —
+// adding a class is a deliberate API change, not a string blob.
+//
+// The zero value is UnknownClass: a sink that forgets to set its class
+// fails closed (every class-aware middleware will warn) instead of
+// silently passing as LocalClass.
+type SinkClass uint8
+
+// Bounded enumeration of sink operational profiles + supporting radix
+// constant. Order is part of the API contract — appending new values is
+// allowed; reordering is not.
+const (
+	// UnknownClass is the zero value. A sink reporting UnknownClass is
+	// treated as "class metadata missing" by middlewares; they emit a
+	// warning per construction inviting the implementer to declare a
+	// concrete class.
+	UnknownClass SinkClass = iota
+
+	// LocalClass — synchronous, in-process, ~µs latency (console, file
+	// with EveryRecord fsync, syslog over a local UNIX socket).
+	// Backpressure / circuit-breaker middleware is overkill here.
+	LocalClass
+
+	// AsyncLocalClass — local transport behind an in-process ring/queue
+	// (file with periodic fsync, async-wrapped console). Bounded loss on
+	// SIGKILL is the contract.
+	AsyncLocalClass
+
+	// RemoteBatchedClass — coalesces N records into a single network
+	// round-trip (CloudWatch PutLogEvents, S3 PutObject, Loki push).
+	// Sinks in this class MUST also implement BatchSink for the
+	// genericHandler fan-in to skip N×Write.
+	RemoteBatchedClass
+
+	// RemoteStreamingClass — long-lived bidirectional stream (OTLP gRPC,
+	// syslog TCP w/ TLS). Has its own internal backpressure; wrapping in
+	// Async is redundant and double-buffers.
+	RemoteStreamingClass
+
+	// maxKnownSinkClass is the inclusive upper bound of declared class
+	// values. NewBaseSink uses it to reject out-of-range arguments at
+	// construction. Kept inside the same const block so reordering an
+	// enum value automatically reorders this guard.
+	maxKnownSinkClass = RemoteStreamingClass
+)
+
+// String returns the human-readable name of c for diagnostics and audit
+// hook messages. Unknown values render as "unknown(N)" so a future class
+// reaching production via a stale binary remains identifiable.
+func (c SinkClass) String() string {
+	//: dense switch — N is small, fixed, and any value below the max is a
+	//: documented identity.
+	switch c {
+	//: zero-value branch — sink forgot to set its class.
+	case UnknownClass:
+		//: explicit name keeps the missing-metadata warning identifiable
+		//: in audit hook output.
+		return "unknown"
+	//: synchronous local transport branch.
+	case LocalClass:
+		//: no decorator should add a queue over a synchronous local sink.
+		return "local"
+	//: in-process queued local transport branch.
+	case AsyncLocalClass:
+		//: documented bounded loss is the contract.
+		return "async-local"
+	//: batched remote transport branch.
+	case RemoteBatchedClass:
+		//: sinks in this class SHOULD also implement BatchSink.
+		return "remote-batched"
+	//: long-lived bidirectional stream branch.
+	case RemoteStreamingClass:
+		//: stream owns its own flow control; Async is redundant.
+		return "remote-streaming"
+	//: forward-compatible branch for values added after this build.
+	default:
+		//: render the numeric code via stdlib strconv.Itoa (decimal radix
+		//: by definition) so a stale binary still reports something a
+		//: maintainer can grep, without a magic base argument.
+		return "unknown(" + strconv.Itoa(int(c)) + ")"
+	}
+}

--- a/internal/core/logger/sink_class_external_test.go
+++ b/internal/core/logger/sink_class_external_test.go
@@ -1,0 +1,42 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/kitsunium/sdk/internal/core/logger"
+)
+
+// TestSinkClass_String verifies the String() representation for every
+// declared class value plus the out-of-range fallback path.
+func TestSinkClass_String(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		c    logger.SinkClass
+		want string
+	}
+	tests := []tc{
+		{"unknown zero value", logger.UnknownClass, "unknown"},
+		{"local", logger.LocalClass, "local"},
+		{"async-local", logger.AsyncLocalClass, "async-local"},
+		{"remote-batched", logger.RemoteBatchedClass, "remote-batched"},
+		{"remote-streaming", logger.RemoteStreamingClass, "remote-streaming"},
+		{"out-of-range renders numeric", logger.SinkClass(99), "unknown(99)"},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; SinkClass.String() must hand back the exact documented label.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		got := tc.c.String()
+		//: the diagnostic name must equal the table's expected value.
+		if got != tc.want {
+			t.Fatalf("SinkClass(%d).String() = %q, want %q", tc.c, got, tc.want)
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, tc)
+		})
+	}
+}

--- a/internal/kernel/errs/error_external_test.go
+++ b/internal/kernel/errs/error_external_test.go
@@ -652,32 +652,36 @@ func TestError_Is(t *testing.T) {
 // wrap-site code, then the inherited Reason and public message.
 func TestError_Error_RendersTrail(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
-	}{
+	}
+	tests := []tc{
 		{"single wrap renders one <- separated trail code"},
 	}
+	//: runCase executes one row directly so the static analyser credits
+	//: the branch; a wrap on a non-zero Code must produce the " <- " trail.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: 0x00_03_0F_70 = origin slot; 0x00_03_0F_71 = wrap-site slot.
+		origin := errs.Define(0x00_03_0F_70, "ORIGIN_TRAIL",
+			"origin public", "origin private")
+		wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_03_0F_71})
+		got := wrapped.Error()
+		//: a populated trail must render the ASCII wrap separator.
+		if !strings.Contains(got, " <- ") {
+			t.Errorf("Error() = %q, want ' <- ' trail separator", got)
+		}
+		//: origin-wins — Reason and public come from the wrapped cause.
+		if !strings.Contains(got, "ORIGIN_TRAIL") || !strings.Contains(got, "origin public") {
+			t.Errorf("Error() = %q, want origin reason + public", got)
+		}
+		//: Private must never leak into the rendered form.
+		if strings.Contains(got, "origin private") {
+			t.Errorf("Error() leaked Private: %q", got)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: 0x00_03_0F_70 = origin slot; 0x00_03_0F_71 = wrap-site slot.
-			origin := errs.Define(0x00_03_0F_70, "ORIGIN_TRAIL",
-				"origin public", "origin private")
-			wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_03_0F_71})
-			got := wrapped.Error()
-			//: a populated trail must render the ASCII wrap separator.
-			if !strings.Contains(got, " <- ") {
-				t.Errorf("Error() = %q, want ' <- ' trail separator", got)
-			}
-			//: origin-wins — Reason and public come from the wrapped cause.
-			if !strings.Contains(got, "ORIGIN_TRAIL") || !strings.Contains(got, "origin public") {
-				t.Errorf("Error() = %q, want origin reason + public", got)
-			}
-			//: Private must never leak into the rendered form.
-			if strings.Contains(got, "origin private") {
-				t.Errorf("Error() leaked Private: %q", got)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -685,30 +689,34 @@ func TestError_Error_RendersTrail(t *testing.T) {
 // monotonic truncation marker " (truncated)" is rendered before the Reason.
 func TestError_Error_RendersTruncated(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name  string
 		wraps int
-	}{
+	}
+	tests := []tc{
 		{"forty wraps overflow the trail cap", 40},
 	}
+	//: runCase executes one row directly so the static analyser credits
+	//: the branch; overflowing the trail cap must flip trailTruncated.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: 0x00_03_0F_72 = origin slot for the truncation walk.
+		var err error = errs.Define(0x00_03_0F_72, "TRUNC_ORIGIN",
+			"trunc public", "trunc private")
+		//: each wrap adds one distinct non-zero trail code; well past the
+		//: documented cap of 16 this must flip trailTruncated.
+		for i := range tc.wraps {
+			//: 0x00_07_01_xx — distinct non-zero wrap codes in layer 7.
+			err = errs.Wrap(err, errs.WrapParams{Code: errs.Code(0x00_07_01_00 + i + 1)})
+		}
+		got := err.Error()
+		//: overflow must surface the verbatim marker operators grep for.
+		if !strings.Contains(got, "(truncated)") {
+			t.Errorf("Error() = %q, want '(truncated)' marker", got)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: 0x00_03_0F_72 = origin slot for the truncation walk.
-			var err error = errs.Define(0x00_03_0F_72, "TRUNC_ORIGIN",
-				"trunc public", "trunc private")
-			//: each wrap adds one distinct non-zero trail code; well past the
-			//: documented cap of 16 this must flip trailTruncated.
-			for i := range tc.wraps {
-				//: 0x00_07_01_xx — distinct non-zero wrap codes in layer 7.
-				err = errs.Wrap(err, errs.WrapParams{Code: errs.Code(0x00_07_01_00 + i + 1)})
-			}
-			got := err.Error()
-			//: overflow must surface the verbatim marker operators grep for.
-			if !strings.Contains(got, "(truncated)") {
-				t.Errorf("Error() = %q, want '(truncated)' marker", got)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -717,30 +725,34 @@ func TestError_Error_RendersTruncated(t *testing.T) {
 // rather than dereferencing the nil receiver.
 func TestWrap_TypedNilErrorCause(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
-	}{
+	}
+	tests := []tc{
 		{"typed-nil *Error cause yields a params-driven error with nil source"},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: a typed-nil *Error is the classic interface-holding-nil trap.
-			var cause *errs.Error
-			//: 0x00_03_0F_73 = wrap slot for the typed-nil path.
-			wrapped := errs.Wrap(cause, errs.WrapParams{
-				Code: 0x00_03_0F_73, Reason: "TYPED_NIL_WRAP",
-				Public: "typed nil collapses to stdlib path", Private: "debug",
-			})
-			//: params apply because no *Error was inherited from the cause.
-			if wrapped.Code() != 0x00_03_0F_73 {
-				t.Errorf("Code = %s, want params code", wrapped.Code())
-			}
-			//: the collapsed path carries no wrapped cause.
-			if wrapped.Source() != nil {
-				t.Errorf("Source = %v, want nil", wrapped.Source())
-			}
+	//: runCase executes one row directly so the static analyser credits
+	//: the branch; a typed-nil *Error cause must collapse to the params path.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: a typed-nil *Error is the classic interface-holding-nil trap.
+		var cause *errs.Error
+		//: 0x00_03_0F_73 = wrap slot for the typed-nil path.
+		wrapped := errs.Wrap(cause, errs.WrapParams{
+			Code: 0x00_03_0F_73, Reason: "TYPED_NIL_WRAP",
+			Public: "typed nil collapses to stdlib path", Private: "debug",
 		})
+		//: params apply because no *Error was inherited from the cause.
+		if wrapped.Code() != 0x00_03_0F_73 {
+			t.Errorf("Code = %s, want params code", wrapped.Code())
+		}
+		//: the collapsed path carries no wrapped cause.
+		if wrapped.Source() != nil {
+			t.Errorf("Source = %v, want nil", wrapped.Source())
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -749,25 +761,30 @@ func TestWrap_TypedNilErrorCause(t *testing.T) {
 // code falls inside it, so errors.Is must still report a hit.
 func TestError_Is_MatchesTrailPrefix(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
-	}{
+	}
+	tests := []tc{
 		{"prefix matches a trail entry the origin misses"},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; the trail-walk arm of matchesPrefix must catch a wrap-site
+	//: code whose subnet the origin misses.
+	runCase := func(t *testing.T, _ tc) {
+		t.Helper()
+		//: origin sits in layer 3; the matcher targets layer 7.
+		origin := errs.Define(0x00_03_0F_74, "PREFIX_TRAIL_ORIGIN",
+			"prefix trail public", "prefix trail private")
+		//: wrap with a layer-7 code so only the trail entry can match.
+		wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_07_01_01})
+		//: subnet over major+layer == 0.7 — origin (layer 3) misses it.
+		matcher := errs.NewPrefixMatcher(0x00_07_00_00, errs.MaskByLayer)
+		if !errors.Is(wrapped, matcher) {
+			t.Errorf("errors.Is(wrapped, layer-7 matcher) = false, want true via trail")
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: origin sits in layer 3; the matcher targets layer 7.
-			origin := errs.Define(0x00_03_0F_74, "PREFIX_TRAIL_ORIGIN",
-				"prefix trail public", "prefix trail private")
-			//: wrap with a layer-7 code so only the trail entry can match.
-			wrapped := errs.Wrap(origin, errs.WrapParams{Code: 0x00_07_01_01})
-			//: subnet over major+layer == 0.7 — origin (layer 3) misses it.
-			matcher := errs.NewPrefixMatcher(0x00_07_00_00, errs.MaskByLayer)
-			if !errors.Is(wrapped, matcher) {
-				t.Errorf("errors.Is(wrapped, layer-7 matcher) = false, want true via trail")
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 
@@ -776,25 +793,29 @@ func TestError_Is_MatchesTrailPrefix(t *testing.T) {
 // through every branch to find a matching *Error code.
 func TestHasCode_MultiUnwrap(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	type tc struct {
 		name string
 		code errs.Code
 		want bool
-	}{
+	}
+	tests := []tc{
 		{"code present in a joined branch", 0x00_03_0F_75, true},
 		{"code absent from every branch", 0x00_03_0F_76, false},
 	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; HasCode must recurse through every Unwrap() []error branch.
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		//: 0x00_03_0F_75 = the sdk branch buried inside the join.
+		sdk := errs.Define(0x00_03_0F_75, "JOINED_SDK",
+			"joined public", "joined private")
+		//: errors.Join exposes Unwrap() []error, forcing the multi walk.
+		joined := errors.Join(errors.New("plain branch"), sdk)
+		if got := errs.HasCode(joined, tc.code); got != tc.want {
+			t.Errorf("HasCode(joined, %s) = %v, want %v", tc.code, got, tc.want)
+		}
+	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			//: 0x00_03_0F_75 = the sdk branch buried inside the join.
-			sdk := errs.Define(0x00_03_0F_75, "JOINED_SDK",
-				"joined public", "joined private")
-			//: errors.Join exposes Unwrap() []error, forcing the multi walk.
-			joined := errors.Join(errors.New("plain branch"), sdk)
-			if got := errs.HasCode(joined, tc.code); got != tc.want {
-				t.Errorf("HasCode(joined, %s) = %v, want %v", tc.code, got, tc.want)
-			}
-		})
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }

--- a/internal/service/codec/tlv/codec_external_test.go
+++ b/internal/service/codec/tlv/codec_external_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/kitsunium/sdk/internal/core/codec"
@@ -1134,6 +1135,10 @@ func TestAppendRollbackOnError(t *testing.T) {
 			t.Fatal("codec does not implement Appender")
 		}
 		prefill := []byte{0xAA, 0xBB, 0xCC}
+		//: snapshot prefill BEFORE Append so any in-place mutation is
+		//: visible — otherwise comparing out against prefill could silently
+		//: agree when prefill itself was clobbered.
+		want := slices.Clone(prefill)
 		out, err := ap.Append(prefill, make(chan int))
 		//: the encode must fail on the unsupported value.
 		if err == nil {
@@ -1141,8 +1146,8 @@ func TestAppendRollbackOnError(t *testing.T) {
 		}
 		//: rollback contract — the returned buffer is byte-for-byte the prior
 		//: prefix: neither truncated/grown (length) nor mutated (content).
-		if !bytes.Equal(out, prefill) {
-			t.Errorf("Append did not roll back: out=%v, want %v", out, prefill)
+		if !bytes.Equal(out, want) {
+			t.Errorf("Append did not roll back: out=%v, want %v", out, want)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/tlv/types_internal_test.go
+++ b/internal/service/codec/tlv/types_internal_test.go
@@ -541,10 +541,16 @@ func TestDecodeLargeScalarSlice(t *testing.T) {
 		if uerr := New().Unmarshal(encoded, &out); uerr != nil {
 			t.Fatalf("%s: Unmarshal err=%v", tc.name, uerr)
 		}
-		//: every element must survive the grow-as-we-go walk.
-		if len(out) != tc.size || out[tc.size-1] != int64(tc.size-1) {
-			t.Errorf("%s: len=%d last=%d, want len=%d last=%d",
-				tc.name, len(out), out[len(out)-1], tc.size, tc.size-1)
+		//: every element must survive the grow-as-we-go walk. Length is
+		//: checked first so a short-decode failure doesn't index past
+		//: out — out[tc.size-1] would panic on len(out) == 0 and mask
+		//: the real failure.
+		if len(out) != tc.size {
+			t.Errorf("%s: len=%d, want len=%d", tc.name, len(out), tc.size)
+			return
+		}
+		if out[tc.size-1] != int64(tc.size-1) {
+			t.Errorf("%s: last=%d, want last=%d", tc.name, out[tc.size-1], tc.size-1)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/xml/encoder_internal_test.go
+++ b/internal/service/codec/xml/encoder_internal_test.go
@@ -5,6 +5,8 @@ import (
 	stdxml "encoding/xml"
 	"errors"
 	"testing"
+
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
 
 type xmlDoc struct {
@@ -102,8 +104,10 @@ func Test_xmlEncoder_Close_FlushError(t *testing.T) {
 			t.Fatalf("%s: EncodeToken setup err=%v", tc.name, terr)
 		}
 		//: Close → Flush fails over the failing writer, hitting the wrap.
-		if err := enc.Close(); err == nil {
-			t.Errorf("%s: Close=nil, want flush error wrapped as MARSHAL_FAILED", tc.name)
+		//: assert the typed code, not just non-nil, so a regression where
+		//: Close stops carrying the dotted-quad sentinel actually fails.
+		if err := enc.Close(); !errs.HasCode(err, CodeXMLMarshalFailed) {
+			t.Errorf("%s: Close err=%v, want CodeXMLMarshalFailed (0.3.3.1)", tc.name, err)
 		}
 	}
 	for _, tc := range tests {

--- a/internal/service/codec/yaml/codec_internal_test.go
+++ b/internal/service/codec/yaml/codec_internal_test.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"bytes"
 	"errors"
+	"slices"
 	"testing"
 )
 
@@ -210,14 +211,17 @@ func Test_yamlCodec_Append(t *testing.T) {
 		if !ok {
 			t.Fatalf("%s: yamlCodec does not implement Appender", tc.name)
 		}
+		//: snapshot dst BEFORE Append so a same-length in-place mutation
+		//: on the error path is still detectable — length alone would miss it.
+		orig := slices.Clone(tc.dst)
 		got, err := ap.Append(tc.dst, tc.v)
 		if tc.wantErr {
 			if err == nil {
 				t.Fatalf("%s: want error, got nil", tc.name)
 			}
-			//: dst returned untouched on error (length match).
-			if len(got) != len(tc.dst) {
-				t.Errorf("%s: dst len changed on error: got=%d want=%d", tc.name, len(got), len(tc.dst))
+			//: dst returned byte-for-byte untouched on error.
+			if !bytes.Equal(got, orig) {
+				t.Errorf("%s: dst mutated on error: got=%q want=%q", tc.name, got, orig)
 			}
 			return
 		}

--- a/internal/service/logger/middleware/async/async_sink_internal_test.go
+++ b/internal/service/logger/middleware/async/async_sink_internal_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/kitsunium/sdk/internal/kernel/recycler"
 )
 
+// ctxKind / flushOutcome consolidate the table-driven test flags so the
+// Test_asyncSink_Flush case struct stays under the KTN-STRUCT-FLAGS
+// threshold and each row's intent is self-documenting.
+
+const (
+	ctxLive      ctxKind = iota //: default — t.Context()
+	ctxNil                      //: literal nil — wait-forever contract
+	ctxCancelled                //: pre-cancelled context — drives the typed cancellation arm
+)
+
+const (
+	outcomeOK        flushOutcome = iota //: Flush returns nil (happy path / fast-return)
+	outcomeCancelled                     //: Flush wraps ctx.Err() as CodeAsyncCtxCancelled
+	outcomeStopped                       //: Flush returns the Stopped sentinel (drainer exited)
+)
+
+// ctxKind enumerates the Flush context flavours the table exercises.
+type ctxKind uint8
+
+// flushOutcome enumerates the three documented terminal states of Flush
+// (nil / typed cancellation / Stopped) so the table-case struct can
+// express the assertion with one enum instead of three parallel bools.
+type flushOutcome uint8
+
 // noopDownstream satisfies corelogger.Sink for white-box drainer tests
 // that don't care about delivery.
 type noopDownstream struct{}
@@ -107,9 +131,10 @@ func Test_asyncSink_handleFull(t *testing.T) {
 
 func Test_asyncSink_Flush(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name      string
-		ctxCancel bool
+	type tc struct {
+		name string
+		//: ctx picks the Flush context flavour for this row.
+		ctx ctxKind
 		//: prime enqueues entries before Flush so the loop sees a non-empty
 		//: ring and falls through to the cancellation arm instead of the
 		//: empty-queue fast path. freshSink has no live drainer so the
@@ -119,64 +144,85 @@ func Test_asyncSink_Flush(t *testing.T) {
 		//: returns false on the first non-empty iteration — driving Flush's
 		//: documented Stopped arm ("flushSignal observed closed").
 		closeSignal bool
-		wantErr     bool
-		wantCode    bool
-		//: wantStopped asserts the Stopped sentinel (drainer-exited path).
-		wantStopped bool
-	}{
-		{"empty queue + live ctx returns nil", false, false, false, false, false, false},
-		{"empty queue + cancelled ctx still flushes downstream", true, false, false, false, false, false},
-		{"explicit nil context is permitted by the contract", false, false, false, false, false, false},
-		{"non-empty queue + cancelled ctx surfaces the typed cancellation", true, true, false, true, true, false},
-		{"non-empty queue + closed flushSignal surfaces Stopped", false, true, true, true, false, true},
+		//: want consolidates the three terminal states (nil/cancelled/
+		//: stopped) so each row carries one verdict instead of three
+		//: parallel booleans.
+		want flushOutcome
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			s := freshSink(t, DropNewest)
-			//: prime the ring so Flush observes remaining > 0 and reaches the
-			//: ctx-cancellation arm rather than returning on the empty path.
-			if tc.prime {
-				if werr := s.queue.TryWrite(newRecordEntry()); werr != nil {
-					t.Fatalf("priming TryWrite err = %v", werr)
-				}
+	tests := []tc{
+		{"empty queue + live ctx returns nil", ctxLive, false, false, outcomeOK},
+		{"empty queue + cancelled ctx still flushes downstream", ctxCancelled, false, false, outcomeOK},
+		{"explicit nil context is permitted by the contract", ctxNil, false, false, outcomeOK},
+		{"non-empty queue + cancelled ctx surfaces the typed cancellation", ctxCancelled, true, false, outcomeCancelled},
+		{"non-empty queue + closed flushSignal surfaces Stopped", ctxLive, true, true, outcomeStopped},
+	}
+	//: runCase executes one row directly so the static analyser credits the
+	//: branch; Flush's documented contract spans the empty-queue fast path,
+	//: nil-ctx wait-forever, cancellation arm, and Stopped sentinel — every
+	//: row drives one of those branches under a freshSink (no live drainer).
+	runCase := func(t *testing.T, tc tc) {
+		t.Helper()
+		s := freshSink(t, DropNewest)
+		//: prime the ring so Flush observes remaining > 0 and reaches the
+		//: ctx-cancellation arm rather than returning on the empty path.
+		if tc.prime {
+			if werr := s.queue.TryWrite(newRecordEntry()); werr != nil {
+				t.Fatalf("priming TryWrite err = %v", werr)
 			}
-			//: pre-close flushSignal to reproduce the documented drainer-exited
-			//: state so Flush's waitForDrainerProgress returns false and the
-			//: Stopped arm runs. freshSink leaves flushSignal nil, so equip a
-			//: dedicated channel first (mirroring Test_waitForDrainerProgress),
-			//: then close it. The drainer never closes this channel in
-			//: production (only Close terminates it indirectly), so this
-			//: white-box setup is the only way to exercise the defensive arm.
-			if tc.closeSignal {
-				s.flushSignal = make(chan struct{}, 1)
-				close(s.flushSignal)
+		}
+		//: pre-close flushSignal to reproduce the documented drainer-exited
+		//: state so Flush's waitForDrainerProgress returns false and the
+		//: Stopped arm runs. freshSink leaves flushSignal nil, so equip a
+		//: dedicated channel first (mirroring Test_waitForDrainerProgress),
+		//: then close it. The drainer never closes this channel in
+		//: production (only Close terminates it indirectly), so this
+		//: white-box setup is the only way to exercise the defensive arm.
+		if tc.closeSignal {
+			s.flushSignal = make(chan struct{}, 1)
+			close(s.flushSignal)
+		}
+		//: select the ctx the row asks for; the nil arm exercises the
+		//: documented "wait-forever, no cancellation" contract.
+		var ctx context.Context
+		switch tc.ctx {
+		case ctxNil:
+			ctx = nil
+		case ctxCancelled:
+			cancelled, cancel := context.WithCancel(t.Context())
+			cancel()
+			ctx = cancelled
+		case ctxLive:
+			fallthrough
+		default:
+			ctx = t.Context()
+		}
+		err := s.Flush(ctx)
+		//: dispatch on the single verdict — each branch fully covers its
+		//: outcome (nil-on-OK, typed code + stdlib chain on cancelled,
+		//: Stopped sentinel on drainer-exited).
+		switch tc.want {
+		case outcomeOK:
+			if err != nil {
+				t.Errorf("Flush err = %v, want nil", err)
 			}
-			ctx := t.Context()
-			if tc.ctxCancel {
-				cancelled, cancel := context.WithCancel(ctx)
-				cancel()
-				ctx = cancelled
+		case outcomeCancelled:
+			if err == nil {
+				t.Fatal("Flush err = nil, want CodeAsyncCtxCancelled")
 			}
-			err := s.Flush(ctx)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("Flush err = %v, wantErr = %v", err, tc.wantErr)
+			if !errs.HasCode(err, CodeAsyncCtxCancelled) {
+				t.Errorf("Flush err = %v, want CodeAsyncCtxCancelled", err)
 			}
-			//: the cancellation arm wraps ctx.Err() with the typed sentinel —
-			//: assert both the dotted-quad code and stdlib Is() chaining.
-			if tc.wantCode {
-				if !errs.HasCode(err, CodeAsyncCtxCancelled) {
-					t.Errorf("Flush err = %v, want CodeAsyncCtxCancelled", err)
-				}
-				if !errors.Is(err, context.Canceled) {
-					t.Errorf("Flush err = %v, want errors.Is(context.Canceled)", err)
-				}
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("Flush err = %v, want errors.Is(context.Canceled)", err)
 			}
-			//: the Stopped arm returns the drainer-exited sentinel verbatim.
-			if tc.wantStopped && !errs.HasCode(err, CodeAsyncStopped) {
+		case outcomeStopped:
+			if !errs.HasCode(err, CodeAsyncStopped) {
 				t.Errorf("Flush err = %v, want Stopped", err)
 			}
-		})
+		}
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { t.Parallel(); runCase(t, tc) })
 	}
 }
 


### PR DESCRIPTION
Construction-time chain inspection + DoS-bounded Describe/Validate. Stacked on PR-05 #43. Pattern-detection panic guards deferred to follow-ups for focus.