### PR TITLE
fix(errs): AST audit scans third-party/ so ADR-0012 writer codes are enforced

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,8 +9,8 @@ load("@gazelle//:def.bzl", "gazelle")
 gazelle(name = "gazelle")
 
 # audit_sources lists every file the internal/kernel/errs AST audit reads
-# at runtime. The audit walks internal/ and pkg/ looking for errs.Define
-# call sites + reads go.work for the workspace sentinel. Under Bazel the
+# at runtime. The audit walks internal/, pkg/, and third-party/ looking for
+# errs.Define call sites + reads go.work for the workspace sentinel. Under Bazel the
 # test sandbox strips the source-tree relationship, so the test target
 # ships this filegroup as runfiles and resolves the root via TEST_SRCDIR
 # + TEST_WORKSPACE. Filegroup stays in the root BUILD so all layers can
@@ -22,6 +22,7 @@ filegroup(
         "//internal/core/codec:audit_srcs",
         "//internal/core/logger:audit_srcs",
         "//internal/core/logger/level:audit_srcs",
+        "//internal/core/writer:audit_srcs",
         "//internal/kernel/buffer:audit_srcs",
         "//internal/kernel/clock:audit_srcs",
         "//internal/kernel/errs:audit_srcs",
@@ -44,6 +45,8 @@ filegroup(
         "//pkg/v1/codec:audit_srcs",
         "//pkg/v1/errs:audit_srcs",
         "//pkg/v1/logger:audit_srcs",
+        "//third-party/aws/writer/cloudwatch:audit_srcs",
+        "//third-party/aws/writer/s3:audit_srcs",
     ],
     visibility = ["//visibility:public"],
 )

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,26 +1,17 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-05-29T20:24:17.387Z",
+  "generatedAt": "2026-05-29T22:24:43.557Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
-    {
-      "type": "fix",
-      "scope": "logger",
-      "breaking": false,
-      "summary": "address CodeRabbit/Qodo review on writer registry (PR #52)",
-      "sha": "661c4f04247d5dd07d2bf10d6e5035d222c39acf",
-      "short": "661c4f0",
-      "date": "2026-05-29T22:08:52+02:00"
-    },
     {
       "type": "feat",
       "scope": "logger",
       "breaking": false,
-      "summary": "add config-driven writer registry (console/file/s3/cloudwatch) — ADR 0012",
-      "sha": "9d5e28fbe57b39e818ca270f84d315a4c23fa62a",
-      "short": "9d5e28f",
-      "date": "2026-05-29T20:57:14+02:00"
+      "summary": "config-driven writer registry (console/file/s3/cloudwatch) — ADR 0012 (#52)",
+      "sha": "3732c6885d1f03b786621b18688e8b51f10fafe9",
+      "short": "3732c68",
+      "date": "2026-05-29T22:26:54+02:00"
     },
     {
       "type": "feat",
@@ -39,6 +30,15 @@
       "sha": "dcff33ba199373bcc579168f287bd783aa5b3e1f",
       "short": "dcff33b",
       "date": "2026-05-25T09:59:30Z"
+    },
+    {
+      "type": "fix",
+      "scope": "docs",
+      "breaking": false,
+      "summary": "base-path the portal for GitHub Pages project deploys + a11y/SEO (#30)",
+      "sha": "5bff559252443700989d2507c57039696da9ded2",
+      "short": "5bff559",
+      "date": "2026-05-25T09:45:30Z"
     },
     {
       "type": "feat",

--- a/internal/core/writer/BUILD.bazel
+++ b/internal/core/writer/BUILD.bazel
@@ -52,3 +52,11 @@ go_test(
         "//internal/kernel/errs",
     ],
 )
+
+# audit_srcs ships this package's .go files to the //internal/kernel/errs AST
+# audit (//:audit_sources) so its errs.Define call sites are scanned under Bazel.
+filegroup(
+    name = "audit_srcs",
+    srcs = glob(["*.go"]),
+    visibility = ["//:__pkg__"],
+)

--- a/internal/kernel/errs/registry_external_test.go
+++ b/internal/kernel/errs/registry_external_test.go
@@ -46,13 +46,16 @@ func sdkRoot(tb testing.TB) (root string) {
 	return ""
 }
 
