### PR TITLE
ci(post-commit): block the merge by drafting a failing pull request

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -14,7 +14,10 @@ name: post-commit
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review matters: a failed run puts the pull request back into
+    # draft, so marking it ready is how you ask for another verdict. Without
+    # this type that second attempt would never be judged.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main, master]
   # On demand: the gate reads the whole history, so its verdict can change
@@ -25,6 +28,10 @@ on:
 
 permissions:
   contents: read
+  # Lets the gate put a failing pull request back into draft. GitHub refuses to
+  # merge a draft on every plan and for admins too, which is the only hard
+  # block available on repositories where a ruleset cannot exist.
+  pull-requests: write
 
 jobs:
   post-commit:


### PR DESCRIPTION
A red status only refuses a merge where a ruleset can require it, and GitHub
declines rulesets on private repositories in Free-plan organisations. Draft
state has no such hole: GitHub refuses to merge a draft on every plan and for
admins too. A failing gate now puts the pull request back into draft, and
`ready_for_review` joins the triggers so marking it ready asks for a new
verdict. Needs `pull-requests: write`, added here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation to run when a draft pull request is marked ready for review.
  * Added permission for the automated gate to return failing pull requests to draft status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->