### PR TITLE
build(docs): add make docs-dev for fast hot-reload iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test lint bench cover docs serve release-dry-run docs-readme profile benchstat-install benchstat-diff sdk-bench sdk-bench-profile sdk-bench-compare
+.PHONY: help build test lint bench cover docs docs-dev serve release-dry-run docs-readme profile benchstat-install benchstat-diff sdk-bench sdk-bench-profile sdk-bench-compare
 
 # `make` with no args prints the help. No aliases — every target on its own.
 .DEFAULT_GOAL := help
@@ -30,6 +30,7 @@ help: ## Print this help (default goal).
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "bench"  "Regenerate every BENCH.md $(DIM)(CPU/RAM/OS/Go/git SHA envelope)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "docs"   "Build the SDK documentation portal $(DIM)(→ docs/site/dist/, 15 pages)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "serve"  "kill / rebuild / re-serve docs on http://localhost:$(DIM)\$${PORT:-4321}$(RST)$(DIM)/$(RST)"
+	@printf "  $(GREEN)%-7s$(RST)  %s\n" "docs-dev" "$(DIM)hot-reloading docs dev server (astro dev, no full rebuild — fast iteration)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "cover"  "bazel coverage --combined_report=lcov //..."
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "release-dry-run"  "$(DIM)compute-bumps + cut-tags in dry-run (see ADR 0007)$(RST)"
 	@printf "  $(GREEN)%-7s$(RST)  %s\n" "docs-readme"  "$(DIM)regenerate pkg/v1/{codec,crypto,errs,hash,sign,kdf,password,logger,logger/writer}/README.md from doc comments (see ADR 0008)$(RST)"
@@ -155,6 +156,15 @@ serve: docs
 	done; \
 	echo "→ serving docs/site/dist on http://localhost:$$port/ (Ctrl+C to stop)"; \
 	cd docs/site && npx --yes serve dist -l $$port --no-clipboard
+
+# `docs-dev` is the fast iteration loop. `serve` does a full PRODUCTION build
+# (~135s: 40s types + 95s render + pagefind) on every restart; `docs-dev` runs
+# the prebuild once, then `astro dev` with hot-module reload — edits to
+# src/pages/*.astro, styles, ADRs, or package docs reflect live with NO rebuild.
+# Use this while iterating; use `make serve` only to preview the real built site.
+# Dev server: http://localhost:4321/ (astro dev default).
+docs-dev:
+	cd docs/site && npm install --silent && npm run dev
 
 # `release-dry-run` previews the auto-bump pipeline without pushing
 # any tag. compute-bumps.sh emits the list of pkg/<major> dirs that


### PR DESCRIPTION
## What

Adds a `make docs-dev` target for iterating on the docs site quickly.

`make serve` does a full **production** build on every restart (~135s: ~40s types + ~95s render of 691 pages + pagefind), which is what makes restarts feel slow. `make docs-dev` runs the prebuild once, then `astro dev` with **hot-module reload** — edits to `src/pages/*.astro`, styles, ADRs, or package docs reflect live with **no rebuild**.

- Use `make docs-dev` while iterating (http://localhost:4321/).
- Keep `make serve` only to preview the real built (`dist/`) site.

## Why not also cache the per-tag content (option B)?

Considered, **not** included here: `sync-versions.mjs` does a deliberate full wipe of `src/content/docs` + `.astro` each run (to avoid Astro "Duplicate id" / orphan-dir bugs after layout migrations), so a per-tag content cache would fight that safety mechanism. It would only speed the ~20s prebuild (not the dominant Astro render, which `docs-dev` sidesteps entirely). Left for a separate change if the prebuild becomes a real pain.

Makefile-only; `make lint` 0, build/test green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `docs-dev` make target for running the documentation development server with hot-reloading capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->