### PR TITLE
fix: 32-bit errs build (#94) + export rotfile RotFileConfig (#93)

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -139,6 +139,11 @@ jobs:
         target:
           - { goos: linux, goarch: amd64 }
           - { goos: linux, goarch: arm64 }
+          # 32-bit guard (issue #94): the packed-uint32 Code type is
+          # arch-portable, so the whole SDK must build on 386/arm; these cells
+          # keep it from regressing back to a 64-bit-only build constraint.
+          - { goos: linux, goarch: "386" }
+          - { goos: linux, goarch: arm }
           - { goos: darwin, goarch: arm64 }
           - { goos: windows, goarch: amd64 }
           - { goos: freebsd, goarch: amd64 }

--- a/internal/core/writer/BUILD.bazel
+++ b/internal/core/writer/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "config_file.go",
         "config_mysql.go",
         "config_redis.go",
+        "config_rotfile.go",
         "config_s3.go",
         "credentials.go",
         "errors.go",
@@ -28,6 +29,7 @@ go_library(
     deps = [
         "//internal/core/logger",
         "//internal/core/logger/level",
+        "//internal/kernel/clock",
         "//internal/kernel/errs",
         "//internal/kernel/snapshot",
     ],

--- a/internal/core/writer/config_rotfile.go
+++ b/internal/core/writer/config_rotfile.go
@@ -1,0 +1,75 @@
+// Package writer — RotFileConfig value type for the "rotfile" writer.
+package writer
+
+import (
+	"time"
+
+	"github.com/kitsunium/sdk/internal/core/logger/level"
+	"github.com/kitsunium/sdk/internal/kernel/clock"
+)
+
+// RotFileConfig configures the "rotfile" writer — a size-capped, on-disk file
+// that rotates when a write would exceed MaxBytes. It is the concrete config a
+// caller passes as writer.Config to writer.Open("rotfile", …); Path is required,
+// an empty Path is rejected with the rotfile open sentinel. It lives in core
+// alongside FileConfig / ConsoleConfig so the public facade can re-export it.
+//
+// On rotation the active file is renamed Path -> Path.1 (shifting Path.1 ->
+// Path.2 … up to MaxBackups, dropping the oldest; MaxBackups == 0 keeps all),
+// optionally gzip'd when Compress is set, then Path is reopened fresh. Every
+// reopen re-applies the O_NOFOLLOW + 0600 hardening (CWE-59), and every rotated
+// .N / .N.gz sibling is forced to 0600 so a gzip never leaks default perms.
+//
+// MaxAgeDays additionally prunes rotated siblings whose modification time is
+// older than the cutoff, evaluated against Clock after every rotation. It
+// composes with MaxBackups (count cap) — a backup is dropped when it exceeds
+// either policy. The numeric .N backup naming is unchanged; calendar pruning
+// reads each sibling's on-disk mtime rather than a name-embedded stamp, so the
+// retention knobs are purely additive over the existing on-disk format.
+//
+// RotateEvery additionally drives a TIME-triggered rotation independent of
+// MaxBytes: when positive, a background ticker forces a rotation on each
+// interval (the "archive every 24h" policy), composing with the size threshold
+// and the MaxBackups / MaxAgeDays retention caps. It is opt-in — the zero value
+// keeps the prior size/manual-only behaviour, so plain file logging never spins
+// a goroutine it did not ask for.
+type RotFileConfig struct {
+	// Path is the active destination file; it is opened
+	// O_APPEND|O_CREATE|O_WRONLY (+ O_NOFOLLOW on Linux) with mode 0600.
+	Path string
+	// MaxBytes is the size threshold: a Write that would push the active file
+	// past MaxBytes triggers a rotation first. A non-positive MaxBytes disables
+	// size-based rotation (the file grows unbounded).
+	MaxBytes int64
+	// MaxBackups caps how many rotated siblings (Path.1 … Path.N) are kept; the
+	// oldest is dropped once the cap is reached. MaxBackups == 0 keeps all.
+	MaxBackups int
+	// Compress gzips each rotated file (Path.1 -> Path.1.gz) with mode 0600.
+	Compress bool
+	// MaxAgeDays prunes rotated siblings whose on-disk modification time is
+	// older than this many days, evaluated after every rotation (manual or
+	// size-triggered) against the injected Clock. A non-positive MaxAgeDays
+	// disables calendar pruning, preserving the prior count-only behavior.
+	MaxAgeDays int
+	// Clock is the time source used for MaxAgeDays calendar pruning; the zero
+	// value (nil) falls back to clock.System. Injectable so tests prune
+	// deterministically without sleeping.
+	Clock clock.Clock
+	// RotateEvery, when strictly positive, starts a background ticker that
+	// forces a rotation on each interval regardless of size — the "archive
+	// every 24h" policy. A non-positive value (the zero default) disables the
+	// ticker entirely: no goroutine is spawned and rotation stays size- and
+	// manual-triggered. The ticker is joined on Close.
+	RotateEvery time.Duration
+	// OnError is invoked once for an interval-rotation (tick) failure, surfaced
+	// on the next Write under the mutex. A failing tick happens on the daemon
+	// goroutine where no caller can see it, so without this hook the operator
+	// has no signal an "archive every 24h" policy is broken; the callback gives
+	// a path to emit a counter or log to a fallback sink. nil disables the
+	// callback. The triggering record is still written either way — the hook
+	// reports the failure, it does not gate the write.
+	OnError func(err error)
+	// MinLevel is the optional per-writer severity floor; the zero value
+	// inherits the handler-global level.
+	MinLevel level.Level
+}

--- a/internal/kernel/errs/code.go
+++ b/internal/kernel/errs/code.go
@@ -1,14 +1,16 @@
-//go:build amd64 || arm64 || riscv64 || ppc64 || ppc64le || s390x
-
 // Package errs — defines the dotted-quad Code type introduced by
 // ADR 0005. Layout: MM.LL.PP.SS over uint32 — Major.Layer.Package.Serial.
 // Codes are comparable, ordered, map-keyable, and const-expressible via
 // hex literals (Pack is a runtime constructor only).
+//
+// Code is a packed uint32 (shifts/masks only), so it is fully portable across
+// 32- and 64-bit GOARCH — there is no build constraint here. Validation bounds
+// every Code to uint32 ≤ 0x7FFFFFFF (validate.go), so the rare int(code) cast
+// round-trips losslessly even where int is 32-bit.
 package errs
 
 import (
 	"strconv"
-	"unsafe"
 )
 
 // Shift values are WIRE-STABLE. Changing them breaks every persisted Code.
@@ -27,11 +29,6 @@ const (
 	MaskByPackage Code = 0xFF_FF_FF_00 // /24 — all codes sharing Major+Layer+Package
 	MaskExact     Code = 0xFF_FF_FF_FF // /32 — exact match only
 )
-
-// requiredIntSize is the expected size of `int` in bytes on supported
-// 64-bit GOARCH targets. Used by the compile-time guard below so the
-// magic number "8" stays named at its single point of use.
-const requiredIntSize uintptr = 8
 
 // padThreshold10 is the cutoff below which itoaPadded3 must emit two
 // leading zeros ("00X"). Named to avoid a bare magic literal.
@@ -54,12 +51,6 @@ type (
 	PkgCode uint8
 	Serial  uint8
 )
-
-// Compile-time guard — int must be `requiredIntSize` bytes so Code()/Layer()
-// int accessors never lose information via int(uint32) casting. The build
-// tag above enforces 64-bit GOARCH; this static assertion is belt-and-braces
-// for exotic build configurations that might bypass the tag.
-var _ [requiredIntSize - unsafe.Sizeof(int(0))]struct{}
 
 // Pack constructs a Code from its four octets. RUNTIME only — sentinel
 // constants MUST use hex literals so they stay const-expressible.

--- a/internal/service/logger/middleware/encwrite/encwrite.go
+++ b/internal/service/logger/middleware/encwrite/encwrite.go
@@ -164,8 +164,9 @@ func (s *EncWriter) Close() error {
 // [len(box) as uint32 big-endian || box]. A box too large for a uint32 length
 // returns FramingFailed.
 func frame(box []byte) (framed []byte, err error) {
-	//: reject boxes too large for the 32-bit length prefix.
-	if len(box) > math.MaxUint32 {
+	//: reject boxes too large for the 32-bit length prefix; widen to uint64 first
+	//: so the MaxUint32 constant does not overflow int on a 32-bit GOARCH.
+	if uint64(len(box)) > math.MaxUint32 {
 		//: no underlying cause — return the framing sentinel directly.
 		return nil, FramingFailed
 	}

--- a/internal/service/proc/exec/BUILD.bazel
+++ b/internal/service/proc/exec/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
         "limittable_as.go",
         "limittable_openbsd.go",
         "limittable_unix.go",
+        "maxrss_rss32_unix.go",
+        "maxrss_rss64_unix.go",
         "procfile_unix.go",
         "rlimit_value_default.go",
         "rlimit_value_signed.go",

--- a/internal/service/proc/exec/cgroup_placement_linux.go
+++ b/internal/service/proc/exec/cgroup_placement_linux.go
@@ -24,9 +24,11 @@ import (
 const cgroupProcsFile string = "cgroup.procs"
 
 // cgroup2SuperMagic is the statfs f_type of the unified cgroup v2 filesystem
-// (CGROUP2_SUPER_MAGIC, the ASCII "cgrp"). Compared against int64(st.Type) so the
-// arch-dependent Statfs_t.Type field (int64 / uint32) widens cleanly.
-const cgroup2SuperMagic int64 = 0x63677270
+// (CGROUP2_SUPER_MAGIC, the ASCII "cgrp"). Typed uint64 and compared against
+// uint64(st.Type) so the arch-dependent Statfs_t.Type field (int64 on amd64/arm64,
+// int32 on 386/arm) widens cleanly — the conversion is real on every GOARCH (the
+// source is signed, the target unsigned), so it is never a redundant cast.
+const cgroup2SuperMagic uint64 = 0x63677270
 
 // cgroupProcsPerm is the perm passed to os.WriteFile; cgroup.procs always exists
 // so the mode is never used to create it — it mirrors the cgroup package's
@@ -63,7 +65,7 @@ func validateCgroupPath(path string) error {
 	}
 	//: the directory must sit on the cgroup2 filesystem — a normal directory that
 	//: merely contains a cgroup.procs file is NOT confinement and is rejected here.
-	if st.Type != cgroup2SuperMagic {
+	if uint64(st.Type) != cgroup2SuperMagic {
 		//: not a cgroup2 mount — refuse rather than spawn an unconfined child.
 		return wrapCgroupUnavailable(nil, errs.String("cgroup_path", path),
 			errs.String("reason", "path is not on a cgroup2 filesystem"))

--- a/internal/service/proc/exec/handle_unix.go
+++ b/internal/service/proc/exec/handle_unix.go
@@ -22,13 +22,11 @@ import (
 // termination; the port reserves -1 for "died by signal, no status".
 const signalledCode int = -1
 
-// maxRSSKB reports the peak resident set size in kilobytes from the wait4
-// rusage. ru.Maxrss is already int64 on every Unix target, so it is read
-// directly without a conversion.
-func maxRSSKB(ru *syscall.Rusage) int64 {
-	//: the kernel reports peak RSS in kilobytes on Unix; pass it through.
-	return ru.Maxrss
-}
+// maxRSSKB (in maxrss_rss64_unix.go / maxrss_rss32_unix.go) reports the peak
+// resident set size in kilobytes from the wait4 rusage. Rusage.Maxrss is int64
+// on a 64-bit GOARCH but int32 on 386/arm, so the widening lives in a per-width
+// file: the 64-bit path passes the value through (no redundant cast), the 32-bit
+// path widens to int64.
 
 // handle is the live supervision handle for one spawned process. It owns the
 // *os.Process, remembers the leader pid and process-group id, and memoises the

--- a/internal/service/proc/exec/maxrss_rss32_unix.go
+++ b/internal/service/proc/exec/maxrss_rss32_unix.go
@@ -1,0 +1,16 @@
+//go:build unix && (386 || arm || mips || mipsle)
+
+// Package exec — peak-RSS read on a 32-bit GOARCH, where Rusage.Maxrss is int32
+// and is widened to the int64 the port expects (see maxrss_rss64_unix.go for the
+// 64-bit counterpart).
+package exec
+
+import "syscall"
+
+// maxRSSKB reports the peak resident set size in kilobytes from the wait4
+// rusage. On a 32-bit GOARCH Rusage.Maxrss is int32, so it is widened to the
+// int64 the coreproc.ExitValue.MaxRSS port field expects.
+func maxRSSKB(ru *syscall.Rusage) int64 {
+	//: the kernel reports peak RSS in kilobytes on Unix; widen to the port width.
+	return int64(ru.Maxrss)
+}

--- a/internal/service/proc/exec/maxrss_rss64_unix.go
+++ b/internal/service/proc/exec/maxrss_rss64_unix.go
@@ -1,0 +1,16 @@
+//go:build unix && !386 && !arm && !mips && !mipsle
+
+// Package exec — peak-RSS read on a 64-bit GOARCH, where Rusage.Maxrss is
+// already int64 and needs no widening cast (see maxrss_rss32_unix.go for the
+// 32-bit counterpart).
+package exec
+
+import "syscall"
+
+// maxRSSKB reports the peak resident set size in kilobytes from the wait4
+// rusage. On a 64-bit GOARCH Rusage.Maxrss is already int64, so the value is
+// passed through without a cast (a cast here would be a redundant conversion).
+func maxRSSKB(ru *syscall.Rusage) int64 {
+	//: the kernel reports peak RSS in kilobytes on Unix; pass it through.
+	return ru.Maxrss
+}

--- a/internal/service/writer/rotfile/CLAUDE.md
+++ b/internal/service/writer/rotfile/CLAUDE.md
@@ -18,7 +18,7 @@ sink is reproduced here and, critically, **re-run on every reopen**.
 | File | Role |
 |---|---|
 | `rotfile.go` | `Writer` singleton, `rotFileFactory` (`Name` / `Open`) |
-| `rotating_sink_config.go` | `Config` value type (the one exported struct), incl. `RotateEvery` |
+| `rotating_sink_config.go` | `Config` — an **alias** of `core/writer.RotFileConfig` (moved there for issue #93 so `pkg/v1/logger` can re-export it); type identity unchanged |
 | `rotating_sink.go` | `rotatingSink` + `Write` / `Flush` / `Close` + `openHardened` / `refuseSymlink` / `newRotatingSink` (wires the interval daemon) |
 | `rotate_interval.go` | `tickRotate` — the `worker.Every` daemon tick body |
 | `decode.go` | `rotFileFactory.Decode` (`core/writer.Decoder`) + key-coercion helpers |

--- a/internal/service/writer/rotfile/rotating_sink_config.go
+++ b/internal/service/writer/rotfile/rotating_sink_config.go
@@ -1,75 +1,14 @@
-// Package rotfile — Config value type for rotatingSink, in the parent-prefixed
-// sibling of rotating_sink.go per KTN-STRUCT-ONEFILE / KTN-STRUCT-COLOCATE.
+// Package rotfile — Config is the rotfile writer's value type. Since issue #93
+// the canonical struct lives in core/writer (RotFileConfig) so the public facade
+// (pkg/v1/logger) can re-export it like ConsoleConfig / FileConfig; this alias
+// keeps the in-package name (Config) and its type identity unchanged, so Open's
+// type-assertion and every existing caller compile untouched.
 package rotfile
 
-import (
-	"time"
+import corewriter "github.com/kitsunium/sdk/internal/core/writer"
 
-	"github.com/kitsunium/sdk/internal/core/logger/level"
-	"github.com/kitsunium/sdk/internal/kernel/clock"
-)
-
-// Config configures the "rotfile" writer — a size-capped, on-disk file that
-// rotates when a write would exceed MaxBytes. It is the concrete config a
-// caller passes as writer.Config to writer.Open("rotfile", …); Path is required,
-// an empty Path is rejected with the rotfile open sentinel.
-//
-// On rotation the active file is renamed Path -> Path.1 (shifting Path.1 ->
-// Path.2 … up to MaxBackups, dropping the oldest; MaxBackups == 0 keeps all),
-// optionally gzip'd when Compress is set, then Path is reopened fresh. Every
-// reopen re-applies the O_NOFOLLOW + 0600 hardening (CWE-59), and every rotated
-// .N / .N.gz sibling is forced to 0600 so a gzip never leaks default perms.
-//
-// MaxAgeDays additionally prunes rotated siblings whose modification time is
-// older than the cutoff, evaluated against Clock after every rotation. It
-// composes with MaxBackups (count cap) — a backup is dropped when it exceeds
-// either policy. The numeric .N backup naming is unchanged; calendar pruning
-// reads each sibling's on-disk mtime rather than a name-embedded stamp, so the
-// retention knobs are purely additive over the existing on-disk format.
-//
-// RotateEvery additionally drives a TIME-triggered rotation independent of
-// MaxBytes: when positive, a background ticker forces a rotation on each
-// interval (the "archive every 24h" policy), composing with the size threshold
-// and the MaxBackups / MaxAgeDays retention caps. It is opt-in — the zero value
-// keeps the prior size/manual-only behaviour, so plain file logging never spins
-// a goroutine it did not ask for.
-type Config struct {
-	// Path is the active destination file; it is opened
-	// O_APPEND|O_CREATE|O_WRONLY (+ O_NOFOLLOW on Linux) with mode 0600.
-	Path string
-	// MaxBytes is the size threshold: a Write that would push the active file
-	// past MaxBytes triggers a rotation first. A non-positive MaxBytes disables
-	// size-based rotation (the file grows unbounded).
-	MaxBytes int64
-	// MaxBackups caps how many rotated siblings (Path.1 … Path.N) are kept; the
-	// oldest is dropped once the cap is reached. MaxBackups == 0 keeps all.
-	MaxBackups int
-	// Compress gzips each rotated file (Path.1 -> Path.1.gz) with mode 0600.
-	Compress bool
-	// MaxAgeDays prunes rotated siblings whose on-disk modification time is
-	// older than this many days, evaluated after every rotation (manual or
-	// size-triggered) against the injected Clock. A non-positive MaxAgeDays
-	// disables calendar pruning, preserving the prior count-only behavior.
-	MaxAgeDays int
-	// Clock is the time source used for MaxAgeDays calendar pruning; the zero
-	// value (nil) falls back to clock.System. Injectable so tests prune
-	// deterministically without sleeping.
-	Clock clock.Clock
-	// RotateEvery, when strictly positive, starts a background ticker that
-	// forces a rotation on each interval regardless of size — the "archive
-	// every 24h" policy. A non-positive value (the zero default) disables the
-	// ticker entirely: no goroutine is spawned and rotation stays size- and
-	// manual-triggered. The ticker is joined on Close.
-	RotateEvery time.Duration
-	// OnError is invoked once for an interval-rotation (tick) failure, surfaced
-	// on the next Write under the mutex. A failing tick happens on the daemon
-	// goroutine where no caller can see it, so without this hook the operator
-	// has no signal an "archive every 24h" policy is broken; the callback gives
-	// a path to emit a counter or log to a fallback sink. nil disables the
-	// callback. The triggering record is still written either way — the hook
-	// reports the failure, it does not gate the write.
-	OnError func(err error)
-	// MinLevel is the optional per-writer severity floor; the zero value
-	// inherits the handler-global level.
-	MinLevel level.Level
-}
+// Config configures the "rotfile" writer. It is an alias of
+// core/writer.RotFileConfig — see that type for the full field documentation
+// (Path / MaxBytes / MaxBackups / Compress / MaxAgeDays / Clock / RotateEvery /
+// OnError / MinLevel).
+type Config = corewriter.RotFileConfig

--- a/pkg/v1/logger/README.md
+++ b/pkg/v1/logger/README.md
@@ -496,7 +496,7 @@ type ConsoleConfig = corewriter.ConsoleConfig
 ```
 
 <a name="ConsoleStream"></a>
-## type [ConsoleStream](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L52>)
+## type [ConsoleStream](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L53>)
 
 ConsoleStream selects which standard stream the console writer targets.
 
@@ -505,7 +505,7 @@ type ConsoleStream = corewriter.ConsoleStream
 ```
 
 <a name="CredentialProvider"></a>
-## type [CredentialProvider](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L56>)
+## type [CredentialProvider](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L57>)
 
 CredentialProvider yields short\-lived credentials on demand for the network writers; the SDK never logs or wraps the returned material.
 
@@ -514,7 +514,7 @@ type CredentialProvider = corewriter.CredentialProvider
 ```
 
 <a name="CredentialValue"></a>
-## type [CredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L60>)
+## type [CredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L61>)
 
 CredentialValue is the opaque, redacting credential set returned by a CredentialProvider; its String output is always "\<redacted\>".
 
@@ -523,7 +523,7 @@ type CredentialValue = corewriter.CredentialValue
 ```
 
 <a name="NewCredentialValue"></a>
-### func [NewCredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L64>)
+### func [NewCredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L65>)
 
 ```go
 func NewCredentialValue(accessKeyID, secretAccessKey, sessionToken string) CredentialValue
@@ -708,7 +708,7 @@ FromConfig builds a Logger from raw, a config blob in the wire format named by f
 FromConfig returns TopologyInvalid \(1.1.0.4\) when format is unregistered, the blob is undecodable, the topology has no writers, a writer Name is unknown, or a writer rejects its options. The error is redacted: it names only the writer and the failure kind, never a decoded credential or option value.
 
 <a name="NewMulti"></a>
-### func [NewMulti](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L94>)
+### func [NewMulti](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L95>)
 
 ```go
 func NewMulti(min Level, specs ...WriterSpec) (lg Logger, err error)
@@ -810,9 +810,9 @@ type RecordSnapshot = corelogger.RecordEvent
 ```
 
 <a name="RotFileConfig"></a>
-## type [RotFileConfig](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L49>)
+## type [RotFileConfig](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L50>)
 
-RotFileConfig configures the "rotfile" writer — a size\- and/or age\-capped, optionally gzip\-compressed on\-disk file that rotates Path \-\> Path.1 … up to MaxBackups \(Path / MaxBytes / MaxBackups / MaxAgeDays / Compress / RotateEvery / MinLevel\). Usable as a value once internal/service/writer/rotfile is imported \(it self\-registers the "rotfile" factory\); pass it via WriterSpec\{Name: "rotfile", Config: cfg\} to NewMulti.
+RotFileConfig configures the "rotfile" writer — a size\- and/or age\-capped, optionally gzip\-compressed on\-disk file that rotates Path \-\> Path.1 … up to MaxBackups \(Path / MaxBytes / MaxBackups / MaxAgeDays / Compress / RotateEvery / MinLevel\). Usable as a value once github.com/kitsunium/sdk/pkg/v1/logger/writer is blank\-imported \(it self\-registers the "rotfile" factory alongside console and file\); pass it via WriterSpec\{Name: "rotfile", Config: cfg\} to NewMulti.
 
 ```go
 type RotFileConfig = corewriter.RotFileConfig
@@ -936,7 +936,7 @@ type WriterName = corewriter.Name
 ```
 
 <a name="WriterSpec"></a>
-## type [WriterSpec](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L73>)
+## type [WriterSpec](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L74>)
 
 WriterSpec names a writer and carries its concrete config. Read at call sites as logger.WriterSpec\{Name: "file", Config: logger.FileConfig\{Path: …\}\}. It is a type alias onto internal/core/writer, so the public type is identity\-equal to the internal writer model \(alias\-based public surface, zero runtime cost\).
 

--- a/pkg/v1/logger/README.md
+++ b/pkg/v1/logger/README.md
@@ -177,6 +177,7 @@ Package logger — declares the WriterEntryConfig DTO consumed by FromConfig. A 
   - [func NewMemorySink\(\) \*MemorySink](<#NewMemorySink>)
 - [type Record](<#Record>)
 - [type RecordSnapshot](<#RecordSnapshot>)
+- [type RotFileConfig](<#RotFileConfig>)
 - [type S3Config](<#S3Config>)
 - [type Sink](<#Sink>)
   - [func ConsoleStderr\(\) Sink](<#ConsoleStderr>)
@@ -495,7 +496,7 @@ type ConsoleConfig = corewriter.ConsoleConfig
 ```
 
 <a name="ConsoleStream"></a>
-## type [ConsoleStream](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L44>)
+## type [ConsoleStream](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L52>)
 
 ConsoleStream selects which standard stream the console writer targets.
 
@@ -504,7 +505,7 @@ type ConsoleStream = corewriter.ConsoleStream
 ```
 
 <a name="CredentialProvider"></a>
-## type [CredentialProvider](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L48>)
+## type [CredentialProvider](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L56>)
 
 CredentialProvider yields short\-lived credentials on demand for the network writers; the SDK never logs or wraps the returned material.
 
@@ -513,7 +514,7 @@ type CredentialProvider = corewriter.CredentialProvider
 ```
 
 <a name="CredentialValue"></a>
-## type [CredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L52>)
+## type [CredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L60>)
 
 CredentialValue is the opaque, redacting credential set returned by a CredentialProvider; its String output is always "\<redacted\>".
 
@@ -522,7 +523,7 @@ type CredentialValue = corewriter.CredentialValue
 ```
 
 <a name="NewCredentialValue"></a>
-### func [NewCredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L56>)
+### func [NewCredentialValue](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L64>)
 
 ```go
 func NewCredentialValue(accessKeyID, secretAccessKey, sessionToken string) CredentialValue
@@ -707,7 +708,7 @@ FromConfig builds a Logger from raw, a config blob in the wire format named by f
 FromConfig returns TopologyInvalid \(1.1.0.4\) when format is unregistered, the blob is undecodable, the topology has no writers, a writer Name is unknown, or a writer rejects its options. The error is redacted: it names only the writer and the failure kind, never a decoded credential or option value.
 
 <a name="NewMulti"></a>
-### func [NewMulti](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L86>)
+### func [NewMulti](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L94>)
 
 ```go
 func NewMulti(min Level, specs ...WriterSpec) (lg Logger, err error)
@@ -806,6 +807,15 @@ RecordSnapshot is a buffered copy of a single recorded log event. It is the elem
 
 ```go
 type RecordSnapshot = corelogger.RecordEvent
+```
+
+<a name="RotFileConfig"></a>
+## type [RotFileConfig](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L49>)
+
+RotFileConfig configures the "rotfile" writer — a size\- and/or age\-capped, optionally gzip\-compressed on\-disk file that rotates Path \-\> Path.1 … up to MaxBackups \(Path / MaxBytes / MaxBackups / MaxAgeDays / Compress / RotateEvery / MinLevel\). Usable as a value once internal/service/writer/rotfile is imported \(it self\-registers the "rotfile" factory\); pass it via WriterSpec\{Name: "rotfile", Config: cfg\} to NewMulti.
+
+```go
+type RotFileConfig = corewriter.RotFileConfig
 ```
 
 <a name="S3Config"></a>
@@ -919,14 +929,14 @@ type WriterEntryConfig struct {
 <a name="WriterName"></a>
 ## type [WriterName](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L27>)
 
-WriterName is the stable alias for a registered writer key \("console" / "file" / "s3" / "cloudwatch"\).
+WriterName is the stable alias for a registered writer key \("console" / "file" / "rotfile" / "s3" / "cloudwatch"\).
 
 ```go
 type WriterName = corewriter.Name
 ```
 
 <a name="WriterSpec"></a>
-## type [WriterSpec](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L65>)
+## type [WriterSpec](<https://github.com/kitsunium/sdk/blob/main/pkg/v1/logger/writer.go#L73>)
 
 WriterSpec names a writer and carries its concrete config. Read at call sites as logger.WriterSpec\{Name: "file", Config: logger.FileConfig\{Path: …\}\}. It is a type alias onto internal/core/writer, so the public type is identity\-equal to the internal writer model \(alias\-based public surface, zero runtime cost\).
 

--- a/pkg/v1/logger/writer.go
+++ b/pkg/v1/logger/writer.go
@@ -23,7 +23,7 @@ const (
 )
 
 // WriterName is the stable alias for a registered writer key
-// ("console" / "file" / "s3" / "cloudwatch").
+// ("console" / "file" / "rotfile" / "s3" / "cloudwatch").
 type WriterName = corewriter.Name
 
 // ConsoleConfig configures the "console" writer (stream + optional MinLevel).
@@ -39,6 +39,14 @@ type S3Config = corewriter.S3Config
 // CloudWatchConfig configures the "cloudwatch" writer. Same import-gated
 // resolution as S3Config.
 type CloudWatchConfig = corewriter.CloudWatchConfig
+
+// RotFileConfig configures the "rotfile" writer — a size- and/or age-capped,
+// optionally gzip-compressed on-disk file that rotates Path -> Path.1 … up to
+// MaxBackups (Path / MaxBytes / MaxBackups / MaxAgeDays / Compress / RotateEvery
+// / MinLevel). Usable as a value once internal/service/writer/rotfile is imported
+// (it self-registers the "rotfile" factory); pass it via WriterSpec{Name:
+// "rotfile", Config: cfg} to NewMulti.
+type RotFileConfig = corewriter.RotFileConfig
 
 // ConsoleStream selects which standard stream the console writer targets.
 type ConsoleStream = corewriter.ConsoleStream

--- a/pkg/v1/logger/writer.go
+++ b/pkg/v1/logger/writer.go
@@ -43,9 +43,10 @@ type CloudWatchConfig = corewriter.CloudWatchConfig
 // RotFileConfig configures the "rotfile" writer — a size- and/or age-capped,
 // optionally gzip-compressed on-disk file that rotates Path -> Path.1 … up to
 // MaxBackups (Path / MaxBytes / MaxBackups / MaxAgeDays / Compress / RotateEvery
-// / MinLevel). Usable as a value once internal/service/writer/rotfile is imported
-// (it self-registers the "rotfile" factory); pass it via WriterSpec{Name:
-// "rotfile", Config: cfg} to NewMulti.
+// / MinLevel). Usable as a value once
+// github.com/kitsunium/sdk/pkg/v1/logger/writer is blank-imported (it
+// self-registers the "rotfile" factory alongside console and file); pass it via
+// WriterSpec{Name: "rotfile", Config: cfg} to NewMulti.
 type RotFileConfig = corewriter.RotFileConfig
 
 // ConsoleStream selects which standard stream the console writer targets.

--- a/pkg/v1/logger/writer_external_test.go
+++ b/pkg/v1/logger/writer_external_test.go
@@ -261,3 +261,40 @@ func TestNewCredentialValue(t *testing.T) {
 		})
 	}
 }
+
+// TestNewMultiRotFileRotates proves the consumer-facing path that issue #93
+// exists to enable: a logger.RotFileConfig resolved through
+// NewMulti(Name:"rotfile") actually rotates at MaxBytes and retains at most
+// MaxBackups rotated siblings. The rotfile factory resolves only because the
+// public pkg/v1/logger/writer blank import (top of file) self-registers it.
+func TestNewMultiRotFileRotates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rot.log")
+	//: MaxBackups=2 caps the rotated siblings at rot.log.1 / rot.log.2.
+	lg, err := logger.NewMulti(logger.LevelInfo, logger.WriterSpec{
+		Name:   "rotfile",
+		Config: logger.RotFileConfig{Path: path, MaxBytes: 64, MaxBackups: 2},
+	})
+	//: the rotfile factory must resolve from the public writer blank import.
+	if err != nil || lg == nil {
+		t.Fatalf("NewMulti(rotfile) err=%v lg=%v want nil+logger", err, lg)
+	}
+	//: emit well past MaxBytes (each record far exceeds 64 bytes) so the sink
+	//: is forced through several rotations.
+	for range 8 {
+		logger.Info(t.Context(), lg, "rotfile-marker-with-enough-bytes-to-exceed-the-cap")
+	}
+	//: the active file must exist after the run.
+	if _, sErr := os.Stat(path); sErr != nil {
+		t.Fatalf("active file %s missing: %v", path, sErr)
+	}
+	//: at least the first rotated sibling must exist — rotation happened.
+	if _, sErr := os.Stat(path + ".1"); sErr != nil {
+		t.Errorf("expected rotated backup %s.1 to exist: %v", path, sErr)
+	}
+	//: MaxBackups=2 must be honoured — no third sibling survives the cap.
+	if _, sErr := os.Stat(path + ".3"); sErr == nil {
+		t.Errorf("backup %s.3 exists but MaxBackups=2 should have evicted it", path)
+	}
+}

--- a/pkg/v1/process/process.go
+++ b/pkg/v1/process/process.go
@@ -129,12 +129,12 @@ func Start(ctx context.Context, spec Spec) (proc Process, err error) {
 // [Start] is the non-panicking form for normal use. The panic value is the typed
 // error, so a top-level recover() can classify it via errs.CodeOf / HasCode.
 func MustStart(ctx context.Context, spec Spec) Process {
-	p, err := Start(ctx, spec)
+	live, err := Start(ctx, spec)
 	//: a failed spawn is the consumer's chosen crash point.
 	if err != nil {
 		//: panic with the typed error value, never a bare string.
 		panic(err)
 	}
 	//: the live process handle on success.
-	return p
+	return live
 }


### PR DESCRIPTION
## What

Two consumer-facing SDK fixes that the downstream status report flagged as blockers.

### `#94` — `errs.Code` failed to build on 32-bit GOARCH
`internal/kernel/errs/code.go` carried a `//go:build amd64 || arm64 || …` tag plus an `unsafe.Sizeof(int)==8` compile-time guard. `Code` is a packed `uint32` (`MM.LL.PP.SS`) with no architecture dependency, so the guard only served to make the whole `errs` package — and therefore every SDK module that imports it — fail to compile on `386`/`arm`/`wasm`. Removed the build tag, the `unsafe` import, and the dead guard; `validate.go` already bounds codes to `≤ 0x7FFFFFFF`, well within `uint32`.

Added two guard lanes to the `bazel-ci` cross-build matrix (`linux/386`, `linux/arm`) so a 32-bit regression is caught in CI.

### `#93` — the `rotfile` writer config was not constructible from `pkg/v1`
`RotFileConfig` lived in `internal/service/writer/rotfile`, so `pkg/v1/logger` could not re-export it the way it does `ConsoleConfig` / `FileConfig`. A consumer could name the `"rotfile"` writer in a `WriterSpec` but had no public type to build its `Config` without importing `internal/*` (blocked by the internal/ firewall).

Moved the canonical struct to `internal/core/writer` (`RotFileConfig`), aliased the in-package service type (`rotfile.Config = corewriter.RotFileConfig`) so type identity is unchanged — `Open`'s type-assertion and every caller compile untouched — and re-exported it as `logger.RotFileConfig`.

## Incidental
- `process.MustStart`: renamed a 1-char local (`p` → `live`) to clear a pre-existing `KTN-VAR-MINLEN` flagged by the full-scope lint.

## Verification
- `errs` + whole kernel module build on `386`/`arm`/`amd64`/`arm64`; 436 errs tests pass.
- `core/writer` + service `rotfile` build; rotfile tests pass; `pkg/v1/logger` 211 tests pass; `RotFileConfig` is a constructible exported type.
- `make lint` / `make build` / `make test` green (pre-commit gate passed on both commits).

Closes #93
Closes #94


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed `rotfile` writer configuration in the public API via `RotFileConfig`, including rotation size limits, backup retention, compression, age-based rotation, error callback, and log severity floor.

* **Documentation**
  * Updated published logger API docs to include `RotFileConfig` and document `rotfile` as a supported writer key.

* **Bug Fixes**
  * Improved sealed-box framing length checks to avoid overflow on 32-bit platforms.
  * Fixed `MustStart` to correctly return the started process instance.

* **Chores**
  * Expanded CI build coverage for additional Go Linux architectures (32-bit).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->