### PR TITLE
feat(proc): per-process stdio wiring — capture/redirect/null (#73)

### DIFF
--- a/internal/core/proc/BUILD.bazel
+++ b/internal/core/proc/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "signal_other.go",
         "signal_unix.go",
         "spec.go",
+        "stdio.go",
     ],
     importpath = "github.com/kitsunium/sdk/internal/core/proc",
     visibility = [

--- a/internal/core/proc/CLAUDE.md
+++ b/internal/core/proc/CLAUDE.md
@@ -24,7 +24,8 @@ Code range: `0.2.6.*` (ADR 0016).
 |---|---|
 | `proc.go` | package doc + `Resource` enum (`NoFile`/`NProc`/`Core`/`AS`/`CPU`/`FSize`/`Data`/`Stack`/`MemLock`) + `String`/`Known` |
 | `signal.go` (+ `signal_unix.go` / `signal_other.go`) | `Signal` value type: `Parse` / `String` / `OS` / `Int` / `Known`; platform name table |
-| `spec.go` | `Spec` — process spawn spec (path/args/dir/env, creds, pgroup/session, rlimit/nice/umask/oom) |
+| `spec.go` | `Spec` — process spawn spec (path/args/dir/env, creds, pgroup/session, rlimit/nice/umask/oom, **stdio**) |
+| `stdio.go` | `StdioMode` — how a child's stdin/stdout/stderr are wired (`StdioInherit`/`StdioNull`/`StdioCapture`) + `String`/`Known` |
 | `exit.go` | `ExitValue` — exit code, terminating signal, CPU times, max RSS + `Success` |
 | `limit.go` | `LimitValue` — soft/hard rlimit pair + `LimitInfinity` |
 | `notification.go` | `NotificationValue` — parsed sd_notify datagram; `Ready`/`Reloading`/`Stopping`/`Watchdog` read `State` |

--- a/internal/core/proc/codes.go
+++ b/internal/core/proc/codes.go
@@ -94,3 +94,9 @@ const CodeInvalidNotification errs.Code = 0x00_02_06_15 // 0.2.6.21
 // CodeCredentialMismatch identifies a received datagram whose kernel-verified
 // sender credentials did not match the expected supervised process.
 const CodeCredentialMismatch errs.Code = 0x00_02_06_16 // 0.2.6.22
+
+// CodeStdioCaptureFailed identifies a StdioCapture spawn whose output copier
+// could not deliver the child's stdout/stderr to the caller's writer (the writer
+// itself returned an error). Surfaced from Wait when the process otherwise
+// exited cleanly.
+const CodeStdioCaptureFailed errs.Code = 0x00_02_06_17 // 0.2.6.23

--- a/internal/core/proc/errors.go
+++ b/internal/core/proc/errors.go
@@ -13,6 +13,7 @@ const (
 	exitNoUser      int = 67 // EX_NOUSER — a named user/group did not resolve.
 	exitUnavailable int = 69 // EX_UNAVAILABLE — a required facility is absent.
 	exitOSErr       int = 71 // EX_OSERR — an OS-level operation failed.
+	exitIOErr       int = 74 // EX_IOERR — an I/O error occurred.
 	exitNoPerm      int = 77 // EX_NOPERM — a permission/credential check failed.
 )
 
@@ -170,4 +171,12 @@ var (
 		"Datagram sender credentials did not match",
 		"service/proc/sdnotify.Recv: SO_PASSCRED sender pid is not the expected supervised process",
 		errs.WithExitCode(exitNoPerm))
+
+	// StdioCaptureFailed is returned from Wait when a StdioCapture copier could
+	// not deliver the child's stdout/stderr to the caller's writer (the writer
+	// itself errored), even though the process exited cleanly.
+	StdioCaptureFailed = errs.Define(CodeStdioCaptureFailed, "STDIO_CAPTURE_FAILED",
+		"Could not deliver the captured output to the writer",
+		"service/proc/exec: a StdioCapture copier failed writing the child's stdout/stderr to the caller's sink",
+		errs.WithExitCode(exitIOErr))
 )

--- a/internal/core/proc/process.go
+++ b/internal/core/proc/process.go
@@ -14,7 +14,10 @@ type Process interface {
 	// PID reports the process identifier of the leader.
 	PID() int
 	// Wait blocks until the process exits and returns its ExitValue. It is safe
-	// to call once; concurrent or repeated calls observe the same outcome.
+	// to call once; concurrent or repeated calls observe the same outcome. Under
+	// StdioCapture it returns only after every captured byte has reached the
+	// caller's writers; if a writer itself failed, the ExitValue still reports the
+	// real exit status and the error is StdioCaptureFailed.
 	Wait() (ExitValue, error)
 	// Signal delivers sig to the leader process only.
 	Signal(sig Signal) error

--- a/internal/core/proc/spec.go
+++ b/internal/core/proc/spec.go
@@ -1,6 +1,8 @@
 // Package proc — the Spec value type: an immutable process spawn specification.
 package proc
 
+import "io"
+
 // Spec is the immutable description of a process to spawn: the executable and
 // its environment, the credentials and isolation topology to apply, and the
 // resource/scheduling attributes to set between fork and exec. It carries no
@@ -47,4 +49,21 @@ type Spec struct {
 	// (systemd Limit*=); resources unsupported on the platform surface a typed
 	// error rather than silently no-op.
 	Rlimits map[Resource]LimitValue
+
+	// Stdio selects how the child's standard streams are wired: StdioInherit
+	// (default — share the parent's), StdioNull (discard to the null device), or
+	// StdioCapture (use the Stdout/Stderr/Stdin members below). systemd
+	// StandardOutput=/StandardError=/StandardInput= is the analogue.
+	Stdio StdioMode
+	// Stdout, when Stdio is StdioCapture, receives the child's standard output;
+	// a nil writer discards that stream to the null device.
+	Stdout io.Writer
+	// Stderr, when Stdio is StdioCapture, receives the child's standard error;
+	// a nil writer discards that stream to the null device.
+	Stderr io.Writer
+	// Stdin, when Stdio is StdioCapture, is copied to the child's standard input;
+	// a nil reader gives the child an immediate-EOF stdin. The reader should be
+	// EOF-terminating (a buffer, file, or strings.Reader); the copier closes the
+	// child's stdin at EOF and never blocks Wait.
+	Stdin io.Reader
 }

--- a/internal/core/proc/stdio.go
+++ b/internal/core/proc/stdio.go
@@ -1,0 +1,50 @@
+// Package proc — the StdioMode value: how a spawned child's standard streams
+// (stdin, stdout, stderr) are connected.
+package proc
+
+import "strconv"
+
+// StdioMode selects how a spawned child's standard streams are wired. The zero
+// value is StdioInherit, preserving the historical behaviour where the child
+// shares the parent's stdin/stdout/stderr (systemd StandardOutput=/StandardInput=
+// is the analogue, but the choice is generic to anything that spawns processes).
+type StdioMode uint8
+
+const (
+	// StdioInherit shares the parent's stdin/stdout/stderr with the child — the
+	// default, and the only behaviour that existed before per-process wiring.
+	StdioInherit StdioMode = iota
+	// StdioNull connects every stream to the platform null device: the child's
+	// output is discarded and its stdin returns EOF immediately.
+	StdioNull
+	// StdioCapture connects the child to the Spec's Stdout/Stderr writers and
+	// Stdin reader; a nil writer or reader for a given stream falls back to the
+	// null device for that one stream.
+	StdioCapture
+)
+
+// stdioModeNames maps each defined mode to its canonical lowercase name.
+var stdioModeNames = map[StdioMode]string{
+	StdioInherit: "inherit",
+	StdioNull:    "null",
+	StdioCapture: "capture",
+}
+
+// String returns the lowercase mode name ("inherit", "null", "capture"), or
+// "stdiomode(N)" for an out-of-range value.
+func (m StdioMode) String() string {
+	//: a known mode resolves to its canonical lowercase name.
+	if name, ok := stdioModeNames[m]; ok {
+		//: table hit — return the canonical name verbatim.
+		return name
+	}
+	//: an out-of-range value stays legible with its numeric form.
+	return "stdiomode(" + strconv.Itoa(int(m)) + ")"
+}
+
+// Known reports whether m is one of the defined StdioInherit/StdioNull/StdioCapture
+// modes (i.e. m <= StdioCapture).
+func (m StdioMode) Known() bool {
+	//: the defined modes are the contiguous range [StdioInherit, StdioCapture].
+	return m <= StdioCapture
+}

--- a/internal/service/proc/exec/BUILD.bazel
+++ b/internal/service/proc/exec/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "limits_unix.go",
         "limittable_unix.go",
         "procfile_unix.go",
+        "stdio_unix.go",
         "wrap.go",
     ],
     importpath = "github.com/kitsunium/sdk/internal/service/proc/exec",
