### PR TITLE
ci: add the mandatory post-commit gate

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -1,18 +1,20 @@
-# Commit guard — checks that commit messages carry no AI attribution and that
-# no credentials were added.
+# post-commit — mandatory merge gate.
 #
-# This file is intentionally a 3-line stub. All the logic lives in
-# kodflow/commit-guard-action and is pinned to @main, so a fix or a new rule
-# added there applies here on the next run with no change to this repo.
-# Do not fork the logic into this file.
+# No AI attribution anywhere in the history, conventional commit subjects,
+# no credentials added. Every rule lives in kodflow/post-commit and is
+# pinned to @main on purpose: a fix or a new rule there is live here on the
+# next run with no change to this file. Pinning a SHA would freeze this
+# repo out of every future fix, which is the opposite of the design — do
+# not pin it, and do not copy the logic into this repo.
+#
+# The job MUST stay named `post-commit`: that is the status the branch
+# ruleset requires, so renaming or deleting this file leaves the required
+# status unreported and blocks every merge.
 name: post-commit
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  # Catches merges and any direct push to the trunk. PR branches are already
-  # covered by the pull_request trigger above, so this is scoped to the trunk
-  # to avoid running the same check twice on the same commits.
   push:
     branches: [main, master]
 
@@ -20,5 +22,8 @@ permissions:
   contents: read
 
 jobs:
-  commit-guard:
-    uses: kodflow/commit-guard-action/.github/workflows/commit-guard.yml@main
+  post-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: kodflow/post-commit@main

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -1,0 +1,24 @@
+# Commit guard — checks that commit messages carry no AI attribution and that
+# no credentials were added.
+#
+# This file is intentionally a 3-line stub. All the logic lives in
+# kodflow/commit-guard-action and is pinned to @main, so a fix or a new rule
+# added there applies here on the next run with no change to this repo.
+# Do not fork the logic into this file.
+name: post-commit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Catches merges and any direct push to the trunk. PR branches are already
+  # covered by the pull_request trigger above, so this is scoped to the trunk
+  # to avoid running the same check twice on the same commits.
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  commit-guard:
+    uses: kodflow/commit-guard-action/.github/workflows/commit-guard.yml@main


### PR DESCRIPTION
Adds `.github/workflows/post-commit.yml`: the mandatory merge gate, run on
every pull request commit and on every push to the trunk.

It fails when **any commit reachable from the branch** — the new ones and the
whole history behind them — carries AI attribution (a `Co-authored-by:`
naming an assistant, a "generated by" banner, the robot-emoji footer, an AI
author identity), when a new commit's subject is not a conventional commit,
or when the diff adds something shaped like a credential.

### Why it is one `uses:` line

All the logic lives in [`kodflow/post-commit`](https://github.com/kodflow/post-commit)
and is pinned to `@main` **by design**: a fix or a new rule lands there once
and applies here on the next run. Pinning a SHA would freeze this repo out of
every future fix — please don't, and don't copy the logic into this repo.

### If this check is red on this very PR

Then the repository's existing history already contains tainted commits. The
gate reports them and rewrites nothing; the repo stays blocked until its
history is rewritten (a separate, deliberate decision — see the central
repo's README).

### Enforcement

A `post-commit` ruleset on the default branch makes this status required for
every merge and every direct push, forbids branch deletion and force-pushes,
and can only be bypassed by repository admins.
