### PR TITLE
fix(e2e-vm): 300s boot windows for parallel cold boots

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -214,21 +214,24 @@ jobs:
           MAC=$(curl -sk -H "Authorization: $PVE_AUTH" \
             "${PROXMOX_API_URL}/nodes/${NODE}/qemu/${VMID}/config" \
             | jq -r '.data.net0' | grep -oiE '([0-9a-f]{2}:){5}[0-9a-f]{2}')
-          for i in $(seq 1 30); do
+          # 300s: a cold base-snapshot boot of 4+ VMs in parallel takes well
+          # over 150s before the first DHCP lease lands (measured live: leases
+          # granted ~2 min after the old 150s window closed).
+          for i in $(seq 1 60); do
             IP=$(ssh ${SSH_OPTS} root@192.168.100.1 \
               "grep -i '${MAC}' /var/lib/misc/dnsmasq.leases 2>/dev/null | awk '{print \$3}'" 2>/dev/null || true)
             [ -n "$IP" ] && { echo "ip=${IP}" >> "$GITHUB_OUTPUT"; echo "IP=$IP"; break; }
             sleep 5
           done
-          [ -n "${IP:-}" ] || { echo "::error::no IP after 150s"; exit 1; }
+          [ -n "${IP:-}" ] || { echo "::error::no IP after 300s"; exit 1; }
 
       - name: Wait for SSH
         run: |
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             ssh ${SSH_OPTS} ${{ matrix.user }}@${{ steps.ip.outputs.ip }} true 2>/dev/null && exit 0
             sleep 5
           done
-          echo "::error::SSH never came up"; exit 1
+          echo "::error::SSH never came up after 300s"; exit 1
 
       # ── 4. Ship the binaries to the VM and run them on the real kernel ──────
       - name: Run conformance + test suites on ${{ matrix.name }}


### PR DESCRIPTION
Run 29970595305 got past tunnel+auth (scoped token works) and the rollback/start API path, then every leg failed `no IP after 150s` — while the dnsmasq leases on the bench show the VMs got their leases ~2 minutes AFTER the window closed. Parallel cold base-snapshot boots simply exceed 150s. IP-detect and SSH-wait windows doubled to 300s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved virtual machine startup checks by allowing more time for IP discovery and SSH readiness.
  * Updated timeout messaging to accurately reflect the extended wait period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->