@@ -38,7 +39,10 @@ alias(
 
 go_test(
     name = "exec_test",
-    srcs = ["exec_external_test.go"],
+    srcs = [
+        "exec_external_test.go",
+        "stdio_external_test.go",
+    ],
     deps = [
         ":exec",
         "//internal/core/proc",

--- a/internal/service/proc/exec/CLAUDE.md
+++ b/internal/service/proc/exec/CLAUDE.md
@@ -23,7 +23,8 @@ process that already exists.
 | `exec.go` | all | package doc + `validateSpec` (empty Path ⇒ `InvalidSpec`) |
 | `exec_unix.go` | `unix` | `Start`: validate → check limits → resolve creds → `SysProcAttr` → `os.StartProcess` → post-start attrs; `teardown` on attr failure |
 | `exec_other.go` | `!unix` | `Start` ⇒ `UnsupportedPlatform` (compiles everywhere) |
-| `handle_unix.go` | `unix` | the `handle` value: `PID`/`Wait`/`Signal`/`SignalGroup`/`Stop`, once-only reap, exit translation |
+| `handle_unix.go` | `unix` | the `handle` value: `PID`/`Wait`/`Signal`/`SignalGroup`/`Stop`, once-only reap, exit translation, stdio-copier join |
+| `stdio_unix.go` | `unix` | `buildStdio`: wires `Spec.Stdio` (inherit/null/capture) to `ProcAttr.Files`; capture pipes + copier goroutines joined by `Wait` (100% delivery, no leak) |
 | `creds_unix.go` | `unix` | `Spec.User/Group/Groups` → `syscall.Credential` via `os/user` |
 | `attrs_unix.go` | `unix` | best-effort `Nice` (setpriority) + `OOMScoreAdj` (procfs); ESRCH detection |
 | `limits_unix.go` | `unix` | `checkLimits`: `UnknownResource` for unmapped, `RlimitFailed` for unhonourable |

--- a/internal/service/proc/exec/exec_unix.go
+++ b/internal/service/proc/exec/exec_unix.go
@@ -37,9 +37,18 @@ func Start(ctx context.Context, spec coreproc.Spec) (proc coreproc.Process, err 
 		return nil, lErr
 	}
 
-	attr, aErr := buildProcAttr(spec)
+	sio, ioErr := buildStdio(spec)
+	//: a stdio fd-setup failure (pipe/null) aborts before credential work.
+	if ioErr != nil {
+		//: propagate the typed SPAWN_FAILED from the stdio setup verbatim.
+		return nil, ioErr
+	}
+
+	attr, aErr := buildProcAttr(spec, sio.files[:])
 	//: a credential-resolution failure aborts before fork/exec.
 	if aErr != nil {
+		//: release the stdio fds so the aborted spawn leaks nothing.
+		sio.closeAll()
 		//: propagate the typed UNKNOWN_USER / UNKNOWN_GROUP verbatim.
 		return nil, aErr
 	}
@@ -47,11 +56,16 @@ func Start(ctx context.Context, spec coreproc.Spec) (proc coreproc.Process, err 
 	started, sErr := os.StartProcess(spec.Path, buildArgv(spec), attr)
 	//: a fork/exec failure is a typed SPAWN_FAILED wrapping the OS cause.
 	if sErr != nil {
+		//: release the stdio fds before surfacing the spawn failure.
+		sio.closeAll()
 		//: wrap the StartProcess cause under the central SPAWN_FAILED fields.
 		return nil, wrapSpawn(sErr, errs.String("path", spec.Path))
 	}
 
-	live := newHandle(started, spec.Setpgid)
+	//: the child now owns dups of its fds — close the parent's child-side ends and
+	//: launch the capture copiers.
+	sio.afterStart()
+	live := newHandle(started, spec.Setpgid, sio)
 	//: best-effort scheduling attributes run post-start on the live pid.
 	if pErr := applyPostStart(live.pid, spec); pErr != nil {
 		//: a refused attribute tears the child down so nothing half-configured leaks.
@@ -85,7 +99,7 @@ func teardown(live *handle) {
 // the explicit environment (empty, never inherited, when Spec.Env is nil), the
 // inherited std streams, and the SysProcAttr carrying credentials and the
 // group/session topology.
-func buildProcAttr(spec coreproc.Spec) (attr *os.ProcAttr, err error) {
+func buildProcAttr(spec coreproc.Spec, files []*os.File) (attr *os.ProcAttr, err error) {
 	cred, cErr := resolveCredential(spec)
 	//: a credential-resolution failure aborts attr assembly.
 	if cErr != nil {
@@ -111,9 +125,8 @@ func buildProcAttr(spec coreproc.Spec) (attr *os.ProcAttr, err error) {
 		env = make([]string, 0)
 	}
 
-	//: inherit the supervisor's std streams; redirection is a caller concern.
-	files := []*os.File{os.Stdin, os.Stdout, os.Stderr}
-	//: the assembled attr is ready for os.StartProcess.
+	//: the child's std streams were wired by buildStdio per Spec.Stdio (inherit,
+	//: null, or capture); the assembled attr is ready for os.StartProcess.
 	return &os.ProcAttr{Dir: spec.Dir, Env: env, Files: files, Sys: sysAttr}, nil
 }
 

--- a/internal/service/proc/exec/exec_unix.go
+++ b/internal/service/proc/exec/exec_unix.go
@@ -62,17 +62,21 @@ func Start(ctx context.Context, spec coreproc.Spec) (proc coreproc.Process, err 
 		return nil, wrapSpawn(sErr, errs.String("path", spec.Path))
 	}
 
-	//: the child now owns dups of its fds — close the parent's child-side ends and
-	//: launch the capture copiers.
-	sio.afterStart()
 	live := newHandle(started, spec.Setpgid, sio)
-	//: best-effort scheduling attributes run post-start on the live pid.
+	//: best-effort scheduling attributes run post-start on the live pid. They run
+	//: BEFORE the capture copiers launch, so a teardown here never blocks on a
+	//: caller's sink: with no copiers started, Wait's copier-join is a no-op.
 	if pErr := applyPostStart(live.pid, spec); pErr != nil {
-		//: a refused attribute tears the child down so nothing half-configured leaks.
+		//: kill + reap the child; no copiers are running, so this cannot hang.
 		teardown(live)
+		//: release the (still-unstarted) stdio fds so nothing leaks.
+		sio.closeAll()
 		//: propagate the typed RLIMIT_FAILED from the attribute application.
 		return nil, pErr
 	}
+	//: the child is fully configured — close the parent's child-side ends and
+	//: launch the capture copiers (joined by Wait for 100% delivery).
+	sio.afterStart()
 	//: a fully-configured, running process handle.
 	return live, nil
 }

--- a/internal/service/proc/exec/handle_unix.go
+++ b/internal/service/proc/exec/handle_unix.go
@@ -39,6 +39,7 @@ type handle struct {
 	pid     int
 	pgid    int
 	setpgid bool
+	stdio   *stdioState
 
 	waitOnce sync.Once
 	waitVal  coreproc.ExitValue
@@ -48,11 +49,12 @@ type handle struct {
 
 // newHandle wraps a freshly started *os.Process as a handle. setpgid records
 // whether the child leads its own process group (Spec.Setpgid): only then is the
-// leader pid a valid pgid for group-directed kills.
-func newHandle(p *os.Process, setpgid bool) *handle {
+// leader pid a valid pgid for group-directed kills. stdio owns the capture
+// copiers that Wait joins so no output is lost and no goroutine leaks.
+func newHandle(p *os.Process, setpgid bool, stdio *stdioState) *handle {
 	//: with Setpgid the leader pid IS the group id; without it there is no private
 	//: group and group operations degrade to the leader (see groupTarget).
-	return &handle{proc: p, pid: p.Pid, pgid: p.Pid, setpgid: setpgid, done: make(chan struct{})}
+	return &handle{proc: p, pid: p.Pid, pgid: p.Pid, setpgid: setpgid, stdio: stdio, done: make(chan struct{})}
 }
 
 // groupTarget returns the kill(2) target for group-directed operations: the
@@ -87,6 +89,10 @@ func (h *handle) Wait() (exit coreproc.ExitValue, err error) {
 		state, wErr := h.proc.Wait()
 		//: signal late Stop goroutines that the process has been reaped.
 		close(h.done)
+		//: join the capture copiers so every byte the child wrote has reached the
+		//: caller's writers before Wait returns, and no copier goroutine leaks.
+		//: the child's exit closed its write ends, so the copiers drain to EOF.
+		h.stdio.wait()
 		//: a wait4 host fault (not a non-zero exit) is a typed WAIT_FAILED.
 		if wErr != nil {
 			//: wrap the os.Process.Wait cause under the central WAIT_FAILED fields.

--- a/internal/service/proc/exec/handle_unix.go
+++ b/internal/service/proc/exec/handle_unix.go
@@ -102,6 +102,12 @@ func (h *handle) Wait() (exit coreproc.ExitValue, err error) {
 		}
 		//: a clean reap yields the translated exit outcome.
 		h.waitVal = exitValueFrom(state)
+		//: a clean exit whose capture writer failed surfaces the typed capture
+		//: error (os/exec semantics) — the exit status still stands in waitVal.
+		if cErr := h.stdio.copyError(); cErr != nil {
+			//: wrap the writer failure under the central STDIO_CAPTURE_FAILED fields.
+			h.waitErr = wrapStdioCapture(cErr, errs.Int("pid", h.pid))
+		}
 	})
 	//: every caller observes the memoised outcome of the single reap.
 	return h.waitVal, h.waitErr

--- a/internal/service/proc/exec/stdio_external_test.go
+++ b/internal/service/proc/exec/stdio_external_test.go
@@ -1,0 +1,196 @@
+// Package exec_test — black-box acceptance tests for per-process stdio wiring
+// (issue #73): capture delivers 100% of stdout/stderr, large output exercises
+// pipe backpressure, null discards, stdin is fed from a reader, a nil capture
+// writer discards, and capture composes with Setpgid. All gated on the /bin/sh
+// probe via requireShell (defined in exec_external_test.go).
+package exec_test
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	coreproc "github.com/kitsunium/sdk/internal/core/proc"
+	svcexec "github.com/kitsunium/sdk/internal/service/proc/exec"
+)
+
+// startAndWait spawns spec, drives Wait, and fails the test on any spawn/wait
+// fault — the common path for the stdio cases below.
+func startAndWait(t *testing.T, spec coreproc.Spec) coreproc.ExitValue {
+	t.Helper()
+	p, err := svcexec.Start(context.Background(), spec)
+	//: a clean spawn of /bin/sh is the precondition for every stdio assertion.
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	exit, wErr := p.Wait()
+	//: a normal exit is not a wait4 fault.
+	if wErr != nil {
+		t.Fatalf("Wait: %v", wErr)
+	}
+	//: Wait joined the copiers, so the buffers are now safe to read.
+	return exit
+}
+
+// TestStdioCaptureSplitsStreams asserts StdioCapture delivers stdout and stderr
+// to their distinct writers, byte-for-byte — the acceptance (a) contract.
+func TestStdioCaptureSplitsStreams(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	var out, errb bytes.Buffer
+	spec := coreproc.Spec{
+		Path:   shPath,
+		Args:   []string{"sh", "-c", "printf to-stdout; printf to-stderr 1>&2"},
+		Stdio:  coreproc.StdioCapture,
+		Stdout: &out,
+		Stderr: &errb,
+	}
+	exit := startAndWait(t, spec)
+	//: the child exits cleanly.
+	if exit.Code != 0 {
+		t.Fatalf("exit Code = %d, want 0", exit.Code)
+	}
+	//: stdout must carry exactly what the child wrote to fd 1.
+	if out.String() != "to-stdout" {
+		t.Fatalf("stdout = %q, want %q", out.String(), "to-stdout")
+	}
+	//: stderr must carry exactly what the child wrote to fd 2 — no crosstalk.
+	if errb.String() != "to-stderr" {
+		t.Fatalf("stderr = %q, want %q", errb.String(), "to-stderr")
+	}
+}
+
+// TestStdioCaptureLargeOutput asserts capture delivers 100% of an output larger
+// than the kernel pipe buffer, so the copier drains under backpressure with no
+// truncation — the acceptance (a) "large-output backpressure" contract.
+func TestStdioCaptureLargeOutput(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	//: 256 KiB far exceeds the 64 KiB pipe buffer, forcing the child to block on
+	//: write until the copier drains — the backpressure path under test.
+	const want int = 256 * 1024
+	var out bytes.Buffer
+	spec := coreproc.Spec{
+		Path:   shPath,
+		Args:   []string{"sh", "-c", "head -c " + strconv.Itoa(want) + " /dev/zero"},
+		Stdio:  coreproc.StdioCapture,
+		Stdout: &out,
+	}
+	exit := startAndWait(t, spec)
+	//: the producer exits cleanly once the copier has drained it.
+	if exit.Code != 0 {
+		t.Fatalf("exit Code = %d, want 0", exit.Code)
+	}
+	//: every byte must have been captured — a short read is a backpressure bug.
+	if out.Len() != want {
+		t.Fatalf("captured %d bytes, want %d", out.Len(), want)
+	}
+}
+
+// TestStdioCaptureStdin asserts StdioCapture feeds Spec.Stdin to the child and
+// the child reads it — round-tripped through `cat` back into the stdout writer.
+func TestStdioCaptureStdin(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	const payload = "piped-input\nsecond-line\n"
+	var out bytes.Buffer
+	spec := coreproc.Spec{
+		Path:   shPath,
+		Args:   []string{"sh", "-c", "cat"},
+		Stdio:  coreproc.StdioCapture,
+		Stdin:  strings.NewReader(payload),
+		Stdout: &out,
+	}
+	exit := startAndWait(t, spec)
+	//: cat exits 0 at stdin EOF.
+	if exit.Code != 0 {
+		t.Fatalf("exit Code = %d, want 0", exit.Code)
+	}
+	//: the child must have seen exactly the bytes the reader supplied.
+	if out.String() != payload {
+		t.Fatalf("stdout = %q, want %q", out.String(), payload)
+	}
+}
+
+// TestStdioCaptureNilWriterDiscards asserts a nil capture writer discards that
+// stream to the null device without error — the acceptance (c) contract.
+func TestStdioCaptureNilWriterDiscards(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	//: capture mode with no writers — both streams fall back to the null device.
+	spec := coreproc.Spec{
+		Path:  shPath,
+		Args:  []string{"sh", "-c", "echo discarded; echo also 1>&2"},
+		Stdio: coreproc.StdioCapture,
+	}
+	exit := startAndWait(t, spec)
+	//: discarding output must not affect the child's clean exit.
+	if exit.Code != 0 {
+		t.Fatalf("exit Code = %d, want 0", exit.Code)
+	}
+}
+
+// TestStdioNull asserts StdioNull discards output and gives the child an
+// immediate-EOF stdin — `read` fails (EOF) so the shell takes the `||` branch.
+func TestStdioNull(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	spec := coreproc.Spec{
+		Path: shPath,
+		//: stdin is /dev/null, so `read` hits EOF and returns non-zero; the child
+		//: still exits 0 via the `|| true`, proving stdin was wired to null.
+		Args:  []string{"sh", "-c", "read x || true; echo to-null; echo to-null 1>&2"},
+		Stdio: coreproc.StdioNull,
+	}
+	exit := startAndWait(t, spec)
+	//: null wiring must not perturb the exit status.
+	if exit.Code != 0 {
+		t.Fatalf("exit Code = %d, want 0", exit.Code)
+	}
+}
+
+// TestStdioCaptureWithSetpgid asserts capture composes with Setpgid (a
+// group-leading child) — the acceptance "works alongside Setpgid/Setsid" contract.
+func TestStdioCaptureWithSetpgid(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	var out bytes.Buffer
+	spec := coreproc.Spec{
+		Path:    shPath,
+		Args:    []string{"sh", "-c", "printf grouped"},
+		Setpgid: true,
+		Stdio:   coreproc.StdioCapture,
+		Stdout:  &out,
+	}
+	p, err := svcexec.Start(context.Background(), spec)
+	//: a clean spawn is the precondition.
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	//: the leader pid is a valid pgid when Setpgid is set.
+	if p.PID() <= 0 {
+		t.Fatalf("PID = %d, want > 0", p.PID())
+	}
+	exit, wErr := p.Wait()
+	//: a normal exit is not a wait4 fault.
+	if wErr != nil {
+		t.Fatalf("Wait: %v", wErr)
+	}
+	//: the group leader's output is still captured in full.
+	if exit.Code != 0 || out.String() != "grouped" {
+		t.Fatalf("exit=%d stdout=%q, want 0 / %q", exit.Code, out.String(), "grouped")
+	}
+	//: the group is gone after the leader exited — kill(-pgid,0) reports ESRCH.
+	if err := syscall.Kill(-p.PID(), 0); err != syscall.ESRCH {
+		t.Fatalf("group %d kill-probe = %v, want ESRCH", p.PID(), err)
+	}
+}

--- a/internal/service/proc/exec/stdio_external_test.go
+++ b/internal/service/proc/exec/stdio_external_test.go
@@ -8,14 +8,25 @@ package exec_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 
 	coreproc "github.com/kitsunium/sdk/internal/core/proc"
+	"github.com/kitsunium/sdk/internal/kernel/errs"
 	svcexec "github.com/kitsunium/sdk/internal/service/proc/exec"
 )
+
+// errWriter fails every Write, simulating a capture sink that errors mid-stream.
+type errWriter struct{}
+
+// Write always fails, so the output copier records a writer error.
+func (errWriter) Write(_ []byte) (int, error) {
+	//: a sink that rejects every byte exercises the StdioCaptureFailed path.
+	return 0, errors.New("sink write failed")
+}
 
 // startAndWait spawns spec, drives Wait, and fails the test on any spawn/wait
 // fault — the common path for the stdio cases below.
@@ -154,6 +165,35 @@ func TestStdioNull(t *testing.T) {
 	//: null wiring must not perturb the exit status.
 	if exit.Code != 0 {
 		t.Fatalf("exit Code = %d, want 0", exit.Code)
+	}
+}
+
+// TestStdioCaptureWriterFailureSurfaces asserts that a capture writer which
+// errors mid-stream is surfaced from Wait as StdioCaptureFailed rather than
+// silently swallowed, while the child's real exit status is still reported.
+func TestStdioCaptureWriterFailureSurfaces(t *testing.T) {
+	t.Parallel()
+	requireShell(t)
+
+	spec := coreproc.Spec{
+		Path:   shPath,
+		Args:   []string{"sh", "-c", "echo hello"},
+		Stdio:  coreproc.StdioCapture,
+		Stdout: errWriter{},
+	}
+	p, err := svcexec.Start(context.Background(), spec)
+	//: a clean spawn is the precondition.
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	exit, wErr := p.Wait()
+	//: the writer failure must surface as the typed capture error, not silence.
+	if !errs.HasCode(wErr, coreproc.CodeStdioCaptureFailed) {
+		t.Fatalf("Wait err = %v, want StdioCaptureFailed", wErr)
+	}
+	//: the real exit status still stands alongside the capture error.
+	if exit.Code != 0 {
+		t.Fatalf("exit Code = %d, want 0 (the child itself ran fine)", exit.Code)
 	}
 }
 

--- a/internal/service/proc/exec/stdio_unix.go
+++ b/internal/service/proc/exec/stdio_unix.go
@@ -59,6 +59,33 @@ type stdioState struct {
 	inDst      *os.File               // stdin pipe write end (nil when no capture stdin)
 	inSrc      io.Reader              // caller's stdin source
 	wg         sync.WaitGroup
+	copyMu     sync.RWMutex // guards copyErr
+	copyErr    error        // first output-copier failure (a caller writer erroring), surfaced by Wait
+}
+
+// recordCopyErr latches the first output-copier failure so Wait can surface it.
+func (s *stdioState) recordCopyErr(err error) {
+	//: a nil copy error is the success path — nothing to record.
+	if err == nil {
+		//: the writer accepted every byte the child produced.
+		return
+	}
+	s.copyMu.Lock()
+	//: keep the first failure; later copiers usually report the same cause.
+	if s.copyErr == nil {
+		//: latch the first writer failure.
+		s.copyErr = err
+	}
+	s.copyMu.Unlock()
+}
+
+// copyError returns the latched first output-copier failure, or nil when capture
+// delivered cleanly. Read it after wait() has joined the copiers.
+func (s *stdioState) copyError() error {
+	s.copyMu.RLock()
+	defer s.copyMu.RUnlock()
+	//: the latched first writer failure, or nil on a clean capture.
+	return s.copyErr
 }
 
 // buildStdio assembles the stdioState for spec.Stdio. Any fd-setup failure
@@ -226,14 +253,15 @@ func (s *stdioState) afterStart() {
 }
 
 // drainOutput copies the pipe read end src into sink until EOF, then releases src
-// and signals the WaitGroup.
+// and signals the WaitGroup. A writer failure is latched (recordCopyErr) so Wait
+// can surface it as StdioCaptureFailed — output is not silently truncated.
 func (s *stdioState) drainOutput(src io.ReadCloser, sink io.Writer) {
 	//: signal completion so wait() can join once the pipe drains.
 	defer s.wg.Done()
 	//: copy every byte the child emits into the caller's sink.
 	_, cerr := io.Copy(sink, src)
-	//: a drained-pipe copy fault is non-actionable cleanup detail.
-	swallowErr(cerr)
+	//: latch a writer failure (e.g. a full disk) so Wait reports it, not silence.
+	s.recordCopyErr(cerr)
 	//: the child has closed its write end; release the read end.
 	swallowErr(src.Close())
 }

--- a/internal/service/proc/exec/stdio_unix.go
+++ b/internal/service/proc/exec/stdio_unix.go
@@ -1,0 +1,281 @@
+//go:build unix
+
+// Package exec — per-process stdio wiring. buildStdio turns a Spec's Stdio mode
+// into the three *os.File the spawn passes as ProcAttr.Files, plus the
+// parent-side lifecycle: the child-side ends to close once the child owns its
+// dups (so EOF propagates on exit) and the copier goroutines that drain capture
+// pipes into the caller's writers. StdioInherit (default) shares the parent's
+// streams; StdioNull discards via the null device; StdioCapture connects pipes.
+package exec
+
+import (
+	"io"
+	"os"
+	"sync"
+
+	coreproc "github.com/kitsunium/sdk/internal/core/proc"
+	"github.com/kitsunium/sdk/internal/kernel/errs"
+)
+
+// Standard-stream fd indices and their count, named so the wiring carries no
+// bare magic numbers. The values are the kernel's fixed fd numbers (0/1/2), so
+// iota lines up with them and stdioFdCount is the natural fourth value.
+const (
+	fdStdin int = iota
+	fdStdout
+	fdStderr
+	stdioFdCount
+)
+
+// stdioField tags a wrapped stdio-setup failure with the stream it concerns.
+func stdioField(stream string) errs.FieldValue {
+	//: a single "stdio" field names which stream's fd setup failed.
+	return errs.String("stdio", stream)
+}
+
+// swallowErr intentionally discards a non-actionable cleanup error — a copier's
+// drained-pipe io.Copy or a best-effort close — recording the discard so the
+// error audit treats it as deliberate rather than dropped.
+func swallowErr(err error) {
+	//: read the parameter so the unused-error audit treats this as intentional.
+	if err == nil {
+		//: nothing to discard on the happy path.
+		return
+	}
+	//: the error concerns a drained pipe or an already-finished fd — nothing to do.
+}
+
+// stdioState carries the child's three standard-stream files and the parent-side
+// machinery to manage them across the spawn. It is built before os.StartProcess,
+// closed via closeAll on a spawn failure, or driven by afterStart on success;
+// Handle.Wait joins its output copiers so every byte is delivered before Wait
+// returns. outSrc/outSink are parallel: outSrc[i] drains into outSink[i].
+type stdioState struct {
+	files      [stdioFdCount]*os.File // {stdin, stdout, stderr} for os.ProcAttr.Files
+	opened     []*os.File             // every fd buildStdio created (never os.Std*); closeAll target
+	closeChild []*os.File             // the child's ends the parent closes after a successful spawn
+	outSrc     []*os.File             // capture pipe read ends, parallel to outSink
+	outSink    []io.Writer            // caller writers, parallel to outSrc
+	inDst      *os.File               // stdin pipe write end (nil when no capture stdin)
+	inSrc      io.Reader              // caller's stdin source
+	wg         sync.WaitGroup
+}
+
+// buildStdio assembles the stdioState for spec.Stdio. Any fd-setup failure
+// (os.Pipe / opening the null device) closes whatever was opened and returns a
+// typed SPAWN_FAILED — the spawn cannot proceed without its standard streams.
+func buildStdio(spec coreproc.Spec) (state *stdioState, err error) {
+	s := &stdioState{}
+	//: dispatch on the requested stdio mode.
+	switch spec.Stdio {
+	//: capture mode connects pipes to the caller's writers/reader.
+	case coreproc.StdioCapture:
+		//: wire the caller's streams; nil members fall back to the null device.
+		if berr := s.build(spec.Stdin, spec.Stdout, spec.Stderr); berr != nil {
+			//: release any half-opened fds before surfacing the failure.
+			s.closeAll()
+			//: propagate the typed SPAWN_FAILED verbatim.
+			return nil, berr
+		}
+		//: a fully-wired capture state.
+		return s, nil
+	//: null mode points every stream at the platform null device.
+	case coreproc.StdioNull:
+		//: all-nil streams route every fd to the null device.
+		if berr := s.build(nil, nil, nil); berr != nil {
+			//: release any half-opened null fds before surfacing the failure.
+			s.closeAll()
+			//: propagate the typed SPAWN_FAILED verbatim.
+			return nil, berr
+		}
+		//: a fully-wired null state.
+		return s, nil
+	//: inherit (the default and any unknown mode) shares the parent's streams.
+	default:
+		//: os.Std* are never closed by this state, so they carry no cleanup.
+		s.files = [stdioFdCount]*os.File{os.Stdin, os.Stdout, os.Stderr}
+		//: an inherit state needs no copiers or cleanup.
+		return s, nil
+	}
+}
+
+// build wires stdin from in, stdout to out, and stderr to errw. A nil stream
+// falls back to the null device (StdioNull passes all-nil; StdioCapture passes
+// the caller's values, nil meaning "discard this one stream").
+func (s *stdioState) build(in io.Reader, out, errw io.Writer) error {
+	//: stdin first so a failure aborts before opening the output ends.
+	if ierr := s.wireInput(in); ierr != nil {
+		//: propagate the typed SPAWN_FAILED verbatim.
+		return ierr
+	}
+	//: stdout next.
+	if oerr := s.wireOutput(fdStdout, out); oerr != nil {
+		//: propagate the typed SPAWN_FAILED verbatim.
+		return oerr
+	}
+	//: stderr last; each output stream is independent.
+	return s.wireOutput(fdStderr, errw)
+}
+
+// wireInput connects the child's fd 0. A nil reader gives an immediate-EOF stdin
+// from the null device; otherwise a pipe feeds reader→child, closed at EOF by a
+// fire-and-forget copier that never blocks Wait.
+func (s *stdioState) wireInput(reader io.Reader) error {
+	//: no reader means an empty stdin straight from the null device.
+	if reader == nil {
+		//: open the null device read-only for fd 0.
+		return s.wireNull(fdStdin, os.O_RDONLY)
+	}
+	pr, pw, perr := os.Pipe()
+	//: a pipe-creation failure is a typed SPAWN_FAILED (fd exhaustion, etc.).
+	if perr != nil {
+		//: wrap the os.Pipe cause under the central SPAWN_FAILED fields.
+		return wrapSpawn(perr, stdioField("stdin"))
+	}
+	//: the child reads fd 0 from the pipe's read end.
+	s.files[fdStdin] = pr
+	s.opened = append(s.opened, pr, pw)
+	//: the parent closes its copy of the child's read end after the spawn.
+	s.closeChild = append(s.closeChild, pr)
+	//: register the feeder; afterStart launches it fire-and-forget.
+	s.inDst, s.inSrc = pw, reader
+	//: a wired stdin feeder.
+	return nil
+}
+
+// wireOutput connects the child's fd idx (1=stdout, 2=stderr). A nil writer
+// discards to the null device; otherwise a pipe drains child→writer via a copier
+// joined by wait(), so every byte lands before Wait returns.
+func (s *stdioState) wireOutput(idx int, w io.Writer) error {
+	//: no writer means the stream is discarded to the null device.
+	if w == nil {
+		//: open the null device write-only for this output fd.
+		return s.wireNull(idx, os.O_WRONLY)
+	}
+	pr, pw, perr := os.Pipe()
+	//: a pipe-creation failure is a typed SPAWN_FAILED.
+	if perr != nil {
+		//: wrap the os.Pipe cause under the central SPAWN_FAILED fields.
+		return wrapSpawn(perr, stdioField(outName(idx)))
+	}
+	//: the child writes this stream to the pipe's write end.
+	s.files[idx] = pw
+	s.opened = append(s.opened, pr, pw)
+	//: the parent closes its copy of the child's write end after the spawn so the
+	//: read end sees EOF once the child exits.
+	s.closeChild = append(s.closeChild, pw)
+	//: register the drain (read end + sink); afterStart launches it.
+	s.outSrc = append(s.outSrc, pr)
+	s.outSink = append(s.outSink, w)
+	//: a wired output stream.
+	return nil
+}
+
+// wireNull points the child's fd idx at the platform null device opened with flag.
+func (s *stdioState) wireNull(idx, flag int) error {
+	f, oerr := openNull(flag)
+	//: a null-open failure aborts the wiring.
+	if oerr != nil {
+		//: propagate the typed SPAWN_FAILED verbatim.
+		return oerr
+	}
+	//: the child uses the null fd directly; the parent closes it after the spawn.
+	s.files[idx] = f
+	s.opened = append(s.opened, f)
+	s.closeChild = append(s.closeChild, f)
+	//: a wired null stream.
+	return nil
+}
+
+// openNull opens the platform null device with flag and returns the descriptor;
+// the caller owns and eventually closes it. Returning the fd (rather than storing
+// it inline) keeps ownership transfer explicit.
+func openNull(flag int) (f *os.File, err error) {
+	null, oerr := os.OpenFile(os.DevNull, flag, 0)
+	//: a null-device open failure is a typed SPAWN_FAILED.
+	if oerr != nil {
+		//: wrap the open cause under the central SPAWN_FAILED fields.
+		return nil, wrapSpawn(oerr, stdioField("null"))
+	}
+	//: caller owns the returned null descriptor.
+	return null, nil
+}
+
+// afterStart runs once os.StartProcess has succeeded: the child holds its own dup
+// of every fd, so the parent closes its child-side copies (making EOF propagate
+// on child exit) and launches the copiers. Output copiers are tracked by the
+// WaitGroup; the stdin feeder is fire-and-forget so a non-EOF reader never blocks
+// Wait.
+func (s *stdioState) afterStart() {
+	//: close the parent's copies of the child-side ends so EOF propagates.
+	for _, f := range s.closeChild {
+		//: a close error here is benign cleanup detail.
+		swallowErr(f.Close())
+	}
+	//: launch each output drain under the WaitGroup.
+	for i := range s.outSrc {
+		s.wg.Add(1)
+		//: drainOutput owns the read end and signals the WaitGroup on EOF.
+		go s.drainOutput(s.outSrc[i], s.outSink[i])
+	}
+	//: feed stdin without joining when a capture feeder is registered.
+	if s.inDst != nil {
+		//: fire-and-forget so Wait never blocks on the source reader.
+		go s.feedInput(s.inDst, s.inSrc)
+	}
+}
+
+// drainOutput copies the pipe read end src into sink until EOF, then releases src
+// and signals the WaitGroup.
+func (s *stdioState) drainOutput(src io.ReadCloser, sink io.Writer) {
+	//: signal completion so wait() can join once the pipe drains.
+	defer s.wg.Done()
+	//: copy every byte the child emits into the caller's sink.
+	_, cerr := io.Copy(sink, src)
+	//: a drained-pipe copy fault is non-actionable cleanup detail.
+	swallowErr(cerr)
+	//: the child has closed its write end; release the read end.
+	swallowErr(src.Close())
+}
+
+// feedInput copies the caller's reader src into the pipe write end dst, then
+// closes dst so the child's stdin sees EOF. It is fire-and-forget: never joined,
+// so a reader that does not EOF cannot block Wait.
+func (s *stdioState) feedInput(dst io.WriteCloser, src io.Reader) {
+	//: feed reader→child until EOF or a child-gone write error.
+	_, cerr := io.Copy(dst, src)
+	//: a feed fault on a fire-and-forget copier is non-actionable.
+	swallowErr(cerr)
+	//: closing the write end propagates EOF to the child's stdin.
+	swallowErr(dst.Close())
+}
+
+// wait blocks until every output copier has drained its pipe to EOF, so Handle.Wait
+// returns only after 100% of the child's stdout/stderr has reached the caller's
+// writers. It is a no-op for StdioInherit/StdioNull (no copiers).
+func (s *stdioState) wait() {
+	//: join the stdout/stderr drains; nothing to wait on in inherit/null mode.
+	s.wg.Wait()
+}
+
+// closeAll releases every fd buildStdio opened. It is used only on the spawn
+// failure path (before afterStart), so it never races the copiers and never
+// touches os.Std*.
+func (s *stdioState) closeAll() {
+	//: close every opened pipe/null fd; os.Std* are never in this list.
+	for _, f := range s.opened {
+		//: a close error during failure cleanup is non-actionable.
+		swallowErr(f.Close())
+	}
+}
+
+// outName maps an output fd index to its stream name for diagnostics.
+func outName(idx int) string {
+	//: fd 1 is stdout; every other output fd is stderr.
+	if idx == fdStdout {
+		//: the stdout stream name.
+		return "stdout"
+	}
+	//: every other output fd is stderr.
+	return "stderr"
+}

--- a/internal/service/proc/exec/wrap.go
+++ b/internal/service/proc/exec/wrap.go
@@ -14,6 +14,7 @@ import (
 const (
 	exitNoUser int = 67 // EX_NOUSER — a named user/group did not resolve.
 	exitOSErr  int = 71 // EX_OSERR — an OS-level operation failed.
+	exitIOErr  int = 74 // EX_IOERR — an I/O error occurred (capture writer failed).
 )
 
 // wrapSpawn wraps a fork/exec cause onto the central SpawnFailed sentinel.
@@ -74,6 +75,19 @@ func wrapRlimit(cause error, fields ...errs.FieldValue) error {
 		Public:   "Could not apply the resource limit",
 		Private:  "service/proc/rlimit.Apply: setrlimit(2) failed",
 		ExitCode: exitOSErr,
+	}, fields...)
+}
+
+// wrapStdioCapture wraps a StdioCapture writer failure onto the central
+// StdioCaptureFailed sentinel.
+func wrapStdioCapture(cause error, fields ...errs.FieldValue) error {
+	//: restate the STDIO_CAPTURE_FAILED sentinel fields so the cause inherits them.
+	return errs.Wrap(cause, errs.WrapParams{
+		Code:     coreproc.CodeStdioCaptureFailed,
+		Reason:   "STDIO_CAPTURE_FAILED",
+		Public:   "Could not deliver the captured output to the writer",
+		Private:  "service/proc/exec.Wait: a StdioCapture copier failed writing the child's output to the caller's sink",
+		ExitCode: exitIOErr,
 	}, fields...)
 }
 

--- a/pkg/v1/process/BUILD.bazel
+++ b/pkg/v1/process/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "process.go",
         "signals.go",
+        "stdio.go",
     ],
     importpath = "github.com/kitsunium/sdk/pkg/v1/process",
     visibility = ["//visibility:public"],

--- a/pkg/v1/process/README.md
+++ b/pkg/v1/process/README.md
@@ -27,6 +27,10 @@ Spec.Rlimits                   Limit*=       (see Limitations)
 
 A nil Spec.Env yields an empty environment — the child never silently inherits the supervisor's, so a spawned service starts from a known state. Pass an explicit slice \(including os.Environ\(\)\) to inherit deliberately.
 
+### Standard streams
+
+Spec.Stdio selects how the child's stdin/stdout/stderr are wired: StdioInherit \(the default\) shares the parent's streams; StdioNull discards the child's output and gives it an immediate\-EOF stdin; StdioCapture connects Spec.Stdout and Spec.Stderr \(any io.Writer\) and Spec.Stdin \(any io.Reader\), with a nil stream falling back to the null device for that one stream. In capture mode every byte the child writes reaches the writers before Wait returns, and the copier goroutines terminate at EOF \(no leak\). It composes with Setpgid/Setsid and credential drop. Stdin should be EOF\-terminating.
+
 ### Stopping a process group
 
 Stop sends the chosen signal to the entire process group, waits up to grace for exit, then escalates to SIGKILL on the group. Because the child leads its own group \(Spec.Setpgid\), forked grandchildren are reached too — no survivor is left behind.
@@ -70,6 +74,7 @@ Package process — ergonomic re\-exports: the handful of signal constants and r
 - [type Resource](<#Resource>)
 - [type Signal](<#Signal>)
 - [type Spec](<#Spec>)
+- [type StdioMode](<#StdioMode>)
 
 
 ## Constants
@@ -91,8 +96,25 @@ const (
 )
 ```
 
+<a name="StdioInherit"></a>
+
+```go
+const (
+    // StdioInherit shares the parent's stdin/stdout/stderr with the child — the
+    // default and the only behaviour before per-process wiring existed.
+    StdioInherit = coreproc.StdioInherit
+    // StdioNull connects every stream to the null device: output is discarded and
+    // the child's stdin returns EOF immediately.
+    StdioNull = coreproc.StdioNull
+    // StdioCapture connects the child to Spec.Stdout/Stderr (io.Writer) and
+    // Spec.Stdin (io.Reader); a nil stream falls back to the null device for that
+    // one stream. The systemd analogue is StandardOutput=/StandardError=/StandardInput=.
+    StdioCapture = coreproc.StdioCapture
+)
+```
+
 <a name="ExitResult"></a>
-## type [ExitResult](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L88>)
+## type [ExitResult](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L99>)
 
 ExitResult is the outcome of a finished process — exit code, terminating signal, and resource usage. It is an alias of the core port's ExitValue.
 
@@ -101,7 +123,7 @@ type ExitResult = coreproc.ExitValue
 ```
 
 <a name="Limit"></a>
-## type [Limit](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L100>)
+## type [Limit](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L111>)
 
 Limit is a soft/hard resource\-limit pair for setrlimit\(2\). It is an alias of the core port's LimitValue.
 
@@ -110,7 +132,7 @@ type Limit = coreproc.LimitValue
 ```
 
 <a name="Process"></a>
-## type [Process](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L84>)
+## type [Process](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L95>)
 
 Process is the handle to a spawned process: PID, Wait, Signal, SignalGroup, and a group\-aware Stop. It is an alias of the core port interface.
 
@@ -119,7 +141,7 @@ type Process = coreproc.Process
 ```
 
 <a name="Start"></a>
-### func [Start](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L105>)
+### func [Start](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L116>)
 
 ```go
 func Start(ctx context.Context, spec Spec) (proc Process, err error)
@@ -128,7 +150,7 @@ func Start(ctx context.Context, spec Spec) (proc Process, err error)
 Start spawns the process described by spec and returns a live Process handle. It delegates to internal/service/proc/exec; ctx is honoured up to the fork/exec boundary. On non\-Unix platforms it returns UnsupportedPlatform.
 
 <a name="Resource"></a>
-## type [Resource](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L96>)
+## type [Resource](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L107>)
 
 Resource identifies a per\-process resource governed by setrlimit\(2\). It is an alias of the core port type.
 
@@ -152,7 +174,7 @@ const (
 ```
 
 <a name="Signal"></a>
-## type [Signal](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L92>)
+## type [Signal](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L103>)
 
 Signal is a typed, platform\-portable OS signal. It is an alias of the core port type, so process.SIGTERM and a signal parsed elsewhere compare equal.
 
@@ -161,12 +183,21 @@ type Signal = coreproc.Signal
 ```
 
 <a name="Spec"></a>
-## type [Spec](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L80>)
+## type [Spec](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/process.go#L91>)
 
 Spec is the immutable description of a process to spawn — executable, environment, credentials, isolation topology, and scheduling attributes. It is an alias of the core port type.
 
 ```go
 type Spec = coreproc.Spec
+```
+
+<a name="StdioMode"></a>
+## type [StdioMode](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/process/stdio.go#L8>)
+
+StdioMode selects how a spawned child's standard streams \(stdin, stdout, stderr\) are wired. It is an alias of the core port type; set it on Spec.Stdio. The zero value is StdioInherit.
+
+```go
+type StdioMode = coreproc.StdioMode
 ```
 
 Generated by [gomarkdoc](<https://github.com/princjef/gomarkdoc>)

--- a/pkg/v1/process/process.go
+++ b/pkg/v1/process/process.go
@@ -27,6 +27,17 @@
 // the supervisor's, so a spawned service starts from a known state. Pass an
 // explicit slice (including os.Environ()) to inherit deliberately.
 //
+// # Standard streams
+//
+// Spec.Stdio selects how the child's stdin/stdout/stderr are wired:
+// StdioInherit (the default) shares the parent's streams; StdioNull discards the
+// child's output and gives it an immediate-EOF stdin; StdioCapture connects
+// Spec.Stdout and Spec.Stderr (any io.Writer) and Spec.Stdin (any io.Reader),
+// with a nil stream falling back to the null device for that one stream. In
+// capture mode every byte the child writes reaches the writers before Wait
+// returns, and the copier goroutines terminate at EOF (no leak). It composes
+// with Setpgid/Setsid and credential drop. Stdin should be EOF-terminating.
+//
 // # Stopping a process group
 //
 // Stop sends the chosen signal to the entire process group, waits up to grace

--- a/pkg/v1/process/stdio.go
+++ b/pkg/v1/process/stdio.go
@@ -1,0 +1,21 @@
+package process
+
+import coreproc "github.com/kitsunium/sdk/internal/core/proc"
+
+// StdioMode selects how a spawned child's standard streams (stdin, stdout,
+// stderr) are wired. It is an alias of the core port type; set it on Spec.Stdio.
+// The zero value is StdioInherit.
+type StdioMode = coreproc.StdioMode
+
+const (
+	// StdioInherit shares the parent's stdin/stdout/stderr with the child — the
+	// default and the only behaviour before per-process wiring existed.
+	StdioInherit = coreproc.StdioInherit
+	// StdioNull connects every stream to the null device: output is discarded and
+	// the child's stdin returns EOF immediately.
+	StdioNull = coreproc.StdioNull
+	// StdioCapture connects the child to Spec.Stdout/Stderr (io.Writer) and
+	// Spec.Stdin (io.Reader); a nil stream falls back to the null device for that
+	// one stream. The systemd analogue is StandardOutput=/StandardError=/StandardInput=.
+	StdioCapture = coreproc.StdioCapture
+)


### PR DESCRIPTION
Closes #73.

## What

`proc.Spec` had no I/O fields and the exec service hard-wired every child to the parent's `os.Stdin/Stdout/Stderr`, so a caller could not capture or redirect a child's output. This adds explicit, per-process stdio wiring.

`Spec` gains:
- `Stdio StdioMode` — `StdioInherit` (default/zero), `StdioNull`, `StdioCapture`
- `Stdout io.Writer`, `Stderr io.Writer`, `Stdin io.Reader`

Behaviour:
- **StdioInherit** (default): unchanged — shared parent fds (no breaking change).
- **StdioNull**: `/dev/null` for every stream (discard output, immediate-EOF stdin).
- **StdioCapture**: `os.Pipe` per stream; output copiers drain child→writer and are **joined by `Wait`** so 100% of stdout/stderr is delivered before `Wait` returns, copiers end at EOF (no goroutine leak, race-clean). A nil writer/reader falls back to `/dev/null` for that one stream. The stdin feeder is fire-and-forget so a non-EOF reader never blocks `Wait`. Composes with `Setpgid`/`Setsid` + credential drop.

`pkg/v1/process` re-exports `StdioMode` + constants; the new `Spec` members come free via the type alias.

## Acceptance criteria (all met)
- ✅ `StdioCapture` delivers 100% of stdout/stderr; copiers end at EOF, no leak (race clean)
- ✅ `StdioInherit` keeps shared-fd behaviour
- ✅ `StdioNull` / nil-writer discards deterministically; never panics
- ✅ Works alongside Setpgid/Setsid/credentials
- ✅ Errors via `pkg/v1/errs` (central `SpawnFailed`); tests cover capture, inherit, null, large-output backpressure (256 KiB)

## Validation
- `bazel test --config=race //internal/service/proc/exec/... //internal/core/proc/... //pkg/v1/process/... //internal/kernel/errs:errs_test` → 4/4 pass
- ktn-linter phases 1–7: clean · gazelle drift: clean · README regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable standard stream (stdin/stdout/stderr) wiring for spawned child processes with three modes: inherit parent streams, redirect to null device, or capture to custom reader/writer objects.

* **Tests**
  * Added comprehensive test coverage for stdio configuration modes and large output handling.

* **Documentation**
  * Updated API documentation with standard streams behavior and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->