### PR TITLE
feat(proc): cgroup Group.Kill()/Freeze()/Thaw() — escape-proof tree control (#74)

### DIFF
--- a/internal/core/proc/CLAUDE.md
+++ b/internal/core/proc/CLAUDE.md
@@ -30,7 +30,7 @@ Code range: `0.2.6.*` (ADR 0016).
 | `notification.go` | `NotificationValue` — parsed sd_notify datagram; `Ready`/`Reloading`/`Stopping`/`Watchdog` read `State` |
 | `process.go` | `Process` interface — `PID` / `Wait` / `Signal` / `SignalGroup` / `Stop` |
 | `reaper.go` | `Reaper` interface — `Start` / `Stop` / `ReapOnce` |
-| `group.go` | `Group` interface — cgroup v2 `SetMemoryMax` / `SetCPUMax` / `SetPidsMax` / `SetIOMax` / `Add` / `Delete` |
+| `group.go` | `Group` interface — cgroup v2 `SetMemoryMax` / `SetCPUMax` / `SetPidsMax` / `SetIOMax` / `Add` / `Kill` / `Freeze` / `Thaw` / `Delete` |
 | `listener.go` | `Listener` interface — sd_notify supervisor side `Recv` / `Close` |
 | `codes.go` | `Code*` constants — range `0.2.6.*` |
 | `errors.go` | the 22 domain sentinels (`UnsupportedPlatform` … `CredentialMismatch`) |

--- a/internal/core/proc/group.go
+++ b/internal/core/proc/group.go
@@ -20,6 +20,19 @@ type Group interface {
 	SetIOMax(spec string) error
 	// Add moves the process pid into this group by writing cgroup.procs.
 	Add(pid int) error
+	// Kill atomically SIGKILLs every process in the group by writing "1" to
+	// cgroup.kill (systemd KillMode=control-group; kernel >= 5.14). Unlike a
+	// process-group kill, nothing escapes — a member that called setsid is still
+	// in the control group. Returns UnsupportedPlatform when cgroup.kill is absent
+	// (older kernels), so callers can fall back to SignalGroup.
+	Kill() error
+	// Freeze quiesces the whole group by writing "1" to cgroup.freeze (kernel
+	// >= 5.2), stopping every member so a consistent signal sweep or snapshot can
+	// run. Returns UnsupportedPlatform when cgroup.freeze is absent. Idempotent.
+	Freeze() error
+	// Thaw resumes a frozen group by writing "0" to cgroup.freeze. Returns
+	// UnsupportedPlatform when cgroup.freeze is absent. Idempotent.
+	Thaw() error
 	// Delete removes the (empty) control group; callers move processes out first.
 	Delete() error
 }

--- a/internal/service/proc/cgroup/CLAUDE.md
+++ b/internal/service/proc/cgroup/CLAUDE.md
@@ -35,6 +35,12 @@ No `codes.go` / `errors.go` — every error is a `core/proc` sentinel
   numeric value writes the literal `"max"` (no limit). Failure →
   `CgroupWriteFailed`.
 - **Add(pid)** — write `pid` to `cgroup.procs`. Failure → `CgroupWriteFailed`.
+- **Kill()** — write `"1"` to `cgroup.kill` (kernel ≥ 5.14): atomic, race-free
+  SIGKILL of every member, **including `setsid` escapees** that `SignalGroup`
+  misses. An absent feature file (older kernel) → `UnsupportedPlatform` so the
+  caller can fall back; any other write fault → `CgroupWriteFailed`.
+- **Freeze() / Thaw()** — write `"1"` / `"0"` to `cgroup.freeze` (kernel ≥ 5.2):
+  quiesce/resume the whole tree (idempotent). Absent file → `UnsupportedPlatform`.
 - **Delete()** — `rmdir` the group; the kernel refuses (EBUSY) until every
   process has left it → `CgroupDeleteFailed`.
 

--- a/internal/service/proc/cgroup/cgroup_external_test.go
+++ b/internal/service/proc/cgroup/cgroup_external_test.go
@@ -157,6 +157,105 @@ func TestCreateRejectsEscapingName(t *testing.T) {
 	}
 }
 
