### PR TITLE
fix(e2e-vm): survive the two-host CI split (API tunnel, dead VMID, always-stop)

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -127,13 +127,22 @@ jobs:
       - name: Open Proxmox API tunnel (bench host)
         run: |
           set -euo pipefail
-          ssh ${SSH_OPTS} -f -N -L 18006:127.0.0.1:8006 root@192.168.100.1
+          # Control socket so the always() cleanup can terminate the forward
+          # deterministically (a bare `ssh -f -N` would leak past the job).
+          ssh ${SSH_OPTS} -f -N -M -S /tmp/pve-tunnel.sock \
+            -L 18006:127.0.0.1:8006 root@192.168.100.1
+          code=000
           for i in $(seq 1 10); do
-            code=$(curl -sk -o /dev/null -w '%{http_code}' "${PROXMOX_API_URL}/version" -H "Authorization: $PVE_AUTH" || true)
-            [ "$code" = "200" ] && { echo "tunnel up (API version=200)"; exit 0; }
+            code=$(curl -sk -o /dev/null -w '%{http_code}' "${PROXMOX_API_URL}/version" -H "Authorization: $PVE_AUTH" || echo 000)
+            [ "$code" = "200" ] && { echo "tunnel up, API auth OK"; exit 0; }
             sleep 2
           done
-          echo "::error::Proxmox API tunnel never came up"; exit 1
+          case "$code" in
+            000) echo "::error::tunnel never came up (no TCP path to the bench API)";;
+            401|403) echo "::error::tunnel is up but the PVE token was refused (HTTP $code) — check CI_RUNNER_API_TOKEN_*";;
+            *) echo "::error::unexpected API answer through the tunnel (HTTP $code)";;
+          esac
+          exit 1
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -265,5 +274,26 @@ jobs:
       - name: Stop VM (always)
         if: always()
         run: |
-          curl -sk -X POST -H "Authorization: $PVE_AUTH" \
-            "${PROXMOX_API_URL}/nodes/${NODE}/qemu/${{ matrix.vmid }}/status/stop" || true
+          # stop is async (returns a UPID): poll it to completion so the runner
+          # never releases while the VM is still stopping (bench nightly race).
+          # Best-effort by design — a dead tunnel must not fail the cleanup.
+          VMID=${{ matrix.vmid }}
+          UPID=$(curl -sk -X POST -H "Authorization: $PVE_AUTH" \
+            "${PROXMOX_API_URL}/nodes/${NODE}/qemu/${VMID}/status/stop" | jq -r '.data // empty' 2>/dev/null || true)
+          if [ -n "$UPID" ]; then
+            for i in $(seq 1 30); do
+              st=$(curl -sk -H "Authorization: $PVE_AUTH" \
+                "${PROXMOX_API_URL}/nodes/${NODE}/tasks/${UPID}/status" | jq -r '.data.status' 2>/dev/null || true)
+              [ "$st" = "stopped" ] && break
+              sleep 2
+            done
+            final=$(curl -sk -H "Authorization: $PVE_AUTH" \
+              "${PROXMOX_API_URL}/nodes/${NODE}/qemu/${VMID}/status/current" | jq -r '.data.status' 2>/dev/null || true)
+            echo "VM ${VMID} final status: ${final:-unknown}"
+          else
+            echo "stop request not accepted (tunnel down?) — leaving VM as-is"
+          fi
+
+      - name: Close API tunnel (always)
+        if: always()
+        run: ssh -S /tmp/pve-tunnel.sock -O exit root@192.168.100.1 2>/dev/null || true

--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -35,7 +35,13 @@ permissions:
   contents: read
 
 env:
-  PROXMOX_API_URL: "https://192.168.100.1:8006/api2/json"
+  # Two-host split (kodflow/labs#185): the runners live on a dedicated CI
+  # Proxmox whose local gateway is NOT the bench anymore — a direct
+  # https://192.168.100.1:8006 call reaches the wrong host. The API is now
+  # consumed through a local SSH tunnel to the bench (opened in the first
+  # step; the runner image's SSH config remaps 192.168.100.1 to the bench
+  # bastion's public IP with the right key).
+  PROXMOX_API_URL: "https://127.0.0.1:18006/api2/json"
   PVE_AUTH: "PVEAPIToken=${{ secrets.CI_RUNNER_API_TOKEN_ID }}=${{ secrets.CI_RUNNER_API_TOKEN_SECRET }}"
   NODE: ${{ secrets.PROXMOX_NODE }}
   SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
@@ -66,14 +72,6 @@ jobs:
           - {
               name: alpine-openrc,
               vmid: 200,
-              goos: linux,
-              goarch: amd64,
-              user: root,
-              ext: "",
-            }
-          - {
-              name: arch-systemd,
-              vmid: 202,
               goos: linux,
               goarch: amd64,
               user: root,
@@ -124,6 +122,18 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
+
+      # ── 0. Tunnel the bench Proxmox API through the SSH bastion ─────────────
+      - name: Open Proxmox API tunnel (bench host)
+        run: |
+          set -euo pipefail
+          ssh ${SSH_OPTS} -f -N -L 18006:127.0.0.1:8006 root@192.168.100.1
+          for i in $(seq 1 10); do
+            code=$(curl -sk -o /dev/null -w '%{http_code}' "${PROXMOX_API_URL}/version" -H "Authorization: $PVE_AUTH" || true)
+            [ "$code" = "200" ] && { echo "tunnel up (API version=200)"; exit 0; }
+            sleep 2
+          done
+          echo "::error::Proxmox API tunnel never came up"; exit 1
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -250,4 +260,10 @@ jobs:
           done
           echo "::endgroup::"
           exit $fail
-      # VM stays running; the next run rolls back to the base snapshot first.
+      # ── 5. Leave the VM stopped: a running VM races the bench nightly jobs
+      # (snapshot rebuild / reclone); the next run rolls back + starts anyway. ──
+      - name: Stop VM (always)
+        if: always()
+        run: |
+          curl -sk -X POST -H "Authorization: $PVE_AUTH" \
+            "${PROXMOX_API_URL}/nodes/${NODE}/qemu/${{ matrix.vmid }}/status/stop" || true


### PR DESCRIPTION
Fixes #114 — the three concrete breaks after the CI runners moved to a dedicated Proxmox host (kodflow/labs#185):

1. **PVE API unreachable**: `https://192.168.100.1:8006` from the runner pods now hits their local gateway (the CI host — no test VMs, no `ci-runner@pve` token). The workflow now opens `ssh -L 18006:127.0.0.1:8006 root@192.168.100.1` (the runner image's SSH config remaps that address to the bench bastion) and consumes `https://127.0.0.1:18006`. A version-endpoint probe gates the job before any VM action.
2. **Dead matrix entry**: `arch-systemd / vmid 202` removed — the template left the bench matrix and the VMID is refused by the allowlist.
3. **Nightly race**: VMs were intentionally left running; they now get a best-effort `status/stop` in an `if: always()` step (the next run rolls back + starts regardless), so e2e can no longer collide with the bench snapshot/reclone jobs.

Follow-up (tracked in #114 / kodflow/labs#188): migrate from direct PVE API driving to the `ci-vm-acquire/release` lease protocol once it ships.

Validation plan: `workflow_dispatch` after tonight's bench daily-refresh completes; acceptance = rollback/boot/IP/SSH path green on the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end virtual machine tests now connect through a secure local tunnel.
  * Removed the `arch-systemd` test target from the test matrix.
  * Virtual machines are now consistently stopped after each test run to prevent conflicts with scheduled jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->