### PR TITLE
test(ring): zero-alloc + SPSC throughput benchmarks (#20)

### DIFF
--- a/internal/kernel/ring/BENCH.md
+++ b/internal/kernel/ring/BENCH.md
@@ -1,0 +1,83 @@
+<!-- generated from internal/kernel/ring/ring_bench_test.go — run `cd internal/kernel && GOWORK=off go test -run='^$' -bench=. -benchmem -benchtime=1s ./ring/` to refresh -->
+# Benchmarks — `internal/kernel/ring`
+
+Lock-free single-producer / single-consumer (SPSC) ring buffer built on
+`sync/atomic` (ADR 0005 kernel/ring block `0.1.3.*`). These benchmarks isolate
+every exported surface of the package and exist to defend the performance claim
+that justifies the package: a non-blocking, zero-allocation FIFO hand-off
+between exactly one producer and one consumer.
+
+The happy-path benches (`TryWrite_Happy`, `TryRead_Happy`) keep the ring from
+saturating/emptying so each operation lands on the fast path (two atomic loads,
+one slot store/load, one atomic store) and proves **0 allocs/op**. The sentinel
+benches (`TryWrite_Full`, `TryRead_Empty`) saturate/empty the ring so every call
+returns the **pre-allocated** `Full` / `Empty` sentinel — also 0 allocs, which is
+the regression guard for PR #15 Wave 6 finding #13 (sentinels must not be
+constructed on the hot path). `Capacity` and `Len` cover the cheap reads.
+`BenchmarkSPSC_ProducerConsumer` measures end-to-end throughput with a dedicated
+producer/consumer goroutine pair (NOT `b.RunParallel`, which would spawn N
+producers + N consumers and violate the SPSC invariant) across ring sizes 4, 64,
+1024, and 65536 so the throughput-vs-depth curve is visible.
+
+## Reproducibility envelope
+
+> **Numbers vary across machines.** This report stamps the box that produced
+> them so cross-machine deltas can be evaluated honestly.
+
+| Dimension | Value |
+|---|---|
+| CPU cores          | 8 |
+| RAM                | 11 GiB |
+| OS / kernel        | Linux 6.12.72-linuxkit |
+| Architecture       | arm64 |
+| Go toolchain       | go1.26.4 linux/arm64 |
+| Git branch         | feat/issue-20-kernel-ring-bench |
+| Git commit         | f3b1610 |
+| Generated (UTC)    | 2026-06-19 |
+| Bench wall-clock   | `-test.benchtime=1s`, single run |
+
+## Results
+
+```
+goos: linux
+goarch: arm64
+pkg: github.com/kitsunium/sdk/internal/kernel/ring
+BenchmarkNew-8                     	  459751	      2590 ns/op	    9472 B/op	       1 allocs/op
+BenchmarkTryWrite_Happy-8          	100000000	        15.38 ns/op	       0 B/op	       0 allocs/op
+BenchmarkTryRead_Happy-8           	100000000	        13.16 ns/op	       0 B/op	       0 allocs/op
+BenchmarkTryWrite_Full-8           	183599595	         6.430 ns/op	       0 B/op	       0 allocs/op
+BenchmarkTryRead_Empty-8           	194103002	         6.348 ns/op	       0 B/op	       0 allocs/op
+BenchmarkCapacity-8                	530012316	         2.304 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLen-8                     	493288366	         2.425 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSPSC_ProducerConsumer/size4-8         	15381303	       107.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSPSC_ProducerConsumer/size64-8        	18557430	        75.48 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSPSC_ProducerConsumer/size1024-8      	20364985	       122.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSPSC_ProducerConsumer/size65536-8     	24867996	        52.38 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/kitsunium/sdk/internal/kernel/ring	16.075s
+```
+
+## How to read this
+
+- **`BenchmarkNew`** — construction allocates the `queueRing` struct plus its
+  `cap+1` slots backing array (`1024+1` ints here): **1 alloc/op**, the only
+  benchmark that allocates. Everything below is the steady-state hot path.
+- **`BenchmarkTryWrite_Happy` / `BenchmarkTryRead_Happy`** — single producer /
+  single consumer, ring kept un-saturated / un-empty, so each call stays on the
+  fast path. **0 allocs/op** confirms the slot store/load reuses the backing
+  array.
+- **`BenchmarkTryWrite_Full` / `BenchmarkTryRead_Empty`** — saturated / empty
+  ring, so every call returns the package-level `Full` / `Empty` sentinel.
+  **0 allocs/op** is the guard that these sentinels stay pre-allocated and are
+  never constructed per call.
+- **`BenchmarkCapacity` / `BenchmarkLen`** — the cheap reads: an immutable field
+  widen and a two-atomic-load snapshot subtract. Both 0 allocs, low-single-digit
+  ns/op.
+- **`BenchmarkSPSC_ProducerConsumer/sizeN`** — one dedicated producer goroutine
+  and one dedicated consumer goroutine move `b.N` records end-to-end across the
+  lock-free buffer at ring depths 4 / 64 / 1024 / 65536. ns/op is per-record
+  wall time across the full producer→consumer hand-off (including spin-retry on
+  `Full`/`Empty`), not a single `TryWrite`. Deeper rings broadly amortise the
+  back-pressure spin; the exact size-to-size ordering is scheduler-sensitive and
+  jitters run-to-run on a shared machine, so read the magnitude (tens of ns per
+  record), not a strictly monotonic curve.

--- a/internal/kernel/ring/BUILD.bazel
+++ b/internal/kernel/ring/BUILD.bazel
@@ -29,6 +29,7 @@ alias(
 go_test(
     name = "ring_test",
     srcs = [
+        "ring_bench_test.go",
         "ring_external_test.go",
         "ring_internal_test.go",
     ],

--- a/internal/kernel/ring/ring_bench_test.go
+++ b/internal/kernel/ring/ring_bench_test.go
@@ -1,0 +1,241 @@
+package ring
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// BenchmarkNew measures Queue construction. New allocates the queueRing struct
+// plus its cap+1 slots backing array, so ~1 alloc is expected — this number is
+// the floor for any caller that builds rings on a hot path and the regression
+// guard if the constructor ever grows a hidden allocation.
+func BenchmarkNew(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		//: build a fresh ring each iteration so the alloc count is per-construction.
+		q, err := New[int](1024)
+		if err != nil {
+			b.Fatalf("New: %v", err)
+		}
+		//: assert on the result so the compiler cannot elide the make.
+		if q == nil {
+			b.Fatal("New returned a nil queue")
+		}
+	}
+}
+
+// BenchmarkTryWrite_Happy measures the single-producer, non-saturated TryWrite
+// path. SPSC is honoured: exactly one goroutine writes. The ring is kept from
+// saturating by draining one slot every iteration, so each TryWrite lands on the
+// fast path (two atomic loads, one slot store, one atomic store). 0 allocs
+// expected — the slot store reuses the backing array.
+func BenchmarkTryWrite_Happy(b *testing.B) {
+	q, err := New[int](1024)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	//: pre-load one item so the very first TryRead in the loop always succeeds.
+	if err := q.TryWrite(0); err != nil {
+		b.Fatalf("seed TryWrite: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		//: write then immediately drain so the ring never saturates and every
+		//: TryWrite stays on the non-Full fast path.
+		if err := q.TryWrite(i); err != nil {
+			b.Fatalf("TryWrite: %v", err)
+		}
+		if _, err := q.TryRead(); err != nil {
+			b.Fatalf("drain TryRead: %v", err)
+		}
+	}
+}
+
+// BenchmarkTryRead_Happy measures the single-consumer, non-empty TryRead path.
+// SPSC is honoured: exactly one goroutine reads. The ring is replenished one
+// slot every iteration so each TryRead lands on the fast path (two atomic loads,
+// one slot load, one zero-store, one atomic store). 0 allocs expected.
+func BenchmarkTryRead_Happy(b *testing.B) {
+	q, err := New[int](1024)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		//: replenish then drain so the ring never empties and every TryRead stays
+		//: on the non-Empty fast path.
+		if err := q.TryWrite(i); err != nil {
+			b.Fatalf("replenish TryWrite: %v", err)
+		}
+		if _, err := q.TryRead(); err != nil {
+			b.Fatalf("TryRead: %v", err)
+		}
+	}
+}
+
+// BenchmarkTryWrite_Full measures the saturated TryWrite path: the ring is
+// filled to capacity before the loop, so every TryWrite hits the wrap-check,
+// finds next == head, and returns the pre-allocated Full sentinel. 0 allocs
+// expected because Full is a package-level var, not a constructed error.
+func BenchmarkTryWrite_Full(b *testing.B) {
+	q, err := New[int](8)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	//: fill the ring to capacity so every benchmarked TryWrite returns Full.
+	for q.TryWrite(0) == nil {
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		//: the ring is saturated — this must return the Full sentinel with no alloc.
+		if err := q.TryWrite(1); !errors.Is(err, Full) {
+			b.Fatalf("TryWrite on full ring: got %v, want Full", err)
+		}
+	}
+}
+
+// BenchmarkTryRead_Empty measures the empty TryRead path: the ring is never
+// written, so every TryRead finds head == tail and returns the pre-allocated
+// Empty sentinel plus the zero value. 0 allocs expected — Empty is a
+// package-level var and the zero value is a stack value.
+func BenchmarkTryRead_Empty(b *testing.B) {
+	q, err := New[int](8)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		//: the ring is empty — this must return the Empty sentinel with no alloc.
+		if _, err := q.TryRead(); !errors.Is(err, Empty) {
+			b.Fatalf("TryRead on empty ring: got %v, want Empty", err)
+		}
+	}
+}
+
+// BenchmarkCapacity measures the immutable Capacity field read. It is a single
+// widening of the stored cap; 0 allocs and a handful of ns/op are expected. The
+// result is consumed via a sink var so the read cannot be optimised away.
+func BenchmarkCapacity(b *testing.B) {
+	q, err := New[int](1024)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	var sink int
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		//: accumulate into a sink so the compiler keeps the Capacity call.
+		sink += q.Capacity()
+	}
+	//: assert the sink accumulated so the Capacity reads cannot be elided.
+	if sink == 0 {
+		b.Fatal("Capacity sink stayed zero")
+	}
+}
+
+// BenchmarkLen measures the Len snapshot: two atomic loads, a subtract, and a
+// modulo. 0 allocs expected. The ring is half-filled so the modulo arithmetic
+// runs on a non-zero span rather than the trivial empty case.
+func BenchmarkLen(b *testing.B) {
+	q, err := New[int](1024)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	//: half-fill the ring so Len exercises the wrap-around subtract, not Len==0.
+	for i := range 512 {
+		if err := q.TryWrite(i); err != nil {
+			b.Fatalf("seed TryWrite: %v", err)
+		}
+	}
+	var sink int
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		//: accumulate into a sink so the compiler keeps the Len call.
+		sink += q.Len()
+	}
+	//: assert the sink accumulated so the Len reads cannot be elided.
+	if sink == 0 {
+		b.Fatal("Len sink stayed zero")
+	}
+}
+
+// BenchmarkSPSC_ProducerConsumer measures the end-to-end SPSC throughput with
+// ONE dedicated producer goroutine and ONE dedicated consumer goroutine — the
+// only topology the ring is contractually safe under.
+//
+// This deliberately does NOT use b.RunParallel. RunParallel spawns GOMAXPROCS
+// worker goroutines all running the same body; here that would mean N concurrent
+// producers AND N concurrent consumers, which violates the SPSC invariant
+// (exactly one TryWrite-er and exactly one TryRead-er at any instant) and would
+// be a data race on head/tail/slots. Instead we hand-roll the two-goroutine
+// pattern: the producer spins on TryWrite (re-trying on Full), the consumer
+// spins on TryRead (re-trying on Empty), and b.N records flow end-to-end across
+// the lock-free buffer. The sub-benchmarks sweep ring sizes 4, 64, 1024, 65536
+// so the throughput-vs-buffer-depth curve (and any false-sharing cliff) is
+// visible. ns/op here is per-record wall time across the full producer→consumer
+// handoff, not a single TryWrite.
+func BenchmarkSPSC_ProducerConsumer(b *testing.B) {
+	for _, size := range []int{4, 64, 1024, 65536} {
+		//: pass size as an argument so the sub-bench body does not capture the
+		//: loop variable by closure (no heap escape per iteration).
+		b.Run(sizeName(size), func(b *testing.B) { benchSPSC(b, size) })
+	}
+}
+
+// benchSPSC runs the two-goroutine SPSC throughput body for one ring size. It is
+// a free function (not a closure) so size arrives as a value argument rather
+// than a captured loop variable.
+func benchSPSC(b *testing.B, size int) {
+	q, err := New[int](size)
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	n := b.N
+	var wg sync.WaitGroup
+	wg.Add(2)
+	b.ReportAllocs()
+	b.ResetTimer()
+	//: dedicated PRODUCER — the sole TryWrite-er. Spin-retry on Full so a
+	//: slow consumer back-pressures instead of dropping records.
+	go func() {
+		defer wg.Done()
+		for i := range n {
+			for q.TryWrite(i) != nil {
+			}
+		}
+	}()
+	//: dedicated CONSUMER — the sole TryRead-er. Spin-retry on Empty until
+	//: all n records have crossed the buffer.
+	go func() {
+		defer wg.Done()
+		for range n {
+			for {
+				if _, err := q.TryRead(); err == nil {
+					break
+				}
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+// sizeName renders a ring size as a stable sub-benchmark label.
+func sizeName(size int) string {
+	switch size {
+	case 4:
+		return "size4"
+	case 64:
+		return "size64"
+	case 1024:
+		return "size1024"
+	default:
+		return "size65536"
+	}
+}


### PR DESCRIPTION
## What

Zero-allocation + SPSC-throughput benchmarks for `internal/kernel/ring`, per the kernel hyperperf tracker, using the `docs/BENCHMARK-TEMPLATE.md` (#21) conventions.

- `BenchmarkNew` — construction (1 alloc/op: the `queueRing` struct + `cap+1` backing array; the only allocating bench)
- `BenchmarkTryWrite_Happy` / `BenchmarkTryRead_Happy` — un-saturated / non-empty fast paths (0 allocs/op)
- `BenchmarkTryWrite_Full` / `BenchmarkTryRead_Empty` — saturated / empty paths returning the **pre-allocated** `Full` / `Empty` sentinels (0 allocs/op — guards that sentinels are never constructed on the hot path)
- `BenchmarkCapacity` / `BenchmarkLen` — the cheap immutable-field + atomic-snapshot reads
- `BenchmarkSPSC_ProducerConsumer/sizeN` — end-to-end throughput across ring depths 4/64/1024/65536

## SPSC correctness

The throughput bench uses **one dedicated producer goroutine + one dedicated consumer goroutine**, NOT `b.RunParallel` — RunParallel would spawn GOMAXPROCS producers *and* consumers, violating the ring's single-producer/single-consumer invariant and racing on head/tail/slots. The two-goroutine pattern is the only topology the ring is contractually safe under (see `ring/CLAUDE.md`).

`BENCH.md` stamps the machine that produced the numbers.

Refs #16. Closes #20.
