### PR TITLE
ci(post-commit): allow the gate to be run on demand

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -17,6 +17,11 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main, master]
+  # On demand: the gate reads the whole history, so its verdict can change
+  # without this repository changing — a new rule lands in kodflow/post-commit,
+  # or the history is rewritten under it. Without this you cannot ask a quiet
+  # repository whether it is still clean; you have to push something to find out.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch:` to the gate workflow.

The gate reads the whole history, so its verdict can change without this
repository changing — a new rule lands in `kodflow/post-commit@main`, or the
history is rewritten under it. Without this you cannot ask a quiet repository
whether it is still clean; you have to push something to find out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an option to run the merge gate workflow manually on demand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->