### PR TITLE
fix(ci,docs): Node 24 actions + versioned-docs 404 / stuck version selector

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -61,12 +61,12 @@ jobs:
           # snapshot — a shallow clone would silently produce an empty dropdown.
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: docs/site/package-lock.json
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Install (locked)
         run: npm ci
       - name: Test versioning logic
@@ -92,4 +92,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload release summary
         if: always() && steps.compute.outputs.majors != ''
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-summary-${{ github.run_number }}
           path: /tmp/release-summary.md

--- a/docs/site/src/components/ReleaseDropdown.astro
+++ b/docs/site/src/components/ReleaseDropdown.astro
@@ -1,13 +1,23 @@
 ---
 // ReleaseDropdown — custom combobox (no browser <select>). The button
-// renders the active build coordinate "<sha>+ · <version>"; clicking
-// (or Enter / Space / ArrowDown) reveals a styled listbox of every
-// release for the current major. Closes on click-outside or Escape.
+// renders the PAGE'S OWN release coordinate (the version it was built
+// for); clicking (or Enter / Space / ArrowDown) reveals a styled
+// listbox of every release for the current major. Closes on
+// click-outside or Escape.
+//
+// The build SHA is build provenance, not a release coordinate: it is
+// the commit the WHOLE site was generated from (always HEAD). Stamping
+// it next to a historical tag (e.g. "7b00a34 · v0.1.1") wrongly implies
+// that commit produced that release. So the SHA is only shown for the
+// "local" coordinate — the one snapshot that genuinely IS HEAD. Every
+// tagged release shows just its own label, derived from the page
+// coordinate, never a single global "latest" constant.
 //
 // Accessibility: roles + aria-expanded + aria-activedescendant follow
 // the WAI-ARIA combobox / listbox pattern. Keyboard: Up / Down move
 // focus, Enter activates, Escape closes.
 import { withBase } from "../../scripts/lib/base.mjs";
+import { LOCAL_RELEASE } from "../../scripts/lib/tag-format.mjs";
 
 interface Release {
   version: string;
@@ -36,6 +46,10 @@ const releases = current?.releases ?? [];
 const shaText = buildSha ? buildSha + (buildDirty ? "+" : "") : null;
 const activeLabel =
   releases.find(r => r.version === currentRelease)?.label ?? currentRelease;
+//: SHA is only meaningful for "local" (it IS HEAD). Show it on the
+//: active pill only when the page being viewed is the local snapshot;
+//: tagged releases render their version label alone.
+const pillSha = currentRelease === LOCAL_RELEASE ? shaText : null;
 ---
 
 {releases.length > 0 && (
@@ -47,9 +61,9 @@ const activeLabel =
       aria-expanded="false"
       aria-label={`Release: ${activeLabel}. Click to switch.`}
     >
-      {shaText && (
+      {pillSha && (
         <span class="pill-sha">
-          {shaText}
+          {pillSha}
           <span class="pill-sep" aria-hidden="true">·</span>
         </span>
       )}
@@ -65,7 +79,7 @@ const activeLabel =
           class:list={[r.version === currentRelease && "active"]}
         >
           <a href={withBase(`/${r.version}/${currentMajor}/`)}>
-            {shaText && (
+            {shaText && r.version === LOCAL_RELEASE && (
               <>
                 <span class="opt-sha">{shaText}</span>
                 <span class="opt-sep" aria-hidden="true">·</span>

--- a/docs/site/src/content.config.ts
+++ b/docs/site/src/content.config.ts
@@ -23,6 +23,17 @@ const docs = defineCollection({
   loader: glob({
     pattern: "**/*.md",
     base: "./src/content/docs",
+    //: The default glob `generateId` slugifies every path segment, which
+    //: strips the dots out of a release coordinate: "0.1.5/v1/index.md"
+    //: collapses to the id "015/v1/index", so Astro publishes that page at
+    //: /015/v1/ instead of /0.1.5/v1/. Everything that *links* to a release
+    //: — the version dropdown, the per-release redirect (/<release>/ →
+    //: /<release>/<major>/), the canonical URLs — uses the DOTTED coordinate
+    //: from versions.json ("0.1.5"), so the slugified path 404s and the
+    //: dropdown can't resolve the page's own release. Preserve the directory
+    //: path verbatim (only drop the ".md") so entry.id === the on-disk
+    //: "<release>/<major>/…" coordinate the rest of the site links to.
+    generateId: ({ entry }) => entry.replace(/\.md$/, ""),
   }),
   schema: z
     .object({


### PR DESCRIPTION
## Node.js 20 deprecation warnings — cleared
Bumped the flagged actions to their Node-24 releases:
- `docs-deploy.yml`: `setup-node` v4→v6.4.0, `configure-pages` v5→v6.0.0, `deploy-pages` v4→v5.0.0, build `node-version` 20→24.
- `sdk-release.yml`: `upload-artifact` v4.4.3→v7.0.1.

(`bazel-ci.yml` was already on Node-24 actions from the earlier `setup-go` bump.)

## Versioned docs portal — 404 + stuck version selector
**Two symptoms, one root cause.** Astro 5's `glob()` content loader slugified the release coordinate (`0.1.5` → `015`), so each version's pages published at `/015/v1/` while the dropdown, redirects, and canonical URLs all linked the **dotted** `/0.1.5/v1/` → **404**. Landing on the 404 page (no valid coordinate) is what made the version selector fall back to — and stick on — the newest `v0.1.5` on every page.

Fixes:
- **`content.config.ts`** — explicit `generateId` preserving the verbatim `<release>/<major>/…` path, so pages publish at the dotted coordinate everything links to.
- **`ReleaseDropdown.astro`** — the global build SHA (`7b00a34`) now renders only for the `local` coordinate (which genuinely is HEAD); tagged releases show their own version label, selected per page.

**Verified** with a full local docs build (node 24, astro + pagefind, 16/16 versioning unit tests): all six `pkg/v0.1.0..v0.1.5` publish at `/<release>/v1/`, and `/0.1.1/v1/` now shows `v0.1.1` selected (was `7b00a34 · v0.1.5`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflows with newer action versions for improved reliability and Node.js 24 support.

* **Documentation**
  * Enhanced release dropdown to distinguish local development builds from tagged releases with updated SHA display.
  * Improved release path handling in documentation configuration to ensure consistent version routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->