### PR TITLE
test(buffer): zero-alloc benchmarks (#18)

### DIFF
--- a/internal/kernel/buffer/BENCH.md
+++ b/internal/kernel/buffer/BENCH.md
@@ -1,0 +1,58 @@
+<!-- generated from internal/kernel/buffer/buffer_bench_test.go — run `cd internal/kernel && GOWORK=off go test -run='^$' -bench=. -benchmem -benchtime=1s ./buffer/` to refresh -->
+# Benchmarks — `internal/kernel/buffer`
+
+Pooled `*[]byte` scratch buffer (ADR 0010), a thin byte-slice specialisation over
+`internal/kernel/recycler.CappedPool`. These benchmarks isolate the warm-pool
+`Get` and the canonical round trip a call site actually performs. They exist to
+guard the documented performance contract: **steady-state `Get`/`Put` is
+0 allocs/op**. Storing `*[]byte` rather than `[]byte` is what keeps the path
+allocation-free — no slice-header boxing into `sync.Pool`'s `any` payload on
+every `Put`. Any regression to allocs/op > 0 on the warm path is a bug.
+
+There is deliberately **no isolated `Put` benchmark**. `Put` cannot be measured
+on its own for a `sync.Pool`-backed recycler: re-inserting a pointer every
+iteration without a paired `Get` grows the pool's per-P shared slice until the
+next GC, so the reported ns/op and B/op describe pool growth rather than the
+cost of a real `Put`. The round trip is the only honest measurement of the
+`Put` half.
+
+## Reproducibility envelope
+
+> **Numbers vary across machines.** This report stamps the box that produced
+> them so cross-machine deltas can be evaluated honestly.
+
+| Dimension | Value |
+|---|---|
+| CPU cores          | 8 |
+| RAM                | 11 GiB |
+| OS / kernel        | Linux 6.12.72-linuxkit |
+| Architecture       | arm64 |
+| Go toolchain       | go1.26.4 linux/arm64 |
+| Git branch         | feat/issue-18-kernel-buffer-bench |
+| Git commit         | f3b1610 |
+| Generated (UTC)    | 2026-06-19 |
+| Bench wall-clock   | `-test.benchtime=1s`, single run |
+
+## Results
+
+```
+goos: linux
+goarch: arm64
+pkg: github.com/kitsunium/sdk/internal/kernel/buffer
+BenchmarkGet_Steadystate-8    	91908540	        13.03 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetPut_RoundTrip-8   	88810491	        13.34 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetPut_Parallel-8    	292483033	         3.782 ns/op	       0 B/op	       0 allocs/op
+```
+
+## How to read this
+
+- **`BenchmarkGet_Steadystate`** — the pool is primed before the timer, so every
+  benched `Get` recycles a `*[]byte` instead of running the factory. The
+  0 allocs/op figure is the steady-state contract the CI gate enforces.
+- **`BenchmarkGetPut_RoundTrip`** — the canonical call-site pattern (borrow, write
+  one byte into the backing array, return). Steady state is 0 allocs/op; the write
+  ensures the bench reflects real scratch use rather than an empty borrow. This is
+  also the honest measurement of `Put`'s cost (see note above).
+- **`BenchmarkGetPut_Parallel`** — the round trip under `RunParallel`. `sync.Pool`'s
+  per-P cache keeps each goroutine's borrow/return lock-free, so the per-op cost
+  drops below the single-threaded number and stays 0-alloc under contention.

--- a/internal/kernel/buffer/BUILD.bazel
+++ b/internal/kernel/buffer/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     name = "buffer_test",
     size = "small",
     srcs = [
+        "buffer_bench_test.go",
         "buffer_external_test.go",
         "buffer_internal_test.go",
     ],

--- a/internal/kernel/buffer/buffer_bench_test.go
+++ b/internal/kernel/buffer/buffer_bench_test.go
@@ -1,0 +1,63 @@
+package buffer
+
+import "testing"
+
+// BenchmarkGet_Steadystate measures the cost of Get once the pool is warm. The
+// loop returns each borrowed buffer immediately so every subsequent Get hits a
+// recycled *[]byte rather than the factory — this is the documented hot-path
+// contract (0 allocs/op after warm-up). A non-zero allocs/op here means a
+// recycled buffer is no longer being handed back and is a regression.
+func BenchmarkGet_Steadystate(b *testing.B) {
+	//: prime the pool so the very first benched Get already has a recycled value.
+	Put(Get())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf := Get()
+		//: return it at once so the next Get recycles instead of allocating.
+		Put(buf)
+	}
+}
+
+// BenchmarkGetPut_RoundTrip measures the canonical call-site pattern: borrow a
+// buffer, write into it, return it. The write touches the backing array so the
+// bench reflects real scratch use rather than an empty borrow/return. Steady
+// state is 0 allocs/op — the round trip never escapes to the GC once warm.
+//
+// There is deliberately no isolated BenchmarkPut: Put cannot be measured on its
+// own for a sync.Pool-backed recycler. Re-inserting a pointer every iteration
+// without a paired Get grows the pool's per-P shared slice until the next GC,
+// so the reported ns/op and B/op describe pool growth, not the cost of a Put.
+// The round trip is the only honest measurement of the Put half.
+func BenchmarkGetPut_RoundTrip(b *testing.B) {
+	//: warm the pool so the first round trip already recycles.
+	Put(Get())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf := Get()
+		//: emulate a real scratch write so the backing array is actually used.
+		*buf = append(*buf, 'x')
+		Put(buf)
+	}
+}
+
+// BenchmarkGetPut_Parallel measures the round trip under contention via
+// RunParallel, where sync.Pool's per-P cache shines: each P keeps a private
+// buffer so Get/Put stay lock-free and 0-alloc on the steady-state path. The
+// number documents how the pool scales when many goroutines borrow and return
+// concurrently — the worst case the per-P cache is designed for.
+func BenchmarkGetPut_Parallel(b *testing.B) {
+	//: warm the pool before fanning out so no P pays the cold-start factory.
+	Put(Get())
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		//: each P borrows and returns against its private per-P cache.
+		for pb.Next() {
+			buf := Get()
+			*buf = append(*buf, 'x')
+			Put(buf)
+		}
+	})
+}


### PR DESCRIPTION
## What

Zero-alloc benchmarks for `internal/kernel/buffer` (the pooled `*[]byte`), per the kernel hyperperf tracker. Uses the conventions from `docs/BENCHMARK-TEMPLATE.md` (#21): white-box `package buffer`, `b.Loop()`, mandatory `b.ReportAllocs()`, a `_Parallel` variant.

- `BenchmarkGet_Steadystate` — warm-pool `Get` (recycles, never hits the factory)
- `BenchmarkGetPut_RoundTrip` — borrow → write one byte → return (real scratch use)
- `BenchmarkGetPut_Parallel` — round trip under `RunParallel` (sync.Pool per-P cache)

All three measure **0 B/op, 0 allocs/op** — the documented steady-state contract. `BENCH.md` stamps the box that produced the numbers.

## Note — no isolated `Put` benchmark

A standalone `BenchmarkPut` is deliberately omitted. `Put` cannot be benchmarked alone for a `sync.Pool`-backed recycler: re-inserting one pointer every iteration without a paired `Get` grows the pool's per-P shared slice until GC, so the figure reports pool growth (observed ~302 ns/op, 22 B/op), not the cost of a real `Put`. The round trip is the honest measurement of the `Put` half. (This corrects an earlier draft that did ship such a bench with misleading `0 B/op` numbers.)

Refs #16. Closes #18.
