### PR TITLE
fix(ci): make the docker build guard portable, and the tree buildable off Linux

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -60,6 +60,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -114,6 +123,15 @@ jobs:
       packages: write
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -165,6 +183,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -277,6 +304,15 @@ jobs:
       packages: write
 
     steps:
+      # OCI reference names must be lowercase, but github.repository keeps the
+      # repository's real case and the expression syntax has no lowercase
+      # function. Re-export through $GITHUB_ENV, which overrides the
+      # workflow-level default for the remaining steps of this job.
+      - name: Normalise image names to lowercase
+        run: |
+          echo "IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+          echo "BASE_IMAGE_NAME=$(echo "$BASE_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -32,8 +32,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: kodflow/devcontainer-template
-  BASE_IMAGE_NAME: kodflow/devcontainer-base
+  IMAGE_NAME: ${{ github.repository }}
+  BASE_IMAGE_NAME: ${{ github.repository_owner }}/devcontainer-base
 
 jobs:
   # =============================================================================
@@ -41,7 +41,7 @@ jobs:
   # =============================================================================
   build-base:
     if: >-
-      github.repository == 'kodflow/devcontainer-template' && (
+      github.event.repository.fork != true && (
         github.event.schedule == '0 3 * * 0' ||
         (github.event_name == 'workflow_dispatch' && github.event.inputs.rebuild_base == 'true') ||
         (github.event_name == 'push' && contains(github.event.head_commit.message, '[base]'))
@@ -106,7 +106,7 @@ jobs:
 
   # Merge base architectures into multi-arch manifest
   merge-base:
-    if: github.repository == 'kodflow/devcontainer-template'
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     needs: build-base
     permissions:
@@ -147,7 +147,7 @@ jobs:
     needs: merge-base
     if: >-
       always() &&
-      github.repository == 'kodflow/devcontainer-template' &&
+      github.event.repository.fork != true &&
       github.event.schedule != '0 3 * * 0' &&
       (needs.merge-base.result == 'success' || needs.merge-base.result == 'skipped') &&
       !failure() && !cancelled()
@@ -267,7 +267,7 @@ jobs:
   merge:
     if: >-
       always() &&
-      github.repository == 'kodflow/devcontainer-template' &&
+      github.event.repository.fork != true &&
       github.event_name != 'pull_request' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -196,6 +196,54 @@ rules:
     exclude:
       - "**/internal/service/writer/console/console_external_test.go"
 
+  # KTN-FUNC-DEADCODE / KTN-CONST-UNUSED (error) — build-tag blind spot.
+  #
+  # TEMPORARY false-positive exception. The linter analyses ONE build
+  # configuration: the host's. On a non-Linux host every *_linux.go is excluded
+  # by its build constraint, so a helper that lives in an untagged file and is
+  # called only from the Linux backend looks uncalled and the rules fire. Each
+  # of the four below is called exactly once, from a *_linux.go:
+  #
+  #   • applyOptions          (proc/cgroup/option.go)  ← cgroup_linux.go
+  #   • wrapCgroupUnavailable (proc/exec/wrap.go)      ← cgroup_placement_linux.go
+  #   • parsePayload          (proc/sdnotify/…)        ← listen_linux.go
+  #   • exitNoPerm            (proc/sdnotify/…)        ← listen_linux.go
+  #
+  # Without this block `make lint` cannot pass on macOS at all, on a pristine
+  # tree, so the repo is only developable from the Linux devcontainer. Moving
+  # the helpers under //go:build linux would silence the rules but is the wrong
+  # shape: parsePayload is pure string parsing with a portable test, and a
+  # tagged copy would drop that coverage everywhere but Linux.
+  #
+  # Scoped to the three platform-split proc files ONLY — real dead code anywhere
+  # else in the SDK still fails the gate. RETIRE this block once the rules
+  # resolve references across every build configuration rather than the host's
+  # alone (mirror the 2026-05-28 retirements).
+  KTN-FUNC-DEADCODE:
+    exclude:
+      - "**/internal/service/proc/cgroup/option.go"
+      - "**/internal/service/proc/exec/wrap.go"
+      - "**/internal/service/proc/sdnotify/sdnotify.go"
+
+  KTN-CONST-UNUSED:
+    exclude:
+      - "**/internal/service/proc/sdnotify/sdnotify.go"
+
+  # KTN-FUNC-BLANKPARAM (info) — same build-tag blind spot, other direction.
+  #
+  # cgroup_other.go is the degrade stub for platforms with no control-group
+  # facility, so createGroup(_ string, _ ...Option) discards both parameters by
+  # design: there is nothing to create and nothing to configure. The rule's own
+  # message ("not required by any interface") is the giveaway — the signature is
+  # fixed by the //go:build seam that pairs it with cgroup_linux.go, which the
+  # rule cannot see from a non-Linux host. Naming the parameters would only
+  # trade this for an unused-parameter complaint.
+  #
+  # Scoped to that one stub. RETIRE alongside the block above.
+  KTN-FUNC-BLANKPARAM:
+    exclude:
+      - "**/internal/service/proc/cgroup/cgroup_other.go"
+
   # ── Audit 2026-05-28 — all five scoped overrides RETIRED (ktn-linter v1.34.5) ─
   # Every exclusion that used to live here was removed and the linter re-run on
   # v1.34.5 (current latest). With v1.34.5 + one code refactor, ALL FIVE are gone;

--- a/.ktn-linter.yaml
+++ b/.ktn-linter.yaml
@@ -246,8 +246,11 @@ rules:
 
   # ── Audit 2026-05-28 — all five scoped overrides RETIRED (ktn-linter v1.34.5) ─
   # Every exclusion that used to live here was removed and the linter re-run on
-  # v1.34.5 (current latest). With v1.34.5 + one code refactor, ALL FIVE are gone;
-  # only the KTN-INTERFACE-ANYUSE domain exception above remains.
+  # v1.34.5 (current latest). With v1.34.5 + one code refactor, ALL FIVE are gone.
+  # This audit covers only the five listed below; the exclusions still active
+  # above (KTN-INTERFACE-ANYUSE, KTN-TEST-PARALLEL, and the build-tag trio
+  # KTN-FUNC-DEADCODE / KTN-CONST-UNUSED / KTN-FUNC-BLANKPARAM) were added after
+  # it and carry their own retirement conditions.
   #
   # • KTN-VAR-PTRINTF — false positive on a generic `*T` (kodflow/ktn-linter#365).
   #   v1.34.5 no longer flags internal/kernel/snapshot's Value[T] *T signatures.

--- a/internal/service/proc/rlimit/rlimit_unix.go
+++ b/internal/service/proc/rlimit/rlimit_unix.go
@@ -115,9 +115,8 @@ func applyOne(pid int, r coreproc.Resource, lv coreproc.LimitValue) error {
 		//: hand back the UNKNOWN_RESOURCE sentinel verbatim.
 		return err
 	}
-	rlim := makeRlimit(lv.Soft, lv.Hard)
 	//: setrlimit(2) operates on the calling process only.
-	if serr := syscall.Setrlimit(rl, &rlim); serr != nil {
+	if serr := syscall.Setrlimit(rl, new(makeRlimit(lv.Soft, lv.Hard))); serr != nil {
 		//: surface the failure through the shared RLIMIT_FAILED wrapper.
 		return rlimitFailed(serr, pid, r.String())
 	}

--- a/internal/service/writer/journald/journald_external_test.go
+++ b/internal/service/writer/journald/journald_external_test.go
@@ -2,6 +2,7 @@ package journald_test
 
 import (
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,6 +16,39 @@ import (
 // readDeadline bounds the server-side datagram read so a lost send fails loud
 // instead of hanging the suite.
 const readDeadline time.Duration = 2 * time.Second
+
+// sunPathMax bounds a unix socket path: sockaddr_un.sun_path is a fixed-size
+// field, and a path that fills it makes bind(2) fail with EINVAL.
+const sunPathMax int = 104
+
+// shortSocketPath returns a bindable unix socket path under a temp directory.
+// t.TempDir() embeds the full subtest name, which on macOS pushes the path
+// under /var/folders past sunPathMax and breaks the bind before the test runs.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	//: "jd" keeps the generated component down to a handful of bytes.
+	dir, err := os.MkdirTemp("", "jd")
+	if err != nil {
+		//: without a directory there is no socket to bind; fail loud.
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	//: t.TempDir() would have removed itself; match that.
+	t.Cleanup(func() {
+		//: cleanup runs past assertion time, so a stuck directory is reported
+		//: rather than allowed to mask the real result.
+		if rerr := os.RemoveAll(dir); rerr != nil {
+			t.Logf("RemoveAll %s: %v", dir, rerr)
+		}
+	})
+
+	path := filepath.Join(dir, "j.sock")
+	//: report the length rather than let bind(2) fail with an opaque EINVAL.
+	if len(path) >= sunPathMax {
+		t.Fatalf("socket path is %d bytes, over the sun_path limit: %s", len(path), path)
+	}
+
+	return path
+}
 
 // closeIgnore drops a fixture Close error in the black-box tests: cleanup runs
 // past assertion time, so a close failure must not mask the real result.
@@ -63,7 +97,7 @@ func Test_journaldSink_UnixgramRoundtrip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			//: bind a real datagram socket so the default dialer has a live peer.
-			path := filepath.Join(t.TempDir(), "j.sock")
+			path := shortSocketPath(t)
 			srv, lerr := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
 			//: a private-tempdir unixgram bind is reliable; a failure is a hard
 			//: fault that must fail the suite, never silently skip the E2E.

--- a/internal/service/writer/journald/journald_internal_test.go
+++ b/internal/service/writer/journald/journald_internal_test.go
@@ -2,11 +2,45 @@ package journald
 
 import (
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/kitsunium/sdk/internal/kernel/errs"
 )
+
+// sunPathMax bounds a unix socket path: sockaddr_un.sun_path is a fixed-size
+// field, and a path that fills it makes bind(2) fail with EINVAL.
+const sunPathMax int = 104
+
+// shortSocketPath returns a bindable unix socket path under a temp directory.
+// t.TempDir() embeds the full subtest name, which on macOS pushes the path
+// under /var/folders past sunPathMax and breaks the bind before the test runs.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	//: "jd" keeps the generated component down to a handful of bytes.
+	dir, err := os.MkdirTemp("", "jd")
+	if err != nil {
+		//: without a directory there is no socket to bind; fail loud.
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	//: t.TempDir() would have removed itself; match that.
+	t.Cleanup(func() {
+		//: cleanup runs past assertion time, so a stuck directory is reported
+		//: rather than allowed to mask the real result.
+		if rerr := os.RemoveAll(dir); rerr != nil {
+			t.Logf("RemoveAll %s: %v", dir, rerr)
+		}
+	})
+
+	path := filepath.Join(dir, "j.sock")
+	//: report the length rather than let bind(2) fail with an opaque EINVAL.
+	if len(path) >= sunPathMax {
+		t.Fatalf("socket path is %d bytes, over the sun_path limit: %s", len(path), path)
+	}
+
+	return path
+}
 
 // errJournaldBoom is a sentinel transport failure injected by the white-box
 // tests to exercise the error-wrapping branches without a real socket.
@@ -92,7 +126,7 @@ func Test_journaldFactory_Open_defaultDialer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			//: bind a real datagram socket so net.Dial has a peer to connect.
-			path := filepath.Join(t.TempDir(), "j.sock")
+			path := shortSocketPath(t)
 			srv, lerr := net.ListenUnixgram(socketNetwork, &net.UnixAddr{Name: path, Net: socketNetwork})
 			//: a private-tempdir unixgram bind is reliable; a failure is a hard
 			//: fault that must fail the test, never silently skip the dial arm.

--- a/pkg/v1/rlimit/BUILD.bazel
+++ b/pkg/v1/rlimit/BUILD.bazel
@@ -24,6 +24,8 @@ go_test(
     srcs = [
         "rlimit_external_test.go",
         "rlimit_other_test.go",
+        "rlimit_support_other_test.go",
+        "rlimit_support_unix_test.go",
     ],
     deps = [
         ":rlimit",

--- a/pkg/v1/rlimit/rlimit_external_test.go
+++ b/pkg/v1/rlimit/rlimit_external_test.go
@@ -2,7 +2,6 @@
 package rlimit_test
 
 import (
-	"runtime"
 	"testing"
 
 	coreproc "github.com/kitsunium/sdk/internal/core/proc"
@@ -11,7 +10,8 @@ import (
 )
 
 // TestApplyDelegates asserts the facade forwards to the service: an unmapped
-// resource yields UnknownResource on Linux and UnsupportedPlatform off it.
+// resource yields UnknownResource wherever rlimits are native, and
+// UnsupportedPlatform where they are not.
 func TestApplyDelegates(t *testing.T) {
 	t.Parallel()
 	err := rlimit.Apply(0, map[rlimit.Resource]rlimit.Limit{
@@ -20,9 +20,12 @@ func TestApplyDelegates(t *testing.T) {
 	})
 	//: select the platform-correct expectation.
 	want := coreproc.CodeUnknownResource
-	//: off Linux the stub short-circuits before mapping.
-	if runtime.GOOS != "linux" {
-		//: the non-Linux stub returns UNSUPPORTED_PLATFORM.
+	//: only off Unix does the stub short-circuit before mapping. Keyed on the
+	//: build-tagged nativeRlimit rather than a runtime.GOOS == "linux" guess,
+	//: which wrongly claimed darwin and the BSDs unsupported when the service
+	//: implements them through setrlimit(2).
+	if !nativeRlimit {
+		//: the non-Unix stub returns UNSUPPORTED_PLATFORM.
 		want = coreproc.CodeUnsupportedPlatform
 	}
 	//: the facade must surface the same typed code the service returns.

--- a/pkg/v1/rlimit/rlimit_other_test.go
+++ b/pkg/v1/rlimit/rlimit_other_test.go
@@ -1,10 +1,15 @@
-//go:build !linux
+//go:build !unix
 
-// Package rlimit_test — non-Linux facade contract: setrlimit/prlimit64 live only
-// on the Linux build, so the facade Apply and PrepareSysProcAttr forward the
-// central UnsupportedPlatform sentinel off Linux. Gated on the same `!linux` tag
-// as the service stub so the e2e-vm CI binary validates the off-platform path on
-// a real non-Linux kernel, not via a runtime.GOOS guess.
+// Package rlimit_test — non-Unix facade contract: setrlimit(2) has no equivalent
+// off Unix, so the facade Apply and PrepareSysProcAttr forward the central
+// UnsupportedPlatform sentinel there. Gated on the same `!unix` tag as the
+// service stub (rlimit_other.go) so the e2e-vm CI binary validates the
+// off-platform path on a real non-Unix kernel, not via a runtime.GOOS guess.
+//
+// `!unix` and NOT `!linux`: the service implements rlimits on every Unix target,
+// Linux through prlimit64(2) and the BSDs through setrlimit(2), so a `!linux`
+// tag pulled these cases onto darwin and the BSDs, where Apply legitimately
+// succeeds and the UnsupportedPlatform expectation never holds.
 package rlimit_test
 
 import (
@@ -15,9 +20,9 @@ import (
 	"github.com/kitsunium/sdk/pkg/v1/rlimit"
 )
 
-// TestApplyUnsupportedOffLinux asserts the facade Apply forwards
-// UnsupportedPlatform off Linux for any resource.
-func TestApplyUnsupportedOffLinux(t *testing.T) {
+// TestApplyUnsupportedOffUnix asserts the facade Apply forwards
+// UnsupportedPlatform off Unix for any resource.
+func TestApplyUnsupportedOffUnix(t *testing.T) {
 	t.Parallel()
 
 	err := rlimit.Apply(0, map[rlimit.Resource]rlimit.Limit{
@@ -26,23 +31,23 @@ func TestApplyUnsupportedOffLinux(t *testing.T) {
 	})
 	//: the facade must forward the central UNSUPPORTED_PLATFORM code.
 	if !errs.HasCode(err, coreproc.CodeUnsupportedPlatform) {
-		//: a missing code means the facade is not delegating faithfully off Linux.
-		t.Fatalf("Apply off Linux = %v, want CodeUnsupportedPlatform", err)
+		//: a missing code means the facade is not delegating faithfully off Unix.
+		t.Fatalf("Apply off Unix = %v, want CodeUnsupportedPlatform", err)
 	}
 }
 
-// TestPrepareUnsupportedOffLinux asserts the facade no-syscall validator forwards
-// UnsupportedPlatform off Linux.
-func TestPrepareUnsupportedOffLinux(t *testing.T) {
+// TestPrepareUnsupportedOffUnix asserts the facade no-syscall validator forwards
+// UnsupportedPlatform off Unix.
+func TestPrepareUnsupportedOffUnix(t *testing.T) {
 	t.Parallel()
 
 	err := rlimit.PrepareSysProcAttr(map[rlimit.Resource]rlimit.Limit{
-		//: the validator must short-circuit before the platform table off Linux.
+		//: the validator must short-circuit before the platform table off Unix.
 		coreproc.ResourceNoFile: {Soft: 1024, Hard: 1024},
 	})
 	//: the facade must forward the central UNSUPPORTED_PLATFORM code.
 	if !errs.HasCode(err, coreproc.CodeUnsupportedPlatform) {
-		//: a missing code means the facade is not delegating faithfully off Linux.
-		t.Fatalf("PrepareSysProcAttr off Linux = %v, want CodeUnsupportedPlatform", err)
+		//: a missing code means the facade is not delegating faithfully off Unix.
+		t.Fatalf("PrepareSysProcAttr off Unix = %v, want CodeUnsupportedPlatform", err)
 	}
 }

--- a/pkg/v1/rlimit/rlimit_support_other_test.go
+++ b/pkg/v1/rlimit/rlimit_support_other_test.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+// Package rlimit_test — build-tagged capability flag for non-Unix targets, where
+// setrlimit(2) has no equivalent and every entry point degrades to
+// UnsupportedPlatform. The //go:build unix sibling sets nativeRlimit true.
+package rlimit_test
+
+// nativeRlimit reports whether this platform applies resource limits natively.
+// False on non-Unix targets (Windows, plan9, js/wasm).
+const nativeRlimit = false

--- a/pkg/v1/rlimit/rlimit_support_unix_test.go
+++ b/pkg/v1/rlimit/rlimit_support_unix_test.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+// Package rlimit_test — build-tagged capability flag mirroring the one the
+// service package carries. Every Unix target applies rlimits natively
+// (setrlimit(2)), so the portable cases in rlimit_external_test.go expect
+// success / UnknownResource here rather than the non-Unix UnsupportedPlatform
+// degrade.
+package rlimit_test
+
+// nativeRlimit reports whether this platform applies resource limits natively.
+// True on every Unix target; the //go:build !unix sibling sets it false.
+const nativeRlimit = true


### PR DESCRIPTION
Two commits.

**`fix(ci)`** — every job in `docker-images.yml` was gated on `github.repository ==` the template repo it was copied from, a condition false by construction here, so all 20 of the last scheduled runs skipped 100% of their jobs and no image was ever built. Guard on the fork flag instead, which preserves the intent (never burn a fork's Actions minutes) and evaluates correctly in any copy. `IMAGE_NAME`/`BASE_IMAGE_NAME` were pinned the same way and now derive from the github context, so images land in this namespace rather than the template owner's.

**`fix(build)`** — `make lint` and `make test` both failed on macOS on a pristine tree, so the repo was only developable from the Linux devcontainer.

- `pkg/v1/rlimit` gated its unsupported-platform cases on `!linux`, but the service implements rlimits on every Unix target and only the `!unix` stub degrades — on darwin `Apply` really works, so three cases asserted a degrade that cannot happen.
- `journald` bound its unixgram fixtures under `t.TempDir()`, whose macOS path exceeds the `sockaddr_un` `sun_path` field, so `bind(2)` returned EINVAL before either test could run.
- Four lint findings were false positives from one cause: the linter analyses only the host build configuration, so off Linux every `*_linux.go` is dropped and a helper called only from the Linux backend looks uncalled. Scoped exclusions with the retirement condition documented, rather than tagging portable code `linux` and losing its cross-platform test coverage. The one genuine finding is fixed in place.

The underlying gap is worth an issue on ktn-linter: the dead-code and unused-const rules should resolve references across every build configuration, not just the host's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource-limit handling across Unix platforms.
  - Clarified unsupported-platform behavior for non-Unix systems.
  - Improved compatibility with systems that impose short Unix socket path limits.

- **Chores**
  - Updated container image workflows to support repositories beyond the original project while preserving existing build, tagging, caching, and publishing behavior.

- **Tests**
  - Expanded platform coverage and strengthened integration-test reliability across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->