### PR TITLE
ci(post-commit): require the owning account on every commit

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -27,3 +27,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: kodflow/post-commit@main
+        with:
+          # Every commit in this repository must carry the owning GitHub
+          # account, not a personal identity. Same value in all three orgs
+          # on purpose — one human commits across the whole fleet, so the
+          # stub stays byte-identical everywhere.
+          authors: kodflow


### PR DESCRIPTION
Sets `authors: kodflow` on the post-commit gate so every commit in this
repository must carry the owning GitHub account rather than a personal
identity.

The stub is now byte-identical to `kodflow/post-commit/stub/post-commit.yml`,
which is the intent: one human commits across the whole fleet, so the same
value applies in all three orgs. Where the stub carried `history: range`, that
line is dropped — the gate goes back to scanning the full history, which is
the default and the stronger guarantee.

`@main` stays unpinned on purpose: a fix in the central repo is live here on
the next run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-commit processing by providing the required commit author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->