-// collectDefineCalls walks every non-test.go file under root/internal and
-// root/pkg, returning each (file:line, call) pair whose callee resolves to
-// errs.Define. Used by the audits below.
+// collectDefineCalls walks every non-test.go file under root/internal,
+// root/pkg, and root/third-party, returning each (file:line, call) pair whose
+// callee resolves to errs.Define. third-party is included so the opt-in
+// vendor-dependent emitters (e.g. the AWS writers, ADR 0012) are audited for
+// the same Public-is-literal / reason / code-uniqueness invariants as the rest
+// of the SDK. Used by the audits below.
 func collectDefineCalls(tb testing.TB, root string) (out []defineCall) {
 	tb.Helper()
 	fset := token.NewFileSet()
-	for _, sub := range []string{"internal", "pkg"} {
+	for _, sub := range []string{"internal", "pkg", "third-party"} {
 		base := filepath.Join(root, sub)
 		filepath.Walk(base, func(path string, info os.FileInfo, _ error) error { //nolint:errcheck // audit is best-effort
 			if info == nil || info.IsDir() {
@@ -188,6 +191,45 @@ func TestAuditCodeUniqueness(t *testing.T) {
 					seen[key] = dc.varName
 				}
 			}
+		})
+	}
+}
+
+func TestAuditScansThirdParty(t *testing.T) {
+	t.Parallel()
+	type tc struct {
+		name string
+		code string
+	}
+	tests := []tc{
+		//: a known errs.Define code from a third-party/* emitter (ADR 0012 AWS
+		//: writers) MUST be collected — proves the audit walks third-party, not
+		//: just internal/ + pkg/. Guards against a regression of the scan roots.
+		{"s3 writer sentinel is audited", "CodeS3ClientInitFailed"},
+	}
+	runCase := func(t *testing.T, c tc) {
+		t.Helper()
+		root := sdkRoot(t)
+		found := false
+		for _, dc := range collectDefineCalls(t, root) {
+			if len(dc.call.Args) == 0 {
+				continue
+			}
+			//: arg[0] is the dotted-quad code identifier passed to errs.Define.
+			if ident, ok := dc.call.Args[0].(*ast.Ident); ok && ident.Name == c.code {
+				found = true
+				break
+			}
+		}
+		//: absence means the audit is blind to third-party — the ADR-0012 drift.
+		if !found {
+			t.Errorf("%s: %q not collected; audit does not scan third-party", c.name, c.code)
+		}
+	}
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			runCase(t, c)
 		})
 	}
 }

--- a/third-party/aws/writer/cloudwatch/BUILD.bazel
+++ b/third-party/aws/writer/cloudwatch/BUILD.bazel
@@ -52,3 +52,11 @@ go_test(
         "@com_github_aws_smithy_go//middleware",
     ],
 )
+
+# audit_srcs ships this package's .go files to the //internal/kernel/errs AST
+# audit (//:audit_sources) so its errs.Define call sites are scanned under Bazel.
+filegroup(
+    name = "audit_srcs",
+    srcs = glob(["*.go"]),
+    visibility = ["//:__pkg__"],
+)

--- a/third-party/aws/writer/s3/BUILD.bazel
+++ b/third-party/aws/writer/s3/BUILD.bazel
@@ -50,3 +50,11 @@ go_test(
         "@com_github_aws_smithy_go//middleware",
     ],
 )
+
+# audit_srcs ships this package's .go files to the //internal/kernel/errs AST
+# audit (//:audit_sources) so its errs.Define call sites are scanned under Bazel.
+filegroup(
+    name = "audit_srcs",
+    srcs = glob(["*.go"]),
+    visibility = ["//:__pkg__"],
+)


### PR DESCRIPTION
## What

The errs registry AST audit (`internal/kernel/errs/registry_external_test.go`) walked only `internal/` and `pkg/`, and `//:audit_sources` never shipped the ADR-0012 writer packages. So the `writer` / `s3` / `cloudwatch` `errs.Define` sentinels escaped the audit's three invariants (Public-is-string-literal, `reason == screamingSnake(varName)`, code-identifier uniqueness) under **both** `go test` and Bazel.

## Fix

- `collectDefineCalls` now walks `internal/`, `pkg/`, **and** `third-party/`.
- Added `audit_srcs` filegroups to `internal/core/writer` + `third-party/aws/writer/{s3,cloudwatch}`, wired into `//:audit_sources`.
- New `TestAuditScansThirdParty` asserts a known third-party sentinel (`CodeS3ClientInitFailed`) is collected — regression guard on the scan roots.

The ADR-0012 sentinels already satisfied every rule; this just makes the audit *see* them. Found by a multi-agent ideation pass over the SDK.

## Out of scope (tracked separately)

`ring` + `middleware/*` + `sink/*` are also absent from `//:audit_sources` and use package-prefixed reasons (`ASYNC_STOPPED` for var `Stopped`) that violate `reason == screamingSnake(varName)`. Enforcing those needs a reason/var reconciliation — a separate change.

## Verification
`bazel test --config=race //...` green (43 targets); `ktn-linter --phases=all` clean; `make build`/`test`/`lint` all pass via pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes reflecting config-driven writer registry and GitHub Pages base-path improvements.

* **Chores**
  * Extended error definition auditing to scan third-party source directories alongside internal packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitsunium/sdk/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->