### PR TITLE
fix(release): compute-bumps spurious-bump on every main build (detached release tag)

### DIFF
--- a/scripts/release/compute-bumps.sh
+++ b/scripts/release/compute-bumps.sh
@@ -41,11 +41,25 @@ EOF
   esac
 done
 
-# Shallow-clone safe range (plan B2). git describe fails silently on
-# repos without tags; fall back to the root commit (always present).
+# Range to diff for "what changed since the last release".
+#
+# cut-tags.sh publishes each release on a DETACHED commit that is a *child* of
+# the main commit it was cut from (ADR 0009 — the dev branch is never touched).
+# That release commit is therefore NOT reachable from HEAD, so `git describe
+# --tags` cannot see the release tags and silently falls back to root..HEAD —
+# which makes compute-bumps emit `pkg` on EVERY main build and cut a spurious
+# patch each time. Instead, baseline on the latest pkg tag's FIRST PARENT (the
+# main commit that release was cut from): the range then captures only the
+# commits added to main since that release (empty ⇒ no bump). Falls back to the
+# root commit on a bootstrap repo that has no pkg tag yet.
 if [ -z "$RANGE" ]; then
-  if last_tag="$(git describe --tags --abbrev=0 2>/dev/null)"; then
-    RANGE="${last_tag}..HEAD"
+  last_pkg="$(latest_pkg_tag 2>/dev/null || true)"
+  last_base=""
+  if [ -n "$last_pkg" ]; then
+    last_base="$(git rev-parse -q --verify "${last_pkg}^1^{commit}" 2>/dev/null || true)"
+  fi
+  if [ -n "$last_base" ]; then
+    RANGE="${last_base}..HEAD"
   elif [ "$(git rev-list --count HEAD)" -eq 1 ]; then
     # Single-commit repo: root == HEAD, so root..HEAD is empty and the
     # initial commit's paths would be invisible. Diff against the empty

--- a/scripts/release/test-compute-bumps.bats
+++ b/scripts/release/test-compute-bumps.bats
@@ -85,3 +85,41 @@ teardown() { rm -rf "$REPO"; }
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+# Regression: the release tag lives on a DETACHED child of main (how cut-tags.sh
+# publishes it), so `git describe` can't see it. compute-bumps must baseline on
+# the tag's first parent, not fall back to root..HEAD and emit a spurious bump.
+@test "detached release tag + no new main commits emits nothing (no spurious bump)" {
+  cd "$(mktemp -d)"
+  git init -q -b main
+  git config user.email "ci@example.invalid"; git config user.name "ci"
+  mkdir -p pkg/v1
+  printf 'module github.com/kitsunium/sdk/pkg\n\ngo 1.26\n' > pkg/go.mod
+  : > pkg/v1/codec.go
+  git add -A; git commit -q -m "init"
+  base="$(git rev-parse HEAD)"
+  # cut-tags-style: a detached commit whose parent is main HEAD, tagged, not on a branch.
+  rel="$(git commit-tree "HEAD^{tree}" -p "$base" -m "release v0.1.0")"
+  git tag pkg/v0.1.0 "$rel"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "detached release tag + a real pkg change after the base emits pkg" {
+  cd "$(mktemp -d)"
+  git init -q -b main
+  git config user.email "ci@example.invalid"; git config user.name "ci"
+  mkdir -p pkg/v1
+  printf 'module github.com/kitsunium/sdk/pkg\n\ngo 1.26\n' > pkg/go.mod
+  : > pkg/v1/codec.go
+  git add -A; git commit -q -m "init"
+  base="$(git rev-parse HEAD)"
+  rel="$(git commit-tree "HEAD^{tree}" -p "$base" -m "release v0.1.0")"
+  git tag pkg/v0.1.0 "$rel"
+  echo "// new" >> pkg/v1/codec.go
+  git commit -aq -m "feat(v1): real change after release"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pkg" ]
+}


### PR DESCRIPTION
## Problem

After the first release (`pkg/v0.1.0`) was cut, a no-change `sdk-release` auto-run **cut a spurious `pkg/v0.1.1`** (since removed). Root cause: `cut-tags.sh` publishes each release on a **detached commit** that is a *child* of the main commit it was cut from (ADR 0009 — the dev branch is never touched). That commit is unreachable from `HEAD`, so `compute-bumps.sh`'s `git describe --tags` can't see the release tags and silently falls back to `root..HEAD` → it emits `pkg` on **every** main build → a spurious patch each time.

## Fix

Baseline on `<latest pkg tag>^1` — the main commit the release was cut from — instead of `git describe`. The diff range then captures only commits added to main *since* that release (empty ⇒ no bump).

## Verification

- On current `main` (`HEAD == pkg/v0.1.0^1`): `compute-bumps` now emits **nothing** (was: `pkg`).
- Detached-tag + a real `pkg/v1/**` change: still emits `pkg`.
- Two bats regression tests reproduce the detached-tag layout via `git commit-tree`.

This is self-protecting: merging this PR triggers `sdk-release`, which runs the **fixed** `compute-bumps` from merged main → emits nothing → no spurious cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of version bump calculations in the release process, resolving issues with certain commit structures.

* **Tests**
  * Added regression tests to prevent future issues with version bump calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->