### PR TITLE
fix(docs-site): silence build warnings (gomod lang + missing-tag worktree)

### DIFF
--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -170,6 +170,16 @@ export default defineConfig({
         codeFontFamily:
           "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
       },
+      //: Shiki has no go.mod grammar, so a ```gomod fence (used in ADR 0009,
+      //: snapshotted into every historical version under src/content/docs/*)
+      //: would log "language could not be found" and fall back to plain text.
+      //: Alias it to `go` — the closest bundled grammar — so module paths and
+      //: pseudo-versions still get reasonable colouring and the build is clean.
+      shiki: {
+        langAlias: {
+          gomod: "go",
+        },
+      },
     }),
     //: Emits sitemap.xml + a sitemap-index for SEO discoverability.
     //: Pages with `noindex` frontmatter can be excluded later via

--- a/docs/site/scripts/sync-versions.mjs
+++ b/docs/site/scripts/sync-versions.mjs
@@ -550,6 +550,19 @@ async function materialiseTag(major, version, tag) {
   const wt = `/tmp/wt-${major}-${version}-${Date.now()}`;
   try {
     await shellSafe("git", ["worktree", "prune"]);
+    //: A clone made before this release was tagged (or a shallow/partial
+    //: clone) can list the release via `gh` yet lack the tag ref locally,
+    //: which would make `worktree add` fail. Fetch the tag on demand so the
+    //: build self-heals instead of silently skipping a published version.
+    const haveTag = await shellSafe("git", [
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      `refs/tags/${tag}`,
+    ]);
+    if (typeof haveTag !== "string" || haveTag.trim() === "") {
+      await shellSafe("git", ["fetch", "--quiet", "origin", "tag", tag]);
+    }
     const add = await shellSafe("git", [
       "worktree",
       "add",
@@ -558,7 +571,9 @@ async function materialiseTag(major, version, tag) {
       tag,
     ]);
     if (typeof add !== "string") {
-      console.warn(`[sync-versions] worktree add failed for ${tag}; skipping`);
+      console.warn(
+        `[sync-versions] worktree add failed for ${tag} (tag not found even after fetch); skipping`,
+      );
       return;
     }
     console.log(`[sync-versions] ${major}/${version} <- ${tag}`);


### PR DESCRIPTION
## What

Two warnings from `make serve` / `make docs`, both fixed:

1. **`language gomod could not be found`** — astro-expressive-code logged this for every snapshotted copy of ADR 0009 (it uses a ```gomod fence; Shiki ships no go.mod grammar, so it fell back to plain text). Added `shiki.langAlias: { gomod: "go" }` to the expressiveCode config — `go` is the closest bundled grammar, so module paths / pseudo-versions still get reasonable colouring. This covers the **historical versioned copies** too (frozen at tag time, so a source-fence change alone couldn't fix them).

2. **`worktree add failed for pkg/v0.1.13 / v0.1.14; skipping`** — `gh release list` sees all releases, but a clone made before those tags were pushed lacks the tag refs locally, so `git worktree add <tag>` failed and those two versions were silently dropped from the version dropdown. `materialiseTag` now fetches a missing tag on demand (`git fetch origin tag <tag>`) before the worktree add, so the build self-heals.

## Verified

Full `npm run build`: **0 warnings**, 691 pages, and v0.1.13 + v0.1.14 now sync (`v1/0.1.14 <- pkg/v0.1.14`). `make lint` 0, `bazel test --config=race //...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced syntax highlighting for Go module code examples throughout the documentation site.

* **Bug Fixes**
  * Improved documentation build reliability by enhancing version tag verification to handle shallow clones gracefully. Missing tags are automatically fetched when needed, with clearer error messages for resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->