### PR TITLE
ci(post-commit): draft a failing PR from a separate least-privilege job

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -14,7 +14,10 @@ name: post-commit
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review matters: a failed run puts the pull request back into
+    # draft, so marking it ready is how you ask for another verdict. Without
+    # this type that second attempt would never be judged.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main, master]
   # On demand: the gate reads the whole history, so its verdict can change
@@ -38,3 +41,32 @@ jobs:
           # on purpose — one human commits across the whole fleet, so the
           # stub stays byte-identical everywhere.
           authors: kodflow
+
+  # The block of last resort, deliberately a SEPARATE job.
+  #
+  # A red status only refuses a merge where a ruleset can require it, and GitHub
+  # declines rulesets outright on a private repository in a Free-plan org. Draft
+  # state has no such hole: GitHub refuses to merge a draft on every plan and
+  # for admins too. So when the gate fails, put the pull request back into
+  # draft; `ready_for_review` above is what lets you ask for a new verdict.
+  #
+  # Why a second job rather than a step inside the action: the write permission
+  # has to live somewhere, and a workflow- or job-level grant on the job above
+  # would hand a pull-request-write token to kodflow/post-commit@main — a
+  # mutable external reference — on every trigger, push and manual runs
+  # included. Here the token never reaches it. This job runs no action at all.
+  block-merge:
+    needs: post-commit
+    if: ${{ failure() && github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr ready --undo "$PR" -R "$REPO"
+          echo "::notice::post-commit failed — pull request put back into draft. Fix the history, then mark it ready: that re-runs the gate."


### PR DESCRIPTION
A red status only refuses a merge where a ruleset can require it, and GitHub
declines rulesets on private repositories in Free-plan organisations. Draft
state has no such hole: GitHub refuses to merge a draft on every plan and for
admins too, so a failing gate now puts the pull request back into draft.

The drafting lives in its own job on purpose. Granting `pull-requests: write`
to the gate job would hand a write-capable token to `kodflow/post-commit@main`
— a mutable external reference — on every trigger. This job runs no action at
all, so the token never reaches it, and the gate job stays `contents: read`.