### PR TITLE
feat(bench): kernel benchmark tooling — sdk-bench targets + template + README (#21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ ROADMAP.md
 # Local artifacts only — bench.txt summaries are cited inline in
 # commit messages, raw .out files stay per-machine.
 /.bench/
+
+# Kernel bench artifacts (`make sdk-bench` / `sdk-bench-profile`).
+# .bench.out is already covered by *.out above; profiles/ is the pprof dir.
+/profiles/

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help: ## Print this help (default goal).
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "profile"      "$(DIM)capture cpu+mem+block+mutex pprof for codec bench (WAVE=<slug>)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "benchstat-diff" "$(DIM)compare two captured waves with mannwhitney p-values (BEFORE / AFTER)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench"        "$(DIM)run every internal/kernel/*_bench_test.go → .bench.out (COUNT=N)$(RST)"
-	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench-profile" "$(DIM)capture cpu+mem+block+mutex pprof across the kernel → profiles/$(RST)"
+	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench-profile" "$(DIM)capture cpu+mem+block+mutex pprof per kernel package → profiles/<pkg>/$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench-compare" "$(DIM)benchstat .bench.main.out vs .bench.out (A/B vs main)$(RST)"
 
 # ── Wrappers ───────────────────────────────────────────────────────────
@@ -227,28 +227,41 @@ benchstat-diff: benchstat-install
 
 # ── Kernel benchmarks (tracker #16 / tooling #21) ───────────────────────
 # `sdk-bench` runs every kernel *_bench_test.go via go test (NOT bazel) so the
-# output stays benchstat-friendly, teeing into .bench.out for A/B comparison.
+# output stays benchstat-friendly, writing .bench.out for A/B comparison.
 # A kernel package with no bench file is not a failure — go test just reports
 # "no tests to run" and exits 0. Override the sample count with COUNT=N.
+# NOTE: the result is redirected (not piped through tee) so make observes the
+# go-test exit code directly — a failed build/bench aborts here instead of
+# being masked by tee's success and leaving a stale/partial .bench.out behind.
 sdk-bench:
 	@echo "::group::kernel benches"
 	@cd internal/kernel && GOWORK=off go test -run=^$$ -bench=. -benchmem \
-	    -count=$${COUNT:-10} ./... | tee $(CURDIR)/.bench.out
+	    -count=$${COUNT:-10} ./... > $(CURDIR)/.bench.out
 	@echo "::endgroup::"
+	@cat $(CURDIR)/.bench.out
 	@echo "Output: .bench.out (feed to benchstat for A/B comparison)"
 
-# `sdk-bench-profile` captures cpu+mem+block+mutex pprof across the kernel.
-# Takes several minutes; the block/mutex profiles need the benches that
-# exercise sync primitives (ring, async) to register meaningful samples.
+# `sdk-bench-profile` captures cpu+mem+block+mutex pprof for every kernel
+# package, one package at a time. Each package writes into its own
+# profiles/<pkg>/ directory: go test reuses fixed profile filenames, so a
+# single `./...` run would have every package overwrite the previous one's
+# profiles. Per-package directories keep a complete set. Takes several minutes;
+# the block/mutex profiles need the benches that exercise sync primitives
+# (ring, async) to register meaningful samples.
 sdk-bench-profile:
 	@mkdir -p $(CURDIR)/profiles
-	@cd internal/kernel && GOWORK=off go test -run=^$$ -bench=. -benchmem \
-	    -cpuprofile=$(CURDIR)/profiles/cpu.prof \
-	    -memprofile=$(CURDIR)/profiles/mem.prof \
-	    -blockprofile=$(CURDIR)/profiles/block.prof \
-	    -mutexprofile=$(CURDIR)/profiles/mutex.prof \
-	    ./...
-	@echo "Profiles saved to profiles/ — open with 'go tool pprof -http=:8080 profiles/cpu.prof'"
+	@cd internal/kernel && for pkg in $$(GOWORK=off go list ./...); do \
+	    name=$$(echo "$$pkg" | sed 's#.*/##'); \
+	    out=$(CURDIR)/profiles/$$name; mkdir -p "$$out"; \
+	    echo "profiling $$pkg → profiles/$$name/"; \
+	    GOWORK=off go test -run=^$$ -bench=. -benchmem \
+	        -cpuprofile="$$out/cpu.prof" \
+	        -memprofile="$$out/mem.prof" \
+	        -blockprofile="$$out/block.prof" \
+	        -mutexprofile="$$out/mutex.prof" \
+	        "$$pkg" || exit $$?; \
+	done
+	@echo "Profiles saved per package under profiles/<pkg>/ — e.g. 'go tool pprof -http=:8080 profiles/ring/cpu.prof'"
 
 # `sdk-bench-compare` runs benchstat on the recorded baseline vs the current
 # tree. Record the baseline first:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test lint bench cover docs serve release-dry-run docs-readme profile benchstat-install benchstat-diff
+.PHONY: help build test lint bench cover docs serve release-dry-run docs-readme profile benchstat-install benchstat-diff sdk-bench sdk-bench-profile sdk-bench-compare
 
 # `make` with no args prints the help. No aliases — every target on its own.
 .DEFAULT_GOAL := help
@@ -35,6 +35,9 @@ help: ## Print this help (default goal).
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "docs-readme"  "$(DIM)regenerate pkg/v1/{codec,crypto,errs,hash,sign,kdf,password,logger,logger/writer}/README.md from doc comments (see ADR 0008)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "profile"      "$(DIM)capture cpu+mem+block+mutex pprof for codec bench (WAVE=<slug>)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "benchstat-diff" "$(DIM)compare two captured waves with mannwhitney p-values (BEFORE / AFTER)$(RST)"
+	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench"        "$(DIM)run every internal/kernel/*_bench_test.go → .bench.out (COUNT=N)$(RST)"
+	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench-profile" "$(DIM)capture cpu+mem+block+mutex pprof across the kernel → profiles/$(RST)"
+	@printf "  $(GREEN)%-7s$(RST)  %s\n" "sdk-bench-compare" "$(DIM)benchstat .bench.main.out vs .bench.out (A/B vs main)$(RST)"
 
 # ── Wrappers ───────────────────────────────────────────────────────────
 # Every target shells to bazel (+ housekeeping tools). The .bazelrc named
@@ -221,3 +224,44 @@ benchstat-diff: benchstat-install
 	benchstat -confidence=0.95 -delta-test=mannwhitney \
 	  .bench/profiles/$(BEFORE)/bench.txt \
 	  .bench/profiles/$(AFTER)/bench.txt
+
+# ── Kernel benchmarks (tracker #16 / tooling #21) ───────────────────────
+# `sdk-bench` runs every kernel *_bench_test.go via go test (NOT bazel) so the
+# output stays benchstat-friendly, teeing into .bench.out for A/B comparison.
+# A kernel package with no bench file is not a failure — go test just reports
+# "no tests to run" and exits 0. Override the sample count with COUNT=N.
+sdk-bench:
+	@echo "::group::kernel benches"
+	@cd internal/kernel && GOWORK=off go test -run=^$$ -bench=. -benchmem \
+	    -count=$${COUNT:-10} ./... | tee $(CURDIR)/.bench.out
+	@echo "::endgroup::"
+	@echo "Output: .bench.out (feed to benchstat for A/B comparison)"
+
+# `sdk-bench-profile` captures cpu+mem+block+mutex pprof across the kernel.
+# Takes several minutes; the block/mutex profiles need the benches that
+# exercise sync primitives (ring, async) to register meaningful samples.
+sdk-bench-profile:
+	@mkdir -p $(CURDIR)/profiles
+	@cd internal/kernel && GOWORK=off go test -run=^$$ -bench=. -benchmem \
+	    -cpuprofile=$(CURDIR)/profiles/cpu.prof \
+	    -memprofile=$(CURDIR)/profiles/mem.prof \
+	    -blockprofile=$(CURDIR)/profiles/block.prof \
+	    -mutexprofile=$(CURDIR)/profiles/mutex.prof \
+	    ./...
+	@echo "Profiles saved to profiles/ — open with 'go tool pprof -http=:8080 profiles/cpu.prof'"
+
+# `sdk-bench-compare` runs benchstat on the recorded baseline vs the current
+# tree. Record the baseline first:
+#   git checkout main && make sdk-bench && mv .bench.out .bench.main.out
+sdk-bench-compare:
+	@command -v benchstat >/dev/null 2>&1 || { \
+	    echo "benchstat not found. Install: make benchstat-install"; \
+	    exit 1; }
+	@test -f .bench.main.out || { \
+	    echo "Missing .bench.main.out — record the baseline first:"; \
+	    echo "  git checkout main && make sdk-bench && mv .bench.out .bench.main.out"; \
+	    exit 1; }
+	@test -f .bench.out || { \
+	    echo "Missing .bench.out — run make sdk-bench on the branch you want to compare."; \
+	    exit 1; }
+	@benchstat .bench.main.out .bench.out

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ make lint    # drift check (read-only): mod tidy + gazelle + gofumpt + ktn-linte
 make bench   # regenerate codec BENCH.md from real Go benchmarks
 ```
 
+## Benchmarks
+
+Kernel hot-path benchmarks live next to their source as
+`internal/kernel/*/*_bench_test.go`. Run them via:
+
+```bash
+make sdk-bench          # steady-state numbers → .bench.out (benchstat-friendly)
+make sdk-bench-profile  # CPU / mem / block / mutex profiles → profiles/
+make sdk-bench-compare  # benchstat A/B comparison vs a recorded .bench.main.out
+```
+
+See `docs/BENCHMARK-TEMPLATE.md` for the bench conventions (white-box package,
+`b.Loop()`, mandatory `b.ReportAllocs()`, `_Parallel` variants, and the
+zero-alloc claims the CI gate enforces).
+
 ## License
 
 MIT — see [LICENSE](./LICENSE) for the full text.

--- a/docs/BENCHMARK-TEMPLATE.md
+++ b/docs/BENCHMARK-TEMPLATE.md
@@ -1,0 +1,103 @@
+# Kernel benchmark template
+
+Every `*_bench_test.go` under `internal/kernel/*` follows this shape. It is the
+canonical reference for the bench-coverage work tracked by #16 (sub-issues #17
+errs, #18 buffer, #19 clock, #20 ring). The living example is
+`internal/kernel/batcher/batcher_bench_test.go`.
+
+## File naming
+
+`<source>_bench_test.go` — e.g. `ring.go` → `ring_bench_test.go`. Enforced by
+ktn-linter `KTN-TEST-SUFFIX`.
+
+## Package line
+
+White-box is the default in the kernel: `package <pkg>` (same package as the
+source), so benchmarks can reach unexported helpers and the steady-state
+internal state the zero-alloc claims depend on. `batcher_bench_test.go` declares
+`package batcher` for exactly this reason. An external `package <pkg>_test` is
+acceptable when a benchmark only needs the exported surface.
+
+## Required structure
+
+```go
+package foo
+
+import "testing"
+
+// BenchmarkBar measures <the exact path> and <why it matters> — e.g. the
+// steady-state Get/Put round-trip that the 0-alloc pool claim rests on.
+func BenchmarkBar(b *testing.B) {
+	input := makeInput()  // setup hoisted ABOVE the loop
+	b.ReportAllocs()      // MANDATORY — the zero-alloc claim only has teeth
+	b.ResetTimer()        // drop setup cost from the measurement
+	for i := 0; b.Loop(); i++ {
+		//: consume the result so the compiler cannot dead-code the body.
+		sink = foo.Bar(input)
+	}
+}
+
+// BenchmarkBar_Parallel — MANDATORY for every concurrent-safe API.
+// EXCEPTION: SPSC primitives (ring) use a dedicated 2-goroutine
+// producer/consumer pattern, NOT b.RunParallel.
+func BenchmarkBar_Parallel(b *testing.B) {
+	input := makeInput()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			//: each P exercises the read path concurrently.
+			sink = foo.Bar(input)
+		}
+	})
+}
+
+// Package-level sink keeps Bench return values alive across the loop.
+var sink any
+```
+
+## Conventions (ktn-linter)
+
+- Each `Benchmark*` carries a doc comment naming **what** it measures and
+  **why** (the perf claim it backs).
+- Every control block inside the body takes a `//:` intent comment — same rule
+  as production code.
+- `b.ReportAllocs()` in **every** body, before the loop.
+
+## Invocation
+
+```bash
+# Run every kernel bench (benchstat-friendly output → .bench.out)
+make sdk-bench                 # COUNT=N overrides the sample count (default 10)
+
+# CPU / mem / block / mutex profiles → profiles/
+make sdk-bench-profile
+
+# A/B vs main
+git checkout main && make sdk-bench && mv .bench.out .bench.main.out
+git checkout <branch> && make sdk-bench
+make sdk-bench-compare
+
+# Single package via go test
+cd internal/kernel && GOWORK=off go test -run='^$' -bench=. -benchmem ./ring/
+```
+
+## Anti-patterns (forbidden)
+
+- `for i := 0; i < b.N; i++` — legacy loop, flagged by `KTN-TEST-BLOOP`. Use
+  `for b.Loop()` (Go 1.24+).
+- Setup inside the measured loop — skews the number.
+- Missing `b.ReportAllocs()` — the zero-alloc claim has no teeth.
+- Discarding return values — the compiler dead-codes the benchmark body; assign
+  to a package-level sink.
+- `b.RunParallel` on an SPSC primitive — violates the single-producer /
+  single-consumer contract; use a dedicated goroutine pair instead.
+
+## Profile interpretation
+
+- `-benchmem`: `B/op` and `allocs/op` per iteration — the headline numbers.
+- `-memprofile` + `go tool pprof`: source-level allocation attribution.
+- `-blockprofile`: goroutines stalling on sync primitives.
+- `-mutexprofile`: contention on mutexes.
+
+For the SDK's hot-path claims, `allocs/op` MUST be `0` on the documented
+zero-alloc benches; a CI gate (#23) asserts this continuously.


### PR DESCRIPTION
## What

Tooling for the kernel hyperperf benchmark tracker (#16). No library code — Makefile targets, a bench-file template, README section, and gitignore.

- `make sdk-bench` — runs every `internal/kernel/*_bench_test.go` via `go test -bench` into `.bench.out` (benchstat-friendly; `COUNT=N` overrides sample count)
- `make sdk-bench-profile` — captures cpu/mem/block/mutex pprof across the kernel into `profiles/`
- `make sdk-bench-compare` — `benchstat .bench.main.out .bench.out` (A/B vs main)
- `docs/BENCHMARK-TEMPLATE.md` — canonical bench-file conventions (white-box package, `b.Loop()`, mandatory `b.ReportAllocs()`, `_Parallel` variants), referencing the living example `internal/kernel/batcher/batcher_bench_test.go`
- README **Benchmarks** section + `/profiles/` gitignore

## Why

The per-package bench coverage issues (#17 errs, #18 buffer, #19 clock, #20 ring) all reuse these targets and this template. Landing the tooling first keeps those PRs to just their bench files.

Closes #21. Refs #16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sdk-bench` command to run kernel benchmarks
  * Added `sdk-bench-profile` command to generate performance profiles
  * Added `sdk-bench-compare` command to compare benchmark results

* **Documentation**
  * Added Benchmarks section to README with usage guide
  * Added benchmark template documenting conventions and requirements for performance testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->