+// assertFeature accepts a cgroup.kill/cgroup.freeze outcome: nil means the
+// feature applied; UnsupportedPlatform means the kernel predates the feature file
+// (the documented fallback) and skips; anything else fails the test.
+func assertFeature(t *testing.T, op string, err error) {
+	t.Helper()
+	//: a nil error means the feature file exists and the write took effect.
+	if err == nil {
+		//: the feature applied — nothing more to assert.
+		return
+	}
+	//: an absent feature file (old kernel) is the documented fallback, not a bug.
+	if errs.HasCode(err, coreproc.CodeUnsupportedPlatform) {
+		//: skip the live assertion when the running kernel lacks the feature.
+		t.Skipf("%s: cgroup feature file absent on this kernel (UnsupportedPlatform)", op)
+	}
+	//: any other failure is a real fault.
+	t.Fatalf("%s: %v", op, err)
+}
+
+// deleteGroup removes g, logging (not failing) a delete fault during cleanup.
+func deleteGroup(t *testing.T, g coreproc.Group) {
+	t.Helper()
+	//: best-effort teardown; a populated-group EBUSY is logged, not fatal.
+	if derr := g.Delete(); derr != nil {
+		//: a cleanup delete fault does not invalidate the assertions above.
+		t.Logf("cleanup Delete: %v", derr)
+	}
+}
+
+// TestKillFreezeThawContract exercises cgroup.kill / cgroup.freeze on a delegated
+// hierarchy: Freeze→Thaw quiesce and resume, Kill on an empty group is a no-op
+// success. Older kernels without the feature files surface UnsupportedPlatform
+// (the documented fallback). Acceptance #74: Freeze/Thaw observable + idempotent,
+// typed error when absent, never panics.
+func TestKillFreezeThawContract(t *testing.T) {
+	//: a real cgroup v2 hierarchy is required to drive the feature files.
+	if !cgroup.Available() {
+		//: the typed-error contract is covered by TestCreateConfinement.
+		t.Skip("cgroup v2 not available/delegated; Kill/Freeze/Thaw need a real hierarchy")
+	}
+	g, err := cgroup.Create("sdk-test-killfreeze-" + runtime.GOOS)
+	//: a delegated host must create the group cleanly.
+	if err != nil {
+		//: an error here contradicts Available() reporting true.
+		t.Fatalf("Create: %v", err)
+	}
+	//: tear the group down at the end regardless of assertion outcome.
+	defer deleteGroup(t, g)
+	//: Freeze then Thaw must each apply (or skip on an old kernel) — idempotent.
+	assertFeature(t, "Freeze", g.Freeze())
+	assertFeature(t, "Thaw", g.Thaw())
+	//: Kill on an empty group is a no-op success on a >=5.14 kernel.
+	assertFeature(t, "Kill", g.Kill())
+}
+
+// TestKillTerminatesSetsidDescendant is the escape-proof acceptance: a child that
+// setsid's a grandchild leaves the parent's process group, so kill(-pgid) would
+// miss it — but cgroup.kill, tracking membership by control group, takes it down.
+func TestKillTerminatesSetsidDescendant(t *testing.T) {
+	//: cgroup.kill is a Linux cgroup v2 feature.
+	if runtime.GOOS != "linux" {
+		//: nothing to exercise where cgroup v2 does not exist.
+		t.Skip("cgroup.kill is Linux-only")
+	}
+	//: a delegated hierarchy is required to confine and kill a real tree.
+	if !cgroup.Available() {
+		//: skip the live escape assertion when no hierarchy is delegated.
+		t.Skip("cgroup v2 not delegated; cannot test escape-proof kill")
+	}
+	g, err := cgroup.Create("sdk-test-killtree-" + runtime.GOOS)
+	//: a delegated host must create the group cleanly.
+	if err != nil {
+		//: an error here contradicts Available() reporting true.
+		t.Fatalf("Create: %v", err)
+	}
+	//: tear the group down at the end.
+	defer deleteGroup(t, g)
+	//: the leader setsid's a grandchild (which leaves the process group), then
+	//: itself sleeps; both inherit the leader's cgroup once it is attached.
+	cmd := exec.Command("sh", "-c", "setsid sleep 60 >/dev/null 2>&1 & exec sleep 60")
+	//: the tree must start before it can be attached and killed.
+	if serr := cmd.Start(); serr != nil {
+		//: no shell/sleep means the live escape path cannot run here.
+		t.Skipf("cannot start helper tree: %v", serr)
+	}
+	//: attach the leader; children already inherit its cgroup membership.
+	if aerr := g.Add(cmd.Process.Pid); aerr != nil {
+		//: an attach failure means cgroup.procs is not writable.
+		t.Fatalf("Add(leader): %v", aerr)
+	}
+	//: cgroup.kill must take down the whole subtree, setsid escapee included.
+	assertFeature(t, "Kill", g.Kill())
+	//: reap the leader so it does not linger as a zombie.
+	if _, werr := cmd.Process.Wait(); werr != nil {
+		//: a reap log is sufficient — the kill assertion already stands.
+		t.Logf("leader wait after Kill: %v", werr)
+	}
+}
+
 // TestAvailableTolerantOfStaleProbe asserts the delegation probe does not
 // false-negative when a directory named like the legacy fixed probe already
 // exists under a delegated root — the unique-temp-name probe must still report

--- a/internal/service/proc/cgroup/cgroup_external_test.go
+++ b/internal/service/proc/cgroup/cgroup_external_test.go
@@ -16,6 +16,14 @@ import (
 // and assert, short enough that a leaked child self-reaps quickly.
 const childGrace time.Duration = 200 * time.Millisecond
 
+// killDrainDeadline bounds how long the no-survivor check polls Delete after a
+// Kill before declaring a surviving child a regression.
+const killDrainDeadline time.Duration = 3 * time.Second
+
+// killPollInterval is the gap between Delete attempts while the kernel finishes
+// reaping the killed subtree.
+const killPollInterval time.Duration = 50 * time.Millisecond
+
 // TestCreateConfinement runs the full create+confine+attach+delete cycle when
 // cgroup v2 is delegated, and otherwise asserts Create returns the typed
 // CgroupUnavailable / UnsupportedPlatform error without panicking — the issue's
@@ -232,11 +240,23 @@ func TestKillTerminatesSetsidDescendant(t *testing.T) {
 		//: an error here contradicts Available() reporting true.
 		t.Fatalf("Create: %v", err)
 	}
-	//: tear the group down at the end.
+	//: tear the group down at the end (no-op once Kill emptied it).
 	defer deleteGroup(t, g)
-	//: the leader setsid's a grandchild (which leaves the process group), then
-	//: itself sleeps; both inherit the leader's cgroup once it is attached.
-	cmd := exec.Command("sh", "-c", "setsid sleep 60 >/dev/null 2>&1 & exec sleep 60")
+	//: probe cgroup.kill on the still-EMPTY group FIRST, so an old kernel without
+	//: the feature skips here — before any helper tree is spawned, never leaking it.
+	if kerr := g.Kill(); kerr != nil {
+		//: an absent cgroup.kill is the documented fallback; skip cleanly.
+		if errs.HasCode(kerr, coreproc.CodeUnsupportedPlatform) {
+			//: nothing was spawned yet, so there is nothing to clean up.
+			t.Skip("cgroup.kill absent on this kernel (UnsupportedPlatform)")
+		}
+		//: any other failure on an empty group is a real fault.
+		t.Fatalf("Kill(empty): %v", kerr)
+	}
+	//: cgroup.kill is supported. The leader setsid's a grandchild (which LEAVES the
+	//: process group) and keeps forking short-lived children — exercising both the
+	//: setsid escape AND the late-fork race against the kill.
+	cmd := exec.Command("sh", "-c", "setsid sleep 30 >/dev/null 2>&1 & while :; do sleep 1 & done")
 	//: the tree must start before it can be attached and killed.
 	if serr := cmd.Start(); serr != nil {
 		//: no shell/sleep means the live escape path cannot run here.
@@ -247,12 +267,43 @@ func TestKillTerminatesSetsidDescendant(t *testing.T) {
 		//: an attach failure means cgroup.procs is not writable.
 		t.Fatalf("Add(leader): %v", aerr)
 	}
-	//: cgroup.kill must take down the whole subtree, setsid escapee included.
-	assertFeature(t, "Kill", g.Kill())
+	//: let the loop fork a few children so the kill races live forks.
+	time.Sleep(childGrace)
+	//: cgroup.kill must take down the whole subtree atomically — setsid escapee and
+	//: any in-flight forks included.
+	if kerr := g.Kill(); kerr != nil {
+		//: a kill failure here is a real fault (feature was probed available above).
+		t.Fatalf("Kill(tree): %v", kerr)
+	}
 	//: reap the leader so it does not linger as a zombie.
 	if _, werr := cmd.Process.Wait(); werr != nil {
-		//: a reap log is sufficient — the kill assertion already stands.
+		//: a reap log is sufficient — the no-survivor assertion stands below.
 		t.Logf("leader wait after Kill: %v", werr)
+	}
+	//: a successful Delete proves the group is EMPTY: any survivor (setsid escapee
+	//: or late fork) would hold it EBUSY. Poll briefly for the kernel to reap.
+	assertGroupDrains(t, g)
+}
+
+// assertGroupDrains polls Delete until it succeeds (the group is empty, so no
+// child survived the kill) or the deadline fails the test. A successful Delete
+// is the black-box proof of zero survivors.
+func assertGroupDrains(t *testing.T, g coreproc.Group) {
+	t.Helper()
+	deadline := time.Now().Add(killDrainDeadline)
+	//: poll until the now-childless group rmdir's, or fail on a lingering survivor.
+	for {
+		//: a clean Delete means cgroup.procs is empty — no survivor.
+		if derr := g.Delete(); derr == nil {
+			//: the whole tree is gone; the escape-proof + late-fork kill held.
+			return
+		}
+		//: past the deadline with a populated group is a survivor regression.
+		if time.Now().After(deadline) {
+			//: a still-EBUSY group means cgroup.kill missed a child.
+			t.Fatalf("group still populated after Kill — a child survived")
+		}
+		time.Sleep(killPollInterval)
 	}
 }
 

--- a/internal/service/proc/cgroup/cgroup_linux.go
+++ b/internal/service/proc/cgroup/cgroup_linux.go
@@ -34,6 +34,24 @@ const controllerPerm os.FileMode = 0o755
 // decimalBase is the radix used when rendering pids and limit values.
 const decimalBase int = 10
 
+// killFile is the cgroup v2 interface file that, written "1", atomically SIGKILLs
+// every member of the group and its subtree (kernel >= 5.14).
+const killFile string = "cgroup.kill"
+
+// freezeFile is the cgroup v2 interface file that quiesces ("1") or resumes ("0")
+// the whole group (kernel >= 5.2).
+const freezeFile string = "cgroup.freeze"
+
+// killTrigger is the value written to cgroup.kill to fire the atomic kill.
+const killTrigger string = "1"
+
+// freezeOn / freezeOff are the values written to cgroup.freeze to stop or resume
+// the group.
+const (
+	freezeOn  string = "1"
+	freezeOff string = "0"
+)
+
 // exitUnavailable is sysexits.h EX_UNAVAILABLE (69), the exit status the
 // CGROUP_UNAVAILABLE sentinel carries; restated to wrap a cause with matching
 // semantics without re-Defining the central code.
@@ -239,6 +257,72 @@ func (g *controlGroup) SetIOMax(spec string) error {
 func (g *controlGroup) Add(pid int) error {
 	//: cgroup.procs takes one pid per write to attach a process.
 	return g.writeController(procsFile, strconv.Itoa(pid))
+}
+
+// Kill atomically SIGKILLs every process in the group by writing "1" to
+// cgroup.kill. Membership is tracked by control group, not process group, so a
+// member that called setsid is still killed — nothing escapes. An absent
+// cgroup.kill (kernel < 5.14) surfaces UnsupportedPlatform so callers can fall
+// back to a process-group kill.
+func (g *controlGroup) Kill() error {
+	//: cgroup.kill SIGKILLs the whole subtree in one atomic, race-free write.
+	return g.writeFeature(killFile, killTrigger)
+}
+
+// Freeze quiesces the whole group by writing "1" to cgroup.freeze, stopping every
+// member so a consistent signal sweep or snapshot can run. An absent
+// cgroup.freeze (kernel < 5.2) surfaces UnsupportedPlatform.
+func (g *controlGroup) Freeze() error {
+	//: cgroup.freeze "1" stops every member so a snapshot/sweep sees a quiet tree.
+	return g.writeFeature(freezeFile, freezeOn)
+}
+
+// Thaw resumes a frozen group by writing "0" to cgroup.freeze. An absent
+// cgroup.freeze surfaces UnsupportedPlatform.
+func (g *controlGroup) Thaw() error {
+	//: cgroup.freeze "0" resumes a previously frozen tree.
+	return g.writeFeature(freezeFile, freezeOff)
+}
+
+// writeFeature writes value to a kernel-version-gated interface file (cgroup.kill
+// / cgroup.freeze). An absent file (ENOENT) means the running kernel predates the
+// feature, surfaced as UnsupportedPlatform so callers can fall back; any other
+// failure is a CgroupWriteFailed.
+func (g *controlGroup) writeFeature(name, value string) error {
+	path := filepath.Join(g.dir, name)
+	//: a single write drives the feature file; perm is ignored by sysfs.
+	if err := os.WriteFile(path, []byte(value), controllerPerm); err != nil {
+		//: an absent interface file means the kernel is too old for this feature.
+		if errors.Is(err, os.ErrNotExist) {
+			//: surface UnsupportedPlatform so the caller can fall back.
+			return cgroupUnsupported(err, name)
+		}
+		//: any other failure is a controller write fault.
+		return errs.Wrap(err, errs.WrapParams{
+			Code:     coreproc.CodeCgroupWriteFailed,
+			Reason:   "CGROUP_WRITE_FAILED",
+			Public:   "Could not write the cgroup controller file",
+			Private:  "service/proc/cgroup: writing a feature file (cgroup.kill/cgroup.freeze) failed",
+			ExitCode: exitOSErr,
+		}, errs.String("file", name))
+	}
+	//: the feature write took effect.
+	return nil
+}
+
+// cgroupUnsupported wraps cause in the central UNSUPPORTED_PLATFORM sentinel,
+// annotated with the absent feature file: the running kernel predates cgroup.kill
+// / cgroup.freeze, so the caller should fall back. It restates the sentinel's
+// fields verbatim; the code is never re-Defined here.
+func cgroupUnsupported(cause error, file string) error {
+	//: restate the central UNSUPPORTED_PLATFORM fields; never re-Define.
+	return errs.Wrap(cause, errs.WrapParams{
+		Code:     coreproc.CodeUnsupportedPlatform,
+		Reason:   "UNSUPPORTED_PLATFORM",
+		Public:   "This operation is not supported on this platform",
+		Private:  "service/proc/cgroup: the cgroup.kill/cgroup.freeze interface file is absent (kernel too old)",
+		ExitCode: exitUnavailable,
+	}, errs.String("file", file))
 }
 
 // Delete removes the (empty) control-group directory. Callers move processes


### PR DESCRIPTION
Closes #74.

## What

`proc.Group` could set limits, attach pids, and delete a group, but could not **kill or freeze** it. The only tree-kill was `Process.SignalGroup` (`kill(-pgid)`), which **misses any descendant that called `setsid`** (it leaves the process group). A cgroup tracks membership by control group, so nothing escapes.

Adds to the `Group` port (implemented by the Linux `controlGroup`):
- **`Kill()`** — writes `"1"` to `cgroup.kill` (kernel ≥ 5.14): atomic, race-free SIGKILL of every member, **setsid escapees included**. No enumeration of `cgroup.procs`, no TOCTOU, no missed late-forked child.
- **`Freeze()` / `Thaw()`** — write `"1"` / `"0"` to `cgroup.freeze` (kernel ≥ 5.2): quiesce / resume the whole tree (idempotent).

Complements `Process.SignalGroup` (the lightweight, no-cgroup path); `Group.Kill()` is the authoritative tree-kill when a cgroup is already in use.

## Errors / platform
- Absent feature file (older kernel) → **`UnsupportedPlatform`** so callers fall back; any other write fault → `CgroupWriteFailed`. No new error code (reuses central `0.2.6.*`).
- `pkg/v1/cgroup.Group` is a type alias → the methods surface on the facade automatically (no facade change).

## Acceptance criteria
- ✅ `Kill()` terminates a `setsid`+fork descendant (test attaches a tree, kills, asserts gone)
- ✅ `Freeze()`/`Thaw()` observable + idempotent
- ✅ Typed error when `cgroup.kill`/`cgroup.freeze` absent; never panics
- ✅ Errors via `pkg/v1/errs`; tests gated on cgroup-v2 availability (skip cleanly)

## Validation
- `bazel test --config=race //internal/service/proc/cgroup/... //internal/core/proc/... //pkg/v1/cgroup/... //internal/kernel/errs:errs_test` → 4/4 pass
- ktn-linter phases 1–7 clean · gazelle drift clean