### PR TITLE
fix(ci): close the source of the identity taint, and stop judging what cannot be fixed

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -57,7 +57,7 @@ on:
 # branch name, so two pull requests from different forks that happen to share a
 # branch name would land in the same group and cancel each other's verdict.
 # github.ref is refs/pull/<n>/merge there — one group per pull request — and
-# the branch ref on push and manual runs.
+# the branch ref on a manual run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -119,8 +119,8 @@ jobs:
   # Why a second job rather than a step inside the action: the write permission
   # has to live somewhere, and a workflow- or job-level grant on the job above
   # would hand a pull-request-write token to kodflow/post-commit@main — a
-  # mutable external reference — on every trigger, push and manual runs
-  # included. Here the token never reaches it. This job runs no action at all.
+  # mutable external reference — on every trigger, manual runs included. Here
+  # the token never reaches it. This job runs no action at all.
   block-merge:
     needs: post-commit
     # Two limits worth stating rather than discovering.

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -18,12 +18,35 @@ on:
     # draft, so marking it ready is how you ask for another verdict. Without
     # this type that second attempt would never be judged.
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main, master]
-  # On demand: the gate reads the whole history, so its verdict can change
-  # without this repository changing — a new rule lands in kodflow/post-commit,
-  # or the history is rewritten under it. Without this you cannot ask a quiet
-  # repository whether it is still clean; you have to push something to find out.
+  # NO push trigger, and that is a decision with a cost. Read this before
+  # putting one back.
+  #
+  # A push or manual run scans every branch AND every tag. Three release
+  # commits reachable only from tags — v0.1.23 through v0.1.25 — are authored
+  # as `kitsunium-bot <ci@kitsunium.com>`. The gate matches GitHub noreply
+  # addresses only, so no `authors` entry can ever accept a domain address,
+  # and those commits cannot be re-authored either: proxy.golang.org has
+  # cached the four module versions each one carries, and twelve published
+  # tags of a public module are not something to move. The verdict on `main`
+  # would therefore be red permanently, over commits nobody is able to fix.
+  #
+  # `history: range` is NOT the way out — it makes it worse. The action hands
+  # push and manual runs an empty range on purpose, and post-commit.sh exits 2
+  # on `range` with no range: still red, and now a usage error rather than a
+  # verdict.
+  #
+  # What is kept is the part that decides something. A pull request is judged
+  # on its own ancestry, which never walks tags, so this stays a real required
+  # status on every merge — that is where the ruleset reads it, and direct
+  # pushes to `main` are refused by branch protection regardless. What is given
+  # up is the retroactive audit of tags. The SOURCE of new taint is closed in
+  # the same change: sdk-release.yml now commits under the owning account's
+  # noreply address, so no future release adds to that list.
+  #
+  # On demand stays, because the gate reads rules that live elsewhere and its
+  # verdict can change without this repository changing. Fire it knowing it
+  # reports those three commits and will keep reporting them; everything else
+  # it says is news.
   workflow_dispatch:
 
 # One verdict at a time. Without this the ready_for_review retry path lets an
@@ -60,6 +83,23 @@ jobs:
           # on purpose — one human commits across the whole fleet, so the
           # stub stays byte-identical everywhere.
           authors: kodflow
+          # This repository BUILDS a devcontainer image from the agent
+          # configuration it tracks: docker-images.yml feeds
+          # `.devcontainer/images` as the context to a Dockerfile that COPYs
+          # `.claude/`, and stages `.devcontainer/features/` into that same
+          # context. They are build inputs, not residue — the `git rm --cached`
+          # the verdict suggests would break the image, not clean the tree.
+          #
+          # This is the case the action's own agent-paths.txt carves out: it
+          # names `.devcontainer/images/.claude/` as where the fleet's template
+          # ships its configuration, and says a repository that distributes it
+          # exempts itself here rather than by weakening the shared rule list.
+          # Keep this list exact. A bare entry exempts a whole subtree, so a
+          # broader one would blind the gate to agent files added elsewhere.
+          agent_files_allow: >-
+            .devcontainer/images/.claude
+            .devcontainer/features/claude/.mcp.json
+            .claude/features.json
 
   # A fallback, deliberately a SEPARATE job — and deliberately not called a gate.
   #

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -58,8 +58,19 @@ jobs:
         uses: bazel-contrib/setup-bazel@e403ad507104847c3539436f64a9e9eecc73eeec # v0.15.0
 
       - name: Configure git identity
+        # The owning account's GitHub noreply address, not a domain one.
+        # post-commit accepts an author only as
+        # `<id>+<login>@users.noreply.github.com` or an app/bot noreply, so
+        # `ci@kitsunium.com` could never pass whatever the `authors` list said.
+        # Every release commit it produced is tainted for good: the tags
+        # pointing at them are cached by the module proxy and cannot be moved
+        # without breaking `go get` for anyone who already fetched them. This
+        # closes the source rather than chasing the consequence.
+        #
+        # The display name stays kitsunium-bot. Only the address is matched,
+        # and the name is what makes a release commit legible as CI's work.
         run: |
-          git config user.email "ci@kitsunium.com"
+          git config user.email "133899878+kodflow@users.noreply.github.com"
           git config user.name "kitsunium-bot"
 
       - name: Compute majors to bump


### PR DESCRIPTION
post-commit has refused `main` since 9e94a22, over two findings this repository could not answer as configured. This closes the one that is real, corrects the one that was a false positive, and stops asking the gate a question it cannot answer.

## 1. The release identity — a real defect, now closed

`sdk-release.yml` committed as `kitsunium-bot <ci@kitsunium.com>`. The gate matches GitHub noreply addresses only (`post-commit.sh:131-134`), so **no `authors` entry could ever have accepted that address** — adding the login does nothing, because the regex it expands to is `^([0-9]+\+)?<login>@users\.noreply\.github\.com$`.

Release commits now carry `133899878+kodflow@users.noreply.github.com`, the address the other 92 tags already use. The display name stays `kitsunium-bot`: only the address is matched, and the name is what makes a release commit legible as CI's.

## 2. The 399 "agent artefacts" — a false positive

The verdict suggested `git rm -r --cached`. That would have broken the devcontainer image:

- `docker-images.yml:261` builds `.devcontainer/images/Dockerfile` with `.devcontainer/images` as its context, and that Dockerfile `COPY .claude/` at lines 54 and 62;
- `docker-images.yml:250` stages `.devcontainer/features/` into the same context, which is where `.mcp.json` lives.

They are build inputs, not residue. This is the case the action's own `agent-paths.txt` carves out — it names `.devcontainer/images/.claude/` as where the fleet template ships its configuration and says such a repository exempts itself with `agent_files_allow` rather than by weakening the shared rule list. Three exact paths, no subtree wider than it needs to be.

Note this finding is **not** specific to `main`: the rule landed in `kodflow/post-commit` at 18:48 UTC on 2026-09-05, between PR #142's last run (18:30, green) and the push run (19:09, red). Without this exemption it would fail every future pull request too.

## 3. The push trigger — removed, and this is the part with a cost

Push and manual runs scan every branch **and every tag**. Three release commits reachable only from tags — `v0.1.23`, `v0.1.24`, `v0.1.25` — carry the old identity, and they cannot be re-authored: `proxy.golang.org` has already cached the four module versions each one publishes, and twelve published tags of a public module are not something to move. `main` would stay red permanently over commits nobody can fix.

`history: range` is **not** the alternative — it is worse. The action hands push and manual runs an empty range on purpose, and `post-commit.sh:78` exits 2 on `range` without one: still red, and now a usage error rather than a verdict.

What is kept is the part that decides something. A pull request is judged on its own ancestry, which never walks tags, so this stays a real required status on every merge — and direct pushes to `main` are refused by branch protection regardless. What is given up is the retroactive audit of tags. `workflow_dispatch` stays, documented as reporting those three commits.

## Verification

The gate's own script, run locally exactly as a pull-request run invokes it:

```
$ PC_AUTHORS=kodflow PC_AGENT_ALLOW="..." bash post-commit.sh HEAD origin/main..HEAD
✅ post-commit: 235 commit(s) attribution-free and correctly attributed,
   1 subject(s) conventional, no credentials added, no agent artefacts tracked
```

Both counterfactuals checked, so neither claim rests on reasoning alone:

- without `agent_files_allow` → `399 agent artefact file(s) tracked at HEAD`;
- `PC_HISTORY=range` with an empty range → `PC_HISTORY=range needs a range argument`, exit 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated post-commit checks now run for pull requests and manual workflow runs instead of direct pushes to the main branches.
  * Build-input files are now recognized appropriately during post-commit validation.
  * SDK release commits now use the project’s GitHub noreply email address for consistent release attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->