### PR TITLE
docs(codec/tlv): correct scratch-pool rationale

### DIFF
--- a/internal/service/codec/tlv/CLAUDE.md
+++ b/internal/service/codec/tlv/CLAUDE.md
@@ -64,8 +64,16 @@ here: decoded values outlive the `Unmarshal` call while the caller may
 reuse the input `data`, so aliasing it risks a use-after-free — the
 `string(rest[:length])` copy is correct and stays. The realised wins are
 the cached `structTypeInfo`, inline-scalar dispatch, pre-computed name
-prefixes, and typed root decode (Phases 6-8). The buffer pool is
-mutualised via `internal/core/codec/scratch`.
+prefixes, and typed root decode (Phases 6-8).
+
+The encode scratch is a **local** `sync.Pool` of `*[]byte` (`scratchPool`,
+`encoder.go`), capped at `maxRetainedScratchBytes = 256 << 10`. It is
+deliberately NOT part of the shared `internal/core/codec/scratch`
+mutualisation: that package pools `*bytes.Buffer` / `*bytes.Reader` (the shape
+the ten library-mediated codecs share), whereas TLV's varint encoder grows a
+raw `[]byte` and would gain nothing from a `bytes.Buffer` wrapper. The shared
+`256 << 10` retain threshold is matched intentionally — it is the project-wide
+oversize-discard ceiling, not copied pool boilerplate.
 
 ## Verification
 


### PR DESCRIPTION
## What

Fixes a factually-wrong line in `internal/service/codec/tlv/CLAUDE.md`. It claimed *"the buffer pool is mutualised via `internal/core/codec/scratch`"*, but:
- tlv imports no `internal/core/codec/scratch` and uses **no `*bytes.Buffer` pool**;
- its encode scratch is a **local** `sync.Pool` of `*[]byte` (`scratchPool` in `encoder.go`), capped at `maxRetainedScratchBytes = 256 << 10`.

The corrected text documents the real design: TLV's varint encoder grows a raw `[]byte`, so it is intentionally outside the shared `*bytes.Buffer`/`*bytes.Reader` scratch mutualisation, and the `256 << 10` ceiling is the project-wide oversize-discard threshold (not copied pool boilerplate).

## Why

Closes the last loose end of the `codec-perf-micro-pprof` goal audit. The acceptance grep `grep -rn '256 << 10|bytesReaderPool' internal/service/codec/` returns 1 (this tlv constant) — now explained as a deliberate, documented exception rather than un-mutualised boilerplate.

Doc-only; `make lint` 0, `bazel test --config=race //...` green, alloc gate 14/14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal performance documentation for codec buffer management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->