### PR TITLE
fix(ci): hold-bootstrap release no longer fails the SDK Release job

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -85,6 +85,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          # GitHub invokes this step as `bash -e`, which re-enables errexit even
+          # though the line above deliberately omits it. Disable it explicitly:
+          # the cut-tags pipeline below may exit 3 (a HELD bootstrap, not a
+          # failure) and errexit would abort before the rc==3 handler runs.
+          # Real failures still fail the job via the explicit `exit "$rc"` below.
+          set +e
           # A manual workflow_dispatch authorises the bootstrap (very first)
           # release; automatic runs must NOT blind-cut it — cut-tags exits 3 to
           # signal a held bootstrap (ADR 0009: validate go.sum + clean-room

--- a/docs/site/src/data/whats-new-local-v1.json
+++ b/docs/site/src/data/whats-new-local-v1.json
@@ -1,44 +1,35 @@
 {
   "release": "local",
   "major": "v1",
-  "generatedAt": "2026-06-03T14:58:48.445Z",
+  "generatedAt": "2026-06-04T20:33:54.046Z",
   "repoUrl": "https://github.com/kitsunium/sdk",
   "entries": [
     {
-      "type": "fix",
-      "scope": "logger",
-      "breaking": false,
-      "summary": "resolve Qodo review findings on writer subsystem (PR #58)",
-      "sha": "636c793ad4374e5f39c57786e30c1775b90ccfb5",
-      "short": "636c793",
-      "date": "2026-06-03T11:25:46+02:00"
-    },
-    {
       "type": "feat",
       "scope": "logger",
       "breaking": false,
-      "summary": "ClickHouse database writer (native protocol, vendored driver)",
-      "sha": "ef2a15aa825ecea3d3b4da995605937b1ac26d19",
-      "short": "ef2a15a",
-      "date": "2026-06-02T13:42:44+02:00"
+      "summary": "writer subsystem v2 — rotation, transports, DB writers + realistic test suite (ADR 0015) (#58)",
+      "sha": "931b84f97dc37223ecc0b4312cc2145810cfca43",
+      "short": "931b84f",
+      "date": "2026-06-04T22:04:50+02:00"
     },
     {
       "type": "feat",
-      "scope": "logger",
+      "scope": null,
       "breaking": false,
-      "summary": "Redis Stream database writer (local-protocol, vendored driver)",
-      "sha": "1b413fb5559e09d3bae4ee2fe3b3a70721f5157e",
-      "short": "1b413fb",
-      "date": "2026-06-02T13:35:49+02:00"
+      "summary": "ADR 0014 — the verb wave (transform tier, crypto ports + compositions, config-driven topology) (#57)",
+      "sha": "98a1257d373a33dd0b3581294694da1ac77a3018",
+      "short": "98a1257",
+      "date": "2026-05-31T23:31:53+02:00"
     },
     {
       "type": "feat",
-      "scope": "logger",
+      "scope": "crypto",
       "breaking": false,
-      "summary": "MySQL database writer (local-protocol, vendored driver)",
-      "sha": "c1a612f3c8a016baf7f5ed940f49fe56992568af",
-      "short": "c1a612f",
-      "date": "2026-06-02T13:25:21+02:00"
+      "summary": "public crypto tier — hash / sign / kdf / password (ADR 0013) (#56)",
+      "sha": "bfcb793de9bab5008c53b7f514747a1bafb1bcee",
+      "short": "bfcb793",
+      "date": "2026-05-30T14:10:16+02:00"
     },
     {
       "type": "fix",
@@ -48,6 +39,15 @@
       "sha": "e8c78b5450e26e658caa2a02d92750027d4bd202",
       "short": "e8c78b5",
       "date": "2026-05-30T00:29:53+02:00"
+    },
+    {
+      "type": "fix",
+      "scope": "docs",
+      "breaking": false,
+      "summary": "make npm test glob node-version-agnostic (#31)",
+      "sha": "dcff33ba199373bcc579168f287bd783aa5b3e1f",
+      "short": "dcff33b",
+      "date": "2026-05-25T09:59:30Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- The `SDK Release` job has failed on every merge to `main` (e.g. run #14) at the **Cut and push tags** step.
- Root cause: the step uses `set -uo pipefail` (intentionally no `-e`) so it can catch `cut-tags.sh` **exit 3** — the ADR 0009 "first release held for manual validation" signal — and turn it into a green no-op. But GitHub invokes the step as `bash -e {0}`, re-enabling errexit, so the `cut-tags.sh | tee` pipeline aborts the moment it returns 3, before the `rc==3` handler runs.
- Fix: add an explicit `set +e` so the intentional exit-3 hold reaches its handler. Real failures still fail the job via the explicit `exit "$rc"`.

## Test plan

- [ ] Simulated the step under `bash -e` with a stub cut-tags: rc=3 → step exits **0** (green hold); rc=1 → **1**; rc=2 → **2**; rc=0 → **0** (real failures still propagate).
- [ ] `bazel-ci.yml` green on this PR.
- [ ] After merge: the next automatic `SDK Release` run on `main` holds the bootstrap gracefully instead of failing.

> Note: this only fixes the held-bootstrap reporting. To actually cut the first `pkg/v1/v1.0.0`, dispatch `SDK Release` manually (`--allow-bootstrap`) after validating go.sum + a clean-room `go get` (ADR 0009).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logger subsystem v2 with rotation, transports, and database writer support.
  * Public crypto tier supporting hash, signing, KDF, and password operations.
  * Architecture decision record for transform tier and crypto port configuration.

* **Bug Fixes**
  * Fixed npm test glob compatibility for Node version agnostic testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->