### PR TITLE
fix(docs): serve/docs-dev build with DOCS_BASE=/ for local preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,13 @@ docs:
 # 4. Start a fresh static server. The PORT env var lets you switch
 #    from the default 4321 (`PORT=5173 make serve`) without editing
 #    the Makefile.
-serve: docs
+# NOTE: serve builds with DOCS_BASE=/ so the site is ROOT-served. The default
+# build bakes base=/<repo> (for the GitHub Pages project page), under which the
+# root index redirects to /<repo>/… — which `serve dist` can't resolve locally
+# (files live at dist/, not dist/<repo>/), so the page comes up blank. Forcing
+# base=/ for the local preview makes http://localhost:<port>/ work.
+serve:
+	@DOCS_BASE=/ $(MAKE) --no-print-directory docs
 	@port=$${PORT:-4321}; \
 	pkill -f "serve.*dist.*-l $$port" 2>/dev/null || true; \
 	for i in 1 2 3 4 5; do \
@@ -162,9 +168,10 @@ serve: docs
 # the prebuild once, then `astro dev` with hot-module reload — edits to
 # src/pages/*.astro, styles, ADRs, or package docs reflect live with NO rebuild.
 # Use this while iterating; use `make serve` only to preview the real built site.
-# Dev server: http://localhost:4321/ (astro dev default).
+# DOCS_BASE=/ so the dev server is root-served (default base=/<repo> would put
+# the app under /<repo>/ and leave / blank). Dev server: http://localhost:4321/.
 docs-dev:
-	cd docs/site && npm install --silent && npm run dev
+	cd docs/site && npm install --silent && DOCS_BASE=/ npm run dev
 
 # `release-dry-run` previews the auto-bump pipeline without pushing
 # any tag. compute-bumps.sh emits the list of pkg/<major> dirs that


### PR DESCRIPTION
## What

`make serve` (and `make docs-dev`) now build with `DOCS_BASE=/` so the local preview is **root-served**.

## Why

The production build bakes `base=/<repo>` (=`/sdk`) for the GitHub Pages *project page*. Under that base the root index redirects to `/sdk/…` and every asset is `/sdk/`-prefixed. But `serve dist` / `astro dev` serve at the host root, where those paths **404** — the page comes up blank/unstyled. Observed in the browser:

```
v1/                         404 document
ClientRouter…js             404 script
_slug_…css                  404 stylesheet
Search…js / Default…js      404 script
kitsunium.jpg               404
```

Forcing `DOCS_BASE=/` for the two **local** targets makes the root index redirect to `/0.1.14/v1/` with root-based `/_astro` + `/brand` assets (verified, zero `/sdk/` left).

Deploy is unaffected: `docs-deploy.yml` builds its own artifact with the real `/<repo>` base, and `make docs` standalone keeps the prod-like base.

> Separately: the container's Docker IP `172.21.0.2` is not host-routable — reach the site via `http://localhost:4321/` (published `4321:4321` in docker-compose).

Makefile-only; `make lint` 0, build/test green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local development and documentation build configuration to ensure consistent root path handling between local preview